### PR TITLE
Fixes issue when original SVG has attributes with value containing &quote

### DIFF
--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -259,7 +259,7 @@ JS2SVG.prototype.createAttrs = function(elem) {
         attrs +=    ' ' +
                     attr.name +
                     this.config.attrStart +
-                    attr.value +
+                    attr.value.replace(/"/g, '&quot;') +
                     this.config.attrEnd;
 
     }, this);


### PR DESCRIPTION
When input tags have attributes with embedded &quote's, this causes an issue when output is generated with &quote's converted to ". Witness the following:

Input:

<text style="color:black;" font-size="12px" zIndex="1" y="13" x="0" font-family='&quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, Verdana, Arial, Helvetica, sans-serif' fill="black"/>

Output:

<text font-size="16" text-anchor="middle" y="25" x="858" font-family=""Lucida Grande", "Lucida Sans Unicode", Verdana, Arial, Helvetica, sans-serif" class="highcharts-title" fill="#274b6d" color="#274b6d">

Expected output:

<text font-size="16" text-anchor="middle" y="25" x="858" font-family="&quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, Verdana, Arial, Helvetica, sans-serif" class="highcharts-title" fill="#274b6d" color="#274b6d">

This patch fixes this issue.
