### PR TITLE
Fixed case where precision could be <0

### DIFF
--- a/plugins/convertTransform.js
+++ b/plugins/convertTransform.js
@@ -304,6 +304,10 @@ function round(data) {
  */
 function smartRound(data, precision) {
     for (var i = data.length, tolerance = Math.pow(.1, precision); i--;) {
+        //Making sure we never go below 0 on toFixed...
+        if (precision < 1.0){
+            precision = 1.0;
+        }
         var rounded = +data[i].toFixed(precision - 1);
         data[i] = +Math.abs(rounded - data[i]).toFixed(precision) >= tolerance ?
             +data[i].toFixed(precision) :


### PR DESCRIPTION
Some image that got converted via imagemin (using svgo) ended up with call of precision <0 when optimizing:

Made sure it can never happen so we can build them.

Stack was:
ERROR in ./www/apps/rabbit/client/assets/img/emoticons/flowers.svg
Module build failed: RangeError: toFixed() digits argument must be between 0 and 20
    at Number.toFixed (native)
    at smartRound (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:310:32)
    at roundTransform (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:273:30)
    at /Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:256:21
    at Array.forEach (native)
    at js2transform (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:255:17)
    at convertToShorts (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:131:17)
    at convertTransform (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:97:16)
    at Object.exports.fn (/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/plugins/convertTransform.js:47:13)
    at /Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/node_modules/imagemin/node_modules/imagemin-svgo/node_modules/svgo/lib/svgo/plugins.js:59:45
 @ ./~/css-loader?disableStructuralMinification&root=/Users/Feel/Dev/letsplay/rabbit/rabbit-node/coco/site/www/apps/rabbit!./~/less-loader!./www/apps/rabbit/client/desktop/desktop.less 2:288305-288425