### PR TITLE
Disable sax-js strict mode

### DIFF
--- a/lib/svgo/svg2js.js
+++ b/lib/svgo/svg2js.js
@@ -4,7 +4,7 @@ var SAX = require('sax'),
     JSAPI = require('./jsAPI');
 
 var config = {
-    strict: true,
+    strict: false,
     trim: true,
     normalize: true,
     lowercase: true,


### PR DESCRIPTION
This is disabled by default in sax-js, and [by their own admission](https://github.com/isaacs/sax-js) makes sax-js a jerk. Having it enabled also causes bugs like [#225](https://github.com/svg/svgo/issues/225) and [#272](https://github.com/svg/svgo/issues/272) - breaking svgo entirely for SVG exported from Illustrator with certain settings. Seems more prudent to let some things 'slip by' with strict mode disabled rather than fail entirely.