### PR TITLE
Replaced deprecated requireing of yml file

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
-require('js-yaml');
+var yaml = require('js-yaml');
+var fs = require('fs');
 
 var EXTEND = require('whet.extend');
 
@@ -26,7 +27,7 @@ module.exports = function(config) {
 
     } else {
 
-        defaults = EXTEND({}, require('../../.svgo.yml'));
+        defaults = EXTEND({}, yaml.safeLoad(fs.readFileSync(__dirname + '/../../.svgo.yml', 'utf8')));
 
         defaults.plugins = preparePluginsArray(defaults.plugins);
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "sax": "~0.6.0",
     "coa": "~0.4.0",
-    "js-yaml": "~2.1.0",
+    "js-yaml": "~3.2.2",
     "colors": "~0.6.0",
     "whet.extend": "~0.9.9"
   },


### PR DESCRIPTION
When using `gulp-imagemin` I got the following error:

```
.../node_modules/gulp-imagemin/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/lib/svgo/config.js:58
    return plugins.map(function(item) {
                   ^
TypeError: Cannot call method 'map' of undefined
```

My project also uses a more recent version of `js-yaml` which conflicted with the version used in svgo.  
So, I replaced the deprecated `require` as described in https://github.com/nodeca/js-yaml#breaking-changes-in-2xx---3xx and updated `js-yaml`.

Should also fix #245.
