### PR TITLE
Order: mergePaths should run before collapseGroups

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -35,12 +35,12 @@ plugins:
   - convertShapeToPath
   - moveElemsAttrsToGroup
   - moveGroupAttrsToElems
-  - collapseGroups
   - convertPathData
   - convertTransform
   - removeEmptyAttrs
   - removeEmptyContainers
   - mergePaths
+  - collapseGroups
   - cleanupIDs
   - removeUnusedNS
   - transformsWithOnePath


### PR DESCRIPTION
An SVG like this one:

```svg
<g>
    <path fill="#AC162C" d="pathdata"/>
    <path fill="#AC162C" d="pathdata-2"/>
</g>
```

…will be compressed into:

```svg
<g fill="#AC162C">
    <path d="pathdata1+2"/>
</g>
```

… which, if svgoed again, will be optimized further:

```svg
<path d="pathdata1+2" fill="#AC162C"/>
```

This is due to `collapseGroups` running before `mergePaths`, therefore not catching the newly-unnecessary `<g fill="#AC162C">`

Test SVG file: http://cl.ly/Yw2Y