### PR TITLE
Deep inheritance analyzis

### DIFF
--- a/test/plugins/removeUnknownsAndDefaults.04.svg
+++ b/test/plugins/removeUnknownsAndDefaults.04.svg
@@ -1,13 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <g fill="red">
-        <path fill="red" d="M118.8 186.9l79.2"/>
+    <g fill="black">
+        <g fill="red">
+            <path fill="red" d="M118.8 186.9l79.2"/>
+        </g>
     </g>
 </svg>
 
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg">
-    <g fill="red">
-        <path d="M118.8 186.9l79.2"/>
+    <g fill="black">
+        <g fill="red">
+            <path d="M118.8 186.9l79.2"/>
+        </g>
     </g>
 </svg>

--- a/test/plugins/removeUnknownsAndDefaults.05.svg
+++ b/test/plugins/removeUnknownsAndDefaults.05.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g fill="red">
+        <g fill="red">
+            <g fill="green">
+                <g fill="green">
+                    <path fill="red" d="M18.8 86.9l39.2"/>        
+                </g>
+            </g>
+            <path fill="red" d="M118.8 186.9l79.2"/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g fill="red">
+        <g>
+            <g fill="green">
+                <g>
+                    <path fill="red" d="M18.8 86.9l39.2"/>
+                </g>
+            </g>
+            <path d="M118.8 186.9l79.2"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Fixing default attribute values remove check for deep inheritance.
And removing useless overrides with the same value as inherited, for example:

```
<svg xmlns="http://www.w3.org/2000/svg">
    <g fill="red">
        <g fill="red">
            <g fill="green">
                <g fill="green">
                    <path fill="red" d="M18.8 86.9l39.2"/>        
                </g>
            </g>
            <path fill="red" d="M118.8 186.9l79.2"/>
        </g>
    </g>
</svg>
```

->

```
<svg xmlns="http://www.w3.org/2000/svg">
    <g fill="red">
        <g>
            <g fill="green">
                <g>
                    <path fill="red" d="M18.8 86.9l39.2"/>
                </g>
            </g>
            <path d="M118.8 186.9l79.2"/>
        </g>
    </g>
</svg>
```
