### PR TITLE
Default to empty config

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -100,7 +100,7 @@ module.exports = require('coa').Cmd()
 
         var input = args && args.input ? args.input : opts.input,
             output = args && args.output ? args.output : opts.output,
-            config,
+            config = {},
             configFull;
 
         // w/o anything


### PR DESCRIPTION
Otherwise, certain situations will cause a silent error. Specifically, this allows you to use `svg -f` without a config file.

I _highly_ recommend logging errors somewhere to avoid confusion – if you can point me to the code which is catching uncaught exceptions I'll happily submit a pull request to fix :)
