### PR TITLE
The cleanupNumericValues plugin doesn't preserve the svg version number.

### DIFF
--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -23,7 +23,7 @@ exports.cleanupNumericValues = function(item, params) {
             match = attr.value.match(regNumericValues);
 
             // if attribute value matches regNumericValues
-            if (match) {
+            if ("version" != attr.name && match) {
                     // round it to the fixed precision
                 var num = +(+match[1]).toFixed(params.floatPrecision),
                     units = match[4] || '';


### PR DESCRIPTION
Hi.

It seem that the svg version number in the root svg element changes from "1.0" to "1" and, in my case, Apache Batik refuses to process it.
