### PR TITLE
Use console instead of util to avoid deprecation warnings

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -4,7 +4,6 @@ require('colors');
 
 var FS = require('fs'),
     PATH = require('path'),
-    UTIL = require('util'),
     SVGO = require('../svgo'),
     YAML = require('js-yaml'),
     PKG = require('../../package.json'),
@@ -132,10 +131,10 @@ module.exports = require('coa').Cmd()
                     config = JSON.parse(FS.readFileSync(configPath, 'utf8'));
                 } catch (err) {
                     if (err.code === 'ENOENT') {
-                        UTIL.error('Error: couldn\'t find config file \'' + opts.config + '\'.');
+                        console.error('Error: couldn\'t find config file \'' + opts.config + '\'.');
                         return;
                     } else if (err.code === 'EISDIR') {
-                        UTIL.error('Error: directory \'' + opts.config + '\' is not a config file.');
+                        console.error('Error: directory \'' + opts.config + '\' is not a config file.');
                         return;
                     }
                     config = YAML.safeLoad(FS.readFileSync(configPath, 'utf8'));
@@ -208,9 +207,9 @@ module.exports = require('coa').Cmd()
                         if (err.code === 'EISDIR')
                             optimizeFolder(input, config, output);
                         else if (err.code === 'ENOENT')
-                            UTIL.error('Error: no such file or directory \'' + input + '\'.');
+                            console.error('Error: no such file or directory \'' + input + '\'.');
                         else
-                            UTIL.error(err);
+                            console.error(err);
                         return;
                     }
                     optimizeFromString(data, config, opts.datauri, input, output);
@@ -240,7 +239,7 @@ function optimizeFromString(svgstr, config, datauri, input, output) {
     svgo.optimize(svgstr, function(result) {
 
         if (result.error) {
-            console.log(result.error);
+            console.error(result.error);
             return;
         }
 
@@ -264,7 +263,7 @@ function optimizeFromString(svgstr, config, datauri, input, output) {
                 output = input;
             }
 
-            UTIL.puts('\r');
+            console.log('\r');
 
             saveFileAndPrintInfo(result.data, output, inBytes, outBytes, time);
 
@@ -290,7 +289,7 @@ function saveFileAndPrintInfo(data, path, inBytes, outBytes, time) {
 
 function printTimeInfo(time) {
 
-    UTIL.puts('Done in ' + time + ' ms!');
+    console.log('Done in ' + time + ' ms!');
 
 }
 
@@ -298,7 +297,7 @@ function printProfitInfo(inBytes, outBytes) {
 
     var profitPercents = 100 - outBytes * 100 / inBytes;
 
-    UTIL.puts(
+    console.log(
         (Math.round((inBytes / 1024) * 1000) / 1000) + ' KiB' +
         (profitPercents < 0 ? ' + ' : ' - ') +
         String(Math.abs((Math.round(profitPercents * 10) / 10)) + '%').green + ' = ' +
@@ -386,7 +385,7 @@ function optimizeFolder(dir, config, output) {
 
     var svgo = new SVGO(config);
 
-    UTIL.puts('Processing directory \'' + dir + '\':\n');
+    console.log('Processing directory \'' + dir + '\':\n');
 
     // absoluted folder path
     var path = PATH.resolve(dir);
@@ -395,12 +394,12 @@ function optimizeFolder(dir, config, output) {
     FS.readdir(path, function(err, files) {
 
         if (err) {
-            UTIL.error(err);
+            console.error(err);
             return;
         }
 
         if (!files.length) {
-            UTIL.puts('Directory \'' + dir + '\' is empty.');
+            console.log('Directory \'' + dir + '\' is empty.');
             return;
         }
 
@@ -420,7 +419,7 @@ function optimizeFolder(dir, config, output) {
                 FS.readFile(filepath, 'utf8', function(err, data) {
 
                     if (err) {
-                        UTIL.error(err);
+                        console.error(err);
                         return;
                     }
 
@@ -432,7 +431,7 @@ function optimizeFolder(dir, config, output) {
                     svgo.optimize(data, function(result) {
 
                         if (result.error) {
-                            console.log(result.error);
+                            console.error(result.error);
                             return;
                         }
 
@@ -452,14 +451,14 @@ function optimizeFolder(dir, config, output) {
                                     mkdirp(output, writeOutput);
                                     return;
                                 } else if (err.code === 'ENOTDIR') {
-                                    UTIL.error('Error: output \'' + output + '\' is not a directory.');
+                                    console.error('Error: output \'' + output + '\' is not a directory.');
                                     return;
                                 }
-                                UTIL.error(err);
+                                console.error(err);
                                 return;
                             }
 
-                            UTIL.puts(file + ':');
+                            console.log(file + ':');
 
                             // print time info
                             printTimeInfo(time);
@@ -483,7 +482,7 @@ function optimizeFolder(dir, config, output) {
             else if (++i < files.length) {
                 optimizeFile(files[i]);
             } else if (!found) {
-                UTIL.puts('No SVG files have been found.');
+                console.log('No SVG files have been found.');
             }
 
 


### PR DESCRIPTION
`util.puts` and `util.error` have been deprecated in io.js and node.js 0.12 and print ugly deprecation warnings on the CLI. This commit replaces them with console equivalents.

Also there were two cases where errors weren't printed to stderr, which I changed to do so.