### PR TITLE
A new option for js2svg restores HTML entities in SVG text.

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -184,4 +184,5 @@ js2svg:
   textStart: ''
   textEnd: ''
   indent: '    '
+  html: true
   pretty: false

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -266,7 +266,13 @@ var Converter = INHERIT(/** @lends Nodes.prototype */{
      * @return {String}
      */
     createText: function(text) {
-
+        if (this.config.html) {
+            text = text.replace("&", "&amp;")
+                       .replace("<", "&lt;")
+                       .replace(">", "&gt;")
+                       .replace("'", "&apos;")
+                       .replace("\"", "&quot;");
+        }
         return  this.createIndent() +
                 this.config.textStart +
                 text +

--- a/test/plugins/cleanupAttrs.02.orig.svg
+++ b/test/plugins/cleanupAttrs.02.orig.svg
@@ -1,0 +1,4 @@
+<svg xmlns="  http://www.w3.org/2000/svg
+  " attr="a      b">
+    test &lt;
+</svg>

--- a/test/plugins/cleanupAttrs.02.should.svg
+++ b/test/plugins/cleanupAttrs.02.should.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" attr="a b">
+    test &lt;
+</svg>


### PR DESCRIPTION
Hi. This is for #80.

I added a new config option passed to js2svg: "html" that forces all the < > & ' " characters that appear in text to be substituted with their HTML entity.

I'm sorry, I didn't know that pull requests open issues.

Thank-you for your work!

Federico
