### PR TITLE
Circle handling for convertShapeToPath plugin

### DIFF
--- a/plugins/convertShapeToPath.js
+++ b/plugins/convertShapeToPath.js
@@ -104,11 +104,14 @@ exports.fn = function(item) {
         var cx = item.attr('cx').value;
         var cy = item.attr('cy').value;
         var r = item.attr('r').value;
-        var pathData =
-            'M' + cx + ' ' + cy +
-            'm' + (-r) + ' 0' +
+		var pathData;
+
+        if (isNaN(cx-r)) return;
+
+        pathData =
+            'M' + (cx-r) + ' ' + cy +
             'a' + r + ' ' + r + ' 0 1 0 ' + (r*2) + ' 0' +
-            'a' + r + ' ' + r + ' 0 1 0 ' + (-r*2) + ' 0z';
+            ' ' + r + ' ' + r + ' 0 1 0 ' + (-r*2) + ' 0z';
 
         item.renameElem('path');
         item.removeAttr(['cx', 'cy', 'r']);

--- a/plugins/convertShapeToPath.js
+++ b/plugins/convertShapeToPath.js
@@ -99,6 +99,24 @@ exports.fn = function(item) {
 
         item.renameElem('path')
             .removeAttr('points');
-    }
 
+    } else if (item.isElem('circle')) {
+        var cx = item.attr('cx').value;
+        var cy = item.attr('cy').value;
+        var r = item.attr('r').value;
+        var pathData =
+            'M' + cx + ' ' + cy +
+            'm' + (-r) + ' 0' +
+            'a' + r + ' ' + r + ' 0 1 0 ' + (r*2) + ' 0' +
+            'a' + r + ' ' + r + ' 0 1 0 ' + (-r*2) + ' 0z';
+
+        item.renameElem('path');
+        item.removeAttr(['cx', 'cy', 'r']);
+        item.addAttr({
+            name: 'd',
+            value: pathData,
+            prefix: '',
+            local: 'd'
+        });
+    }
 };

--- a/test/plugins/convertShapeToPath.04.svg
+++ b/test/plugins/convertShapeToPath.04.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+	<circle cx="100" cy="100" r="20"/>
+	<circle cx="100" cy="100" r="20" fill="#666"/>
+	<circle cx="100" cy="100" r="20%" fill="#666"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M80 100a20 20 0 1 0 40 0 20 20 0 1 0 -40 0z"/>
+    <path fill="#666" d="M80 100a20 20 0 1 0 40 0 20 20 0 1 0 -40 0z"/>
+    <circle cx="100" cy="100" r="20%" fill="#666"/>
+</svg>


### PR DESCRIPTION
Uses two arcs technique for representing a circle as a path.
http://stackoverflow.com/questions/5737975/circle-drawing-with-svgs-arc-path/10477334#10477334
