### PR TITLE
Stripping y1="0" on a linearGradient confuses some browsers

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -1315,7 +1315,6 @@ exports.elems = {
         ],
         defaults: {
             x1: '0',
-            y1: '0',
             x2: '100%',
             y2: '0',
             spreadMethod: 'pad'


### PR DESCRIPTION
Per the SVG 1.1 spec, on a `linearGradient`, the default value of `y1` is 0. svgo is therefore correct to strip such an attribute.

Unfortunately, however, some browser engines (I tested recent-ish versions of Firefox and Chromium) seem to think the default value of `y1` should be 1, not 0. As a result, optimized SVGs with such a gradient will render wrong in these browsers.

This trivial change just makes svgo not strip a default `y1` from a `linearGradient`, thus avoiding the problem.