### PR TITLE
Add setDimensions plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -51,3 +51,4 @@ plugins:
   - removeDimensions
   - removeAttrs
   - addClassesToSVGElement
+  - setDimensions

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Today we have:
 * [ [ removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) ] remove width/height attributes if viewBox is present (disabled by default)
 * [ [ removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) ] remove attributes by pattern (disabled by default)
 * [ [ addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) ] add classnames to an outer `<svg>` element (disabled by default)
+* [ [ setDimensions](https://github.com/svg/svgo/blob/master/plugins/setDimensions.js) ] set width and height (disabled by default)
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md).
 

--- a/plugins/setDimensions.js
+++ b/plugins/setDimensions.js
@@ -1,0 +1,43 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'adds or updates specified width and height';
+
+exports.params = {
+    width: 50,
+    height: 50
+};
+
+/**
+ * Remove width/height attributes when a viewBox attribute is present.
+ *
+ * @example
+ * <svg>
+ *   ↓
+ * <svg width="50" height="50">
+ *
+ * @param {Object} item current iteration item
+ * @param {Object} params plugin params
+ *
+ * @author Ally Palanzi
+ */
+exports.fn = function(item, params) {
+
+    if (item.isElem('svg')) {
+        item.addAttr({
+            name: 'width',
+            local: 'width',
+            prefix: '',
+            value: params.width
+        });
+        item.addAttr({
+            name: 'height',
+            local: 'height',
+            prefix: '',
+            value: params.height
+        });
+    }
+};

--- a/test/plugins/setDimensions.01.svg
+++ b/test/plugins/setDimensions.01.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100.5" height=".5" viewBox="0 0 100.5 .5">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100.5 .5">
+    test
+</svg>

--- a/test/plugins/setDimensions.02.svg
+++ b/test/plugins/setDimensions.02.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+    test
+</svg>


### PR DESCRIPTION
Adds a setDimensions plugin that allows users to specify a width and height for their svg.
