### PR TITLE
Fix --output and --folder options

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -145,6 +145,12 @@ module.exports = require('coa').Cmd()
 
         }
 
+        // --output
+        if (opts.output) {
+            config = config || {};
+            config.output = opts.output;
+        }
+
         // --folder
         if (opts.folder) {
             optimizeFolder(opts.folder, config, configFull);
@@ -370,6 +376,7 @@ function optimizeFolder(path, config) {
 
             // absoluted file path
             var filepath = PATH.resolve(path, file);
+            var outfilepath = config.output ? PATH.resolve(config.output, file) : filepath;
 
             // check if file name matches *.svg
             if (regSVGFile.test(filepath)) {
@@ -395,7 +402,7 @@ function optimizeFolder(path, config) {
                         outBytes = Buffer.byteLength(result.data, 'utf8');
                         time = Date.now() - startTime;
 
-                        FS.writeFile(filepath, result.data, 'utf8', function() {
+                        FS.writeFile(outfilepath, result.data, 'utf8', function() {
 
                             UTIL.puts(file + ':');
 
@@ -405,6 +412,11 @@ function optimizeFolder(path, config) {
                             // print optimization profit info
                             printProfitInfo(inBytes, outBytes);
 
+                            //move on to the next file
+                            if (++i < files.length) {
+                                optimizeFile(files[i]);
+                            }
+
                         });
 
                     });
@@ -412,10 +424,11 @@ function optimizeFolder(path, config) {
                 });
 
             }
-
-            if (++i < files.length) {
-                optimizeFile(files[i]);
+            //move on to the next file
+            else if (++i < files.length) {
+                optimizeFile(files[i]); 
             }
+
 
         }
 


### PR DESCRIPTION
let output work with folder, allow folder option to continue after it encounters a non-svg file
