### PR TITLE
Use null prototype for maps

### DIFF
--- a/test/plugins/cleanupIDs.04.svg
+++ b/test/plugins/cleanupIDs.04.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs>
-        <text id="test01">
+        <text id="__proto__">
             referenced text
         </text>
         <text id="test02">
@@ -160,9 +160,9 @@
             referenced text
         </text>
     </defs>
-    <tref xlink:href="#test01"/>
-    <tref xlink:href="#test01"/>
-    <tref xlink:href="#test01"/>
+    <tref xlink:href="#__proto__"/>
+    <tref xlink:href="#__proto__"/>
+    <tref xlink:href="#__proto__"/>
     <tref xlink:href="#test02"/>
     <tref xlink:href="#test03"/>
     <tref xlink:href="#test04"/>


### PR DESCRIPTION
I was looking at the cleanupID plugin to add functionality and noticed it could be cleaned up a little.

The main change is using `Object.create(null)` instead of `{}` to create the ID maps. This lets us remove the ID prefixing everywhere. The change mostly improves readability, but making less strings will result in faster garbage collection and runtime.

Other changes include cleaning up whitespace and inverting `if` statements to decrease nesting and improve readability. 