### PR TITLE
Fix issue with convertPathData with sequential h or v movements

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -492,7 +492,7 @@ function collapseRepeated(path) {
             item.instruction === prev.instruction
         ) {
             // increase previous h or v data with current
-            if (item.instruction === 'h' || item.instruction === 'v') {
+            if ((item.instruction === 'h' || item.instruction === 'v')&& (prev.data[0] >= 0) == (item.data[0] >= 0)) {
                 prev.data[0] += item.data[0];
             // concat previous data with current
             } else {

--- a/test/plugins/convertPathData.12.svg
+++ b/test/plugins/convertPathData.12.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 50h30h-30"/>
+    <path d="M10 50h-30h30"/>
+    <path d="M10 50h-30h-50"/>
+    <path d="M10 50h30h50"/>
+    <path d="M10 50v30v-30"/>
+    <path d="M10 50v-30v30"/>
+    <path d="M10 50v-30v-50"/>
+    <path d="M10 50v30v50"/>
+    <path d="M10 50L10 80L10 0"/>
+    <path d="M10 50L10 10L10 80"/>
+    <path d="M10 50L80 50L0 50"/>
+    <path d="M10 50L0 50L80 50"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 50h30-30"/>
+    <path d="M10 50h-30 30"/>
+    <path d="M10 50h-80"/>
+    <path d="M10 50h80"/>
+    <path d="M10 50v30-30"/>
+    <path d="M10 50v-30 30"/>
+    <path d="M10 50v-80"/>
+    <path d="M10 50v80"/>
+    <path d="M10 50v30-80"/>
+    <path d="M10 50v-40 70"/>
+    <path d="M10 50h70-80"/>
+    <path d="M10 50h-10 80"/>
+</svg>


### PR DESCRIPTION
Quick test and fix for convertPathData when a path has movements in h or v in opposite directions-

eg:

```
M10 50h30h-30
```

would produce

```
M10 50h0
```
