### PR TITLE
Add ability to enable multipass

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -33,9 +33,18 @@ SVGO.prototype.optimize = function(svgstr, callback) {
             return;
         }
 
-        svgjs = PLUGINS(svgjs, config.plugins);
+        var svg = { data : null },
+            maxIterationCount = config.multipass ? 10 : 1,
+            counter = 0,
+            prevResult;
 
-        callback(JS2SVG(svgjs, config.js2svg));
+        do {
+            prevResult = svg;
+            svgjs = PLUGINS(svgjs, config.plugins);
+            svg = JS2SVG(svgjs, config.js2svg);
+        } while(++counter < maxIterationCount && prevResult.data !== svg.data);
+
+        callback(svg);
 
     });
 

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -86,6 +86,11 @@ module.exports = require('coa').Cmd()
         })
         .end()
     .opt()
+        .name('multipass').title('Enable multipass')
+        .long('multipass')
+        .flag()
+        .end()
+    .opt()
         .name('pretty').title('Make SVG pretty printed')
         .long('pretty')
         .flag()
@@ -134,6 +139,14 @@ module.exports = require('coa').Cmd()
         // --enable
         if (opts.enable) {
             config = changePluginsState(opts.enable, true, config);
+        }
+
+        // --multipass
+        if (opts.multipass) {
+
+            config = config || {};
+            config.multipass = true;
+
         }
 
         // --pretty

--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -25,6 +25,8 @@ module.exports = function(config) {
             defaults.plugins = optimizePluginsArray(defaults.plugins);
         }
 
+        defaults.multipass = config.multipass;
+
     } else {
 
         defaults = EXTEND({}, yaml.safeLoad(fs.readFileSync(__dirname + '/../../.svgo.yml', 'utf8')));
@@ -33,6 +35,7 @@ module.exports = function(config) {
 
         if (config) {
             defaults = extendConfig(defaults, config);
+            defaults.multipass = config.multipass;
         }
 
         defaults.plugins = optimizePluginsArray(defaults.plugins);


### PR DESCRIPTION
This PR add ability to enable multipass in SVGO via `--multipass` option. With this flag optimization will be applied until the result differs from the one obtained in the previous step.

Let's take a concrete example:

``` xml
<svg xmlns="http://www.w3.org/2000/svg">
    <g transform="translate(-39, -239)">
        <g id="заглушки" transform="translate(39, 37)">
            <rect id="Rectangle-1183" fill="#D4D4D4" x="8" y="223" width="7" height="19"></rect>
            <rect id="Rectangle-1183" fill="#D4D4D4" x="4" y="227" width="42" height="3"></rect>
            <rect id="Rectangle-1183" fill="#D0011B" x="23" y="227" width="6" height="3"></rect>
            <rect id="Rectangle-1183" fill="#D0011B" x="35" y="227" width="6" height="3"></rect>
            <rect id="Rectangle-1183" fill="#D0011B" x="11" y="227" width="6" height="3"></rect>
        </g>
    </g>
</svg>
```

The result with the current version SVGO (all the plugins are enabled):

``` xml
<svg xmlns="http://www.w3.org/2000/svg">
    <g>
        <path id="Rectangle-1183" fill="#D4D4D4" d="M8 21h7v19H8zM4 25h42v3H4z"/>
        <path fill="#D0011B" d="M23 25h6v3h-6zM35 25h6v3h-6zM11 25h6v3h-6z"/>
    </g>
</svg>
```

As you can see, the result it's not optimal. There're redundant `<g>` and redundant attribute `id` in the first `<path>`. And you aren't able to improve this result by changing the order of the plugins.

The result with `--multipass` option:

``` xml
<svg xmlns="http://www.w3.org/2000/svg">
    <path fill="#D4D4D4" d="M8 21h7v19H8zm-4 4h42v3H4z"/>
    <path fill="#D0011B" d="M23 25h6v3h-6zm12 0h6v3h-6zm-24 0h6v3h-6z"/>
</svg>
```

The result is much better.
