### PR TITLE
Prevented removeUselessStrokeAndFill from removing non-default fill-rule

### DIFF
--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -48,7 +48,14 @@ exports.fn = function(item, params) {
         ) {
             item.eachAttr(function(attr) {
                 if (regFillProps.test(attr.name)) {
-                    item.removeAttr(attr.name);
+                    if (
+                        attr.name !== 'fill-rule' ||
+                        (attr.name === 'fill-rule' &&
+                        attr.value === 'nonzero'
+                        )
+                    ) {
+                        item.removeAttr(attr.name);
+                    }
                 }
             });
 

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -50,8 +50,8 @@ exports.fn = function(item, params) {
                 if (
                     regFillProps.test(attr.name) &&
                     (attr.name !== 'fill-rule' ||
-                    (attr.name === 'fill-rule' &&
-                    attr.value === 'nonzero')
+                     attr.name === 'fill-rule' &&
+                     attr.value === 'nonzero'
                     )
                 ) {
                     item.removeAttr(attr.name);

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -47,15 +47,14 @@ exports.fn = function(item, params) {
             item.hasAttr('fill-opacity', '0')
         ) {
             item.eachAttr(function(attr) {
-                if (regFillProps.test(attr.name)) {
-                    if (
-                        attr.name !== 'fill-rule' ||
-                        (attr.name === 'fill-rule' &&
-                        attr.value === 'nonzero'
-                        )
-                    ) {
-                        item.removeAttr(attr.name);
-                    }
+                if (
+                    regFillProps.test(attr.name) &&
+                    (attr.name !== 'fill-rule' ||
+                    (attr.name === 'fill-rule' &&
+                    attr.value === 'nonzero')
+                    )
+                ) {
+                    item.removeAttr(attr.name);
                 }
             });
 

--- a/test/plugins/removeUselessStrokeAndFill.02.svg
+++ b/test/plugins/removeUselessStrokeAndFill.02.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <circle fill="none" fill-rule="evenodd" cx="60" cy="60" r="50"/>
+    <circle fill="none" fill-rule="nonzero" cx="60" cy="60" r="50"/>
     <circle fill="red" fill-opacity="0" cx="60" cy="60" r="50"/>
     <circle fill="red" fill-opacity=".5" cx="60" cy="60" r="50"/>
 </svg>


### PR DESCRIPTION
The current `removeUselessStrokeAndFill` plugin removes any `fill-rule` if `fill` is set to none or `fill-opacity` is set to 0. Nested paths require `fill-rule` to determine whether or not they should render inside a shape - this is why svgo has previously broken/collapsed some images, especially those assembled with [boolean operations](http://bohemiancoding.com/sketch/support/documentation/04-shapes/2-boolean-operations.html).

This PR checks if the current attr up for removal is `fill-rule`, and if so, whether or not its value differs from the default `nonzero`; if it does, it leaves it intact.

This should fix the following issues: [#151](https://github.com/svg/svgo/issues/151), [#161](https://github.com/svg/svgo/issues/161), [#191](https://github.com/svg/svgo/issues/191), [#201](https://github.com/svg/svgo/issues/201), [#217](https://github.com/svg/svgo/issues/217)

Updated tests to verify `fill-rule="evenodd"` does not get removed by svgo, as it is a [non-default value](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule).