### PR TITLE
moveGroupAttrsToElems now applies transforms to sub-groups & text.

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -32,8 +32,8 @@ plugins:
   - removeHiddenElems
   - removeEmptyText
   - moveElemsAttrsToGroup
-  - collapseGroups
   - moveGroupAttrsToElems
+  - collapseGroups
   - convertPathData
   - convertTransform
   - removeEmptyAttrs

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -1,10 +1,13 @@
 'use strict';
 
-exports.type = 'perItemReverse';
+exports.type = 'perItem';
 
 exports.active = true;
 
-var pathElems = require('./_collections.js').pathElems;
+var pathElems = require('./_collections.js').pathElems.slice();
+
+pathElems.push('g');
+pathElems.push('text');
 
 /**
  * Move group attrs to the content elements.

--- a/test/plugins/moveGroupAttrsToElems.03.svg
+++ b/test/plugins/moveGroupAttrsToElems.03.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g transform="rotate(30)">
+        <g transform="scale(2)">
+            <path d="M0,0 L10,20"/>
+            <path d="M0,10 L20,30"/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g>
+            <path d="M0,0 L10,20" transform="rotate(30) scale(2)"/>
+            <path d="M0,10 L20,30" transform="rotate(30) scale(2)"/>
+        </g>
+    </g>
+</svg>

--- a/test/plugins/moveGroupAttrsToElems.04.svg
+++ b/test/plugins/moveGroupAttrsToElems.04.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g transform="rotate(30)">
+        <g>
+            <g transform="scale(2)">
+                <path d="M0,0 L10,20"/>
+                <path d="M0,10 L20,30"/>
+            </g>
+        </g>
+        <path d="M0,10 L20,30"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g>
+            <g>
+                <path d="M0,0 L10,20" transform="rotate(30) scale(2)"/>
+                <path d="M0,10 L20,30" transform="rotate(30) scale(2)"/>
+            </g>
+        </g>
+        <path d="M0,10 L20,30" transform="rotate(30)"/>
+    </g>
+</svg>


### PR DESCRIPTION
Cases where there are multiple levels of groups with transforms would not push down to lower paths.

Made 'moveGroupAttrsToElems' also push transforms to 'group' and 'text' elements.

Admittedly 'text' should be optional (as it just drops the transform attribute on to the element).. may make a configurable list of elements to push transforms to.
