### PR TITLE
Add lcov.info to npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,6 @@ test
 .jshintignore
 .jshintrc
 .travis.yml
+lcov.info
 logo.svg
 CHANGELOG.MD


### PR DESCRIPTION
lcov.info's presence (in the npm package) confuses Drupal 7, which interprets any .info file inside of a Drupal theme or Drupal module to be a Drupal sub-theme or Drupal sub-module.

Drupal themes are increasingly using grunt and grunt plugins, and this npm package is used by at least grunt-grunticon.

This issue manifests itself in Drupal as a menu rebuild failing when clearing caches; e.g. "PDOException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'title' cannot be null: INSERT INTO {menu_router} ...."
