### PR TITLE
The config.js was prematurely returning when enable/disable was set

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -55,10 +55,10 @@ function _getConfig(params) {
                 if (params.pretty) defaultConfig.js2svg.pretty = true;
 
                 // --disable
-                if (params.disable) return changePluginsState(params.disable, false, defaultConfig);
+                if (params.disable) /*return*/ changePluginsState(params.disable, false, defaultConfig);
 
                 // --enable
-                if (params.enable) return changePluginsState(params.enable, true, defaultConfig);
+                if (params.enable) /*return*/ changePluginsState(params.enable, true, defaultConfig);
 
                 // --config
                 if (params.config) {


### PR DESCRIPTION
I was trying to use both "disable" and "config", and my custom config would never get applied when the enable/disable options were used.  This is because the config.js file was returning and not letting the rest of the config do its thing.  I left the `return` statements there just in case someone needs to see them in the future.  I'm not sure what egde case this may break, but so far it works with all of my testing and I can't see any reason why they should have been there in the first place.
