### PR TITLE
Add Sketch.app ns to `editorNamespaces`

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -2067,7 +2067,8 @@ exports.editorNamespaces = [
     'http://ns.adobe.com/Flows/1.0/',
     'http://ns.adobe.com/ImageReplacement/1.0/',
     'http://ns.adobe.com/GenericCustomNamespace/1.0/',
-    'http://ns.adobe.com/XPath/1.0/'
+    'http://ns.adobe.com/XPath/1.0/',
+    'http://www.bohemiancoding.com/sketch/ns'
 ];
 
 // http://www.w3.org/TR/SVG/linking.html#processingIRI


### PR DESCRIPTION
Plugin `removeEditorsNSData` do not removes Sketch.app (http://www.bohemiancoding.com/sketch/) meta data. This pr fix that.
