### PR TITLE
Allow config to specify use of self closing tags

### DIFF
--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -26,7 +26,8 @@ var defaults = {
     regEntities: /[&'"<>]/g,
     regValEntities: /[&"<>]/g,
     encodeEntity: encodeEntity,
-    pretty: false
+    pretty: false,
+    useShortTags: true
 };
 
 var entities = {
@@ -228,13 +229,22 @@ JS2SVG.prototype.createElem = function(data) {
 
     // empty element and short tag
     if (data.isEmpty()) {
-
-        return  this.createIndent() +
-                this.config.tagShortStart +
-                data.elem +
-                this.createAttrs(data) +
-                this.config.tagShortEnd;
-
+        if (this.config.useShortTags) {
+            return this.createIndent() +
+                   this.config.tagShortStart +
+                   data.elem +
+                   this.createAttrs(data) +
+                   this.config.tagShortEnd;
+        } else {
+            return this.createIndent() +
+                   this.config.tagShortStart +
+                   data.elem +
+                   this.createAttrs(data) +
+                   this.config.tagOpenEnd +
+                   this.config.tagCloseStart +
+                   data.elem +
+                   this.config.tagCloseEnd;
+        }
     // non-empty element
     } else {
         var tagOpenStart = this.config.tagOpenStart,


### PR DESCRIPTION
Allow config to specify `useShortTags` (default true).

When `useShortTags` is true, empty elements are terminated with />

When `useShortTags` is false, empty elements are closed with a full closing tag
e.g. < / path >