### PR TITLE
Always traverse all files in the given folder.

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -405,16 +405,16 @@ function optimizeFolder(path, config) {
                             // print optimization profit info
                             printProfitInfo(inBytes, outBytes);
 
-                            if (++i < files.length) {
-                                optimizeFile(files[i]);
-                            }
-
                         });
 
                     });
 
                 });
 
+            }
+
+            if (++i < files.length) {
+                optimizeFile(files[i]);
             }
 
         }


### PR DESCRIPTION
Previously SVGO would stop traversing files in a folder if it encountered a non-SVG file, this patch fixes this behavior
