### PR TITLE
Do not remove overriden attributes with default values

### DIFF
--- a/test/plugins/removeUnknownsAndDefaults.03.svg
+++ b/test/plugins/removeUnknownsAndDefaults.03.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g fill="red">
+        <path fill="#000" d="M118.8 186.9l79.2"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g fill="red">
+        <path fill="#000" d="M118.8 186.9l79.2"/>
+    </g>
+</svg>


### PR DESCRIPTION
Overriden attributes in group content may have default values and it is not great to remove them.
