### PR TITLE
Simplify.js plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -40,6 +40,7 @@ plugins:
   - removeEmptyAttrs
   - removeEmptyContainers
   - mergePaths
+  - simplifyPaths
   - cleanupIDs
   - removeUnusedNS
   - transformsWithOnePath

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "coa": "~0.4.1",
     "js-yaml": "~3.2.2",
     "colors": "~1.0.3",
+    "simplify-js": "^1.2.1",
     "whet.extend": "~0.9.9"
   },
   "devDependencies": {

--- a/plugins/simplifyPaths.js
+++ b/plugins/simplifyPaths.js
@@ -1,0 +1,150 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = true;
+
+exports.params = {
+    tolerance: 1,
+    highQuality: false
+};
+
+var simplify = require('simplify-js'),
+    path2js = require('./_path').path2js,
+    js2path = require('./_path').js2path;
+
+/**
+ * Dramatically reduce the number of points in a polyline while retaining its shape.
+ *
+ * @see http://mourner.github.io/simplify-js/
+ *
+ * @param {Number} tolerance Affects the amount of simplification (in the same metric as the point coordinates).
+ * @param {Boolean} highQuality Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower.
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Sebastiaan Deckers
+ */
+exports.fn = function(item, params) {
+
+    if (item.isElem(['polyline', 'polygon']) && item.hasAttr('points')) {
+        var points = item.attr('points');
+        points.value = processPoints(points.value, item, params);
+    }
+
+    else if (item.isElem(['path', 'glyph']) && item.hasAttr('d')) {
+        var d = item.attr('d');
+        d.value = processPath(d.value, item, params);
+    }
+
+    else if (item.isElem('animateMotion') && item.hasAttr('path')) {
+        var path = item.attr('path');
+        path.value = processPath(path.value, item, params);
+    }
+
+    else if (item.isElem('animate') &&
+        item.hasAttr('attributeName') &&
+        item.attr('attributeName').value === 'd'
+    ) {
+        if (item.hasAttr('values')) {
+            var values = item.attr('values');
+            var paths = values.value.split(/\s*\;\s*/)
+                .map(Function.prototype.call, String.prototype.trim);
+            values.value = paths.map(function(path) {
+                return processPath(path, item, params);
+            }).join(';');
+        }
+        if (item.hasAttr('from')) {
+            var from = item.attr('from');
+            from.value = processPath(from.value, item, params);
+        }
+        if (item.hasAttr('to')) {
+            var to = item.attr('to');
+            to.value = processPath(to.value, item, params);
+        }
+    }
+
+};
+
+function processPoints(points, item, params) {
+    if (points.length === 0) {
+        return points;
+    }
+    var coords = points.split(/\s+/)
+        .map(function(pair) {
+            var xy = pair.split(',');
+            return {
+                x: parseFloat(xy[0], 10),
+                y: parseFloat(xy[1], 10)
+            };
+        });
+    var simplified = simplify(coords, params.tolerance, params.highQuality);
+    return simplified.map(function(coord) {
+        return coord.x + ',' + coord.y;
+    }).join(' ');
+}
+
+function processPath(path, item, params) {
+    var instructions = path2js(path, params);
+    var sequences = collapseLineInstructions(instructions);
+    var simplified = sequences.map(function(sequence) {
+        if (isLine(sequence) && sequence.points.length >= 2) {
+            sequence.points = simplify(
+                sequence.points,
+                params.tolerance,
+                params.highQuality
+            );
+        }
+        return sequence;
+    });
+    var instructions = spreadLineSequences(simplified);
+    return js2path(instructions, params);
+}
+
+function collapseLineInstructions(instructions) {
+    var sequences = [];
+    var lastInstruction = '';
+    instructions.forEach(function(instruction) {
+        var sameSequence = lastInstruction === instruction.instruction;
+        lastInstruction = instruction.instruction;
+        if (isLine(instruction)) {
+            if (!sameSequence) {
+                sequences.push({
+                    instruction: instruction.instruction,
+                    points: []
+                });
+            }
+            if (Array.isArray(instruction.data) &&
+                instruction.data.length === 2
+            ) {
+                sequences[sequences.length - 1].points.push({
+                    x: instruction.data[0],
+                    y: instruction.data[1]
+                });
+            }
+        } else {
+            sequences.push(instruction);
+        }
+    });
+    return sequences;
+}
+
+function spreadLineSequences(simplified) {
+    return simplified.reduce(function(instructions, sequence) {
+        if (isLine(sequence)) {
+            sequence.points.forEach(function(point) {
+                instructions.push({
+                    instruction: sequence.instruction,
+                    data: [point.x, point.y]
+                });
+            });
+        } else {
+            instructions.push(sequence);
+        }
+        return instructions;
+    }, []);
+}
+
+function isLine(instruction) {
+    return instruction.instruction === 'L' ||
+        instruction.instruction === 'l';
+}

--- a/test/plugins/simplifyPaths.01.svg
+++ b/test/plugins/simplifyPaths.01.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polyline points="1,1 5,5 10,0 10,0.5"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polyline points="1,1 5,5 10,0.5"/>
+</svg>

--- a/test/plugins/simplifyPaths.02.svg
+++ b/test/plugins/simplifyPaths.02.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polygon points="1,1 5,5 10,0 10,0.5"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polygon points="1,1 5,5 10,0.5"/>
+</svg>

--- a/test/plugins/simplifyPaths.03.svg
+++ b/test/plugins/simplifyPaths.03.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polyline points=""/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <polyline points=""/>
+</svg>

--- a/test/plugins/simplifyPaths.04.svg
+++ b/test/plugins/simplifyPaths.04.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0L5 5L5 6L10 10L10 5L5 10z"/>
+    <path d="c 50,0 50,100 100,100 c 50,0 50,-100 100,-100"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0L5 5L10 10L10 5L5 10z"/>
+    <path d="c50 0 50 100 100 100c50 0 50 -100 100 -100"/>
+</svg>

--- a/test/plugins/simplifyPaths.05.svg
+++ b/test/plugins/simplifyPaths.05.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <glyph d="L5 5L5 6L10 10"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <glyph d="L5 5L10 10"/>
+</svg>

--- a/test/plugins/simplifyPaths.06.svg
+++ b/test/plugins/simplifyPaths.06.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle cx="" cy="" r="10" fill="red">
+        <animateMotion
+            dur="1s"
+            repeatDur="indefinite"
+            path="L5 5L5 6L10 10" />
+    </circle>
+    <circle cx="" cy="" r="5" fill="green">
+        <animate dur="1s" from="L5 5L5 6L10 10" to="L5 5L5 6L10 10" attributeName="d" attributeType="XML"/>
+    </circle>
+    <circle cx="" cy="" r="5" fill="green">
+        <animate dur="1s" values="L5 5L5 6L10 10;L5 5L5 6L10 10" attributeName="d" attributeType="XML"/>
+    </circle>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle cx="" cy="" r="10" fill="red">
+        <animateMotion dur="1s" repeatDur="indefinite" path="L5 5L10 10"/>
+    </circle>
+    <circle cx="" cy="" r="5" fill="green">
+        <animate dur="1s" from="L5 5L10 10" to="L5 5L10 10" attributeName="d" attributeType="XML"/>
+    </circle>
+    <circle cx="" cy="" r="5" fill="green">
+        <animate dur="1s" values="L5 5L10 10;L5 5L10 10" attributeName="d" attributeType="XML"/>
+    </circle>
+</svg>


### PR DESCRIPTION
Reduce file size drastically on complex polylines. Especially useful with maps.

Supports simplifying `<polygon>`, `<polyline>` point series, as well as simplifying sequential line instructions in path syntax on `<path>`, `<glyph>`, `<animate>`, and `<animateMotion>`.

Uses the Simplify.js library. Demo: http://mourner.github.io/simplify-js/

cc svg/svgo/issues/240 & svg/svgo/issues/9
cc @cheeaun