### PR TITLE
Expose JSAPI as a factory method

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -13,6 +13,7 @@
 var CONFIG = require('./svgo/config'),
     SVG2JS = require('./svgo/svg2js'),
     PLUGINS = require('./svgo/plugins'),
+    JSAPI = require('./svgo/jsAPI.js'),
     JS2SVG = require('./svgo/js2svg');
 
 var SVGO = module.exports = function(config) {
@@ -37,5 +38,18 @@ SVGO.prototype.optimize = function(svgstr, callback) {
         callback(JS2SVG(svgjs, config.js2svg));
 
     });
+
+};
+
+
+/**
+ * The factory that creates a content item with the helper methods.
+ *
+ * @param {Object} data which passed to jsAPI constructor
+ * @returns {JSAPI} content item
+ */
+SVGO.prototype.createContentItem = function(data) {
+
+    return new JSAPI(data);
 
 };

--- a/test/jsapi/_index.js
+++ b/test/jsapi/_index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var SVGO = require(process.env.COVERAGE ?
+    '../../lib-cov/svgo.js' :
+    '../../lib/svgo.js');
+
+var JSAPI = require(process.env.COVERAGE ?
+    '../../lib-cov/svgo/jsAPI.js' :
+    '../../lib/svgo/jsAPI.js');
+
+describe('svgo object', function() {
+
+    it('should has createContentItem method', function() {
+        var svgo = new SVGO();
+        svgo.createContentItem.should.be.a.Function;
+    });
+
+    it('should be able to create content item', function() {
+        var svgo = new SVGO();
+        var item = svgo.createContentItem({
+            elem: 'elementName',
+            prefix: 'prefixName',
+            local: 'localName'
+        });
+
+        item.should.be.an.Object.and.an.instanceof(JSAPI);
+        item.should.have.ownProperty('elem').equal('elementName');
+        item.should.have.ownProperty('prefix').equal('prefixName');
+        item.should.have.ownProperty('local').equal('localName');
+    });
+
+    it('should be able create content item without argument', function() {
+        var svgo = new SVGO();
+        var item = svgo.createContentItem();
+
+        item.should.be.an.Object.and.an.instanceof(JSAPI);
+        item.should.be.empty;
+    });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,3 +3,4 @@
 test/config
 test/svg2js
 test/plugins
+test/jsapi


### PR DESCRIPTION
Hello.

I would like to use SVGO as a pipeline for optimization and transformation with my own plugins. All content items must be instances of the JSAPI class to not break the chain of the existing plugins. Unfortunately, consumers of the SVGO module don’t have direct access to that class.

So, I propose to add new `createContentItem` method to the public SVGO API. It allows to create new items without exposing inner class.
