### PR TITLE
JSAPI.prototype.clone - fixes #311

### DIFF
--- a/lib/svgo/jsAPI.js
+++ b/lib/svgo/jsAPI.js
@@ -3,15 +3,40 @@
 var EXTEND = require('whet.extend');
 
 var JSAPI = module.exports = function(data, parentNode) {
-
     EXTEND(this, data);
-    if (parentNode) {
-        Object.defineProperty(this, 'parentNode', {
-            writable: true,
-            value: parentNode
-        })
+    this.parentNode = parentNode;
+};
+
+/**
+ * Perform a deep clone of this node.
+ * 
+ * @return {Object} element
+ */
+JSAPI.prototype.clone = function() {
+    var node = this;
+    var nodeData = {};
+
+    Object.keys(node).forEach(function(key) {
+        if (key != 'content' && key != 'parentNode') {
+            nodeData[key] = node[key];
+        }
+    });
+
+    // Deep-clone node data
+    // This is still faster than using EXTEND(true…)
+    nodeData = JSON.parse(JSON.stringify(nodeData));
+
+    var clonedNode = new JSAPI(nodeData);
+  
+    if (node.content) {
+        clonedNode.content = node.content.map(function(childNode) {
+            var clonedChild = childNode.clone();
+            clonedChild.parentNode = clonedNode;
+            return clonedChild;
+        });
     }
 
+    return clonedNode;
 };
 
 /**

--- a/lib/svgo/jsAPI.js
+++ b/lib/svgo/jsAPI.js
@@ -4,7 +4,7 @@ var EXTEND = require('whet.extend');
 
 var JSAPI = module.exports = function(data, parentNode) {
     EXTEND(this, data);
-    this.parentNode = parentNode;
+    if (parentNode) this.parentNode = parentNode;
 };
 
 /**

--- a/lib/svgo/jsAPI.js
+++ b/lib/svgo/jsAPI.js
@@ -4,7 +4,12 @@ var EXTEND = require('whet.extend');
 
 var JSAPI = module.exports = function(data, parentNode) {
     EXTEND(this, data);
-    if (parentNode) this.parentNode = parentNode;
+    if (parentNode) {
+        Object.defineProperty(this, 'parentNode', {
+            writable: true,
+            value: parentNode
+        })
+    }
 };
 
 /**
@@ -17,7 +22,7 @@ JSAPI.prototype.clone = function() {
     var nodeData = {};
 
     Object.keys(node).forEach(function(key) {
-        if (key != 'content' && key != 'parentNode') {
+        if (key != 'content') {
             nodeData[key] = node[key];
         }
     });
@@ -26,7 +31,10 @@ JSAPI.prototype.clone = function() {
     // This is still faster than using EXTEND(true…)
     nodeData = JSON.parse(JSON.stringify(nodeData));
 
-    var clonedNode = new JSAPI(nodeData);
+    // parentNode gets set to a proper object by the parent clone,
+    // but it needs to be true/false now to do the right thing
+    // in the constructor.
+    var clonedNode = new JSAPI(nodeData, !!node.parentNode);
   
     if (node.content) {
         clonedNode.content = node.content.map(function(childNode) {


### PR DESCRIPTION
I made `parentNode` enumerable again, breaking `JSON.stringify(node)`. If being able to convert a node to JSON is useful, a custom `.toJSON` would fix that, but as far as I can tell it was only used for cloning.