### PR TITLE
Adds plugin to clean attrs added by Sketch

### DIFF
--- a/plugins/removeSketchAttrs.js
+++ b/plugins/removeSketchAttrs.js
@@ -1,0 +1,35 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+/**
+ * Removes xmlns:sketch from svg element and all Sketch attributes
+ * http://www.bohemiancoding.com/sketch
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Giovanni Collazo
+ */
+
+var sketchAttrRegex = /(sketch:[a-z]+)/;
+
+exports.fn = function(item) {
+
+    // Removes the xmlns:sketch from <svg> element
+    if (item.attrs && item.attrs['xmlns:sketch']) {
+      item.removeAttr('xmlns:sketch');
+    }
+
+    // Removes sketch:type="MSShapeGroup" attrs
+    for (var attr in item.attrs) {
+      var match = attr.match(sketchAttrRegex);
+
+      if (match) {
+        item.removeAttr(match[0]);
+      }
+    }
+
+};

--- a/test/plugins/removeSketchAttrs.01.svg
+++ b/test/plugins/removeSketchAttrs.01.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <g id="a" sketch:type="MSPage">
+        <path id="Shape1" sketch:type="MSShapeGroup"></path>
+    </g>
+    <g id="b" sketch:type="MSLayerGroup">
+        <path id="Shape2" sketch:type="MSShapeGroup"></path>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="a">
+        <path id="Shape1"/>
+    </g>
+    <g id="b">
+        <path id="Shape2"/>
+    </g>
+</svg>


### PR DESCRIPTION
I created a plugin to remove all the attributes added by [Sketch](http://www.bohemiancoding.com/sketch/) a very popular vector design application for Mac. I'm not really sure that this is the best way to implement this but it works and tests are passing.

Is this something you might want to have out of the box? If not what is the best way to distribute and use plugins from the community?
