### PR TITLE
Add option --quiet

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -430,7 +430,7 @@ function optimizeFolder(dir, config, output) {
 
     var svgo = new SVGO(config);
 
-    if (! config.quiet) {
+    if (!config.quiet) {
         console.log('Processing directory \'' + dir + '\':\n');
     }
 

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -304,7 +304,7 @@ function optimizeFromString(svgstr, config, datauri, input, output) {
                 output = input;
             }
 
-            if (! config.quiet) {
+            if (!config.quiet) {
                 console.log('\r');
             }
 
@@ -505,7 +505,7 @@ function optimizeFolder(dir, config, output) {
                                 return;
                             }
 
-                            if (! config.quiet) {
+                            if (!config.quiet) {
                                 console.log(file + ':');
 
                                 // print time info

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -104,6 +104,11 @@ module.exports = require('coa').Cmd()
         .flag()
         .end()
     .opt()
+        .name('quiet').title('Only output error messages, not regular status messages')
+        .short('q').long('quiet')
+        .flag()
+        .end()
+    .opt()
         .name('show-plugins').title('Show available plugins and exit')
         .long('show-plugins')
         .flag()
@@ -168,6 +173,11 @@ module.exports = require('coa').Cmd()
                 }
             }
 
+        }
+
+        // --quiet
+        if (opts.quiet) {
+            config.quiet = opts.quiet;
         }
 
         // --precision
@@ -257,7 +267,6 @@ module.exports = require('coa').Cmd()
             optimizeFromString(opts.string, config, opts.datauri, input, output);
 
         }
-
     });
 
 function optimizeFromString(svgstr, config, datauri, input, output) {
@@ -295,9 +304,11 @@ function optimizeFromString(svgstr, config, datauri, input, output) {
                 output = input;
             }
 
-            console.log('\r');
+            if (! config.quiet) {
+                console.log('\r');
+            }
 
-            saveFileAndPrintInfo(result.data, output, inBytes, outBytes, time);
+            saveFileAndPrintInfo(config, result.data, output, inBytes, outBytes, time);
 
         }
 
@@ -305,9 +316,12 @@ function optimizeFromString(svgstr, config, datauri, input, output) {
 
 }
 
-function saveFileAndPrintInfo(data, path, inBytes, outBytes, time) {
+function saveFileAndPrintInfo(config, data, path, inBytes, outBytes, time) {
 
     FS.writeFile(path, data, 'utf8', function() {
+        if (config.quiet) {
+            return;
+        }
 
         // print time info
         printTimeInfo(time);
@@ -320,7 +334,6 @@ function saveFileAndPrintInfo(data, path, inBytes, outBytes, time) {
 }
 
 function printTimeInfo(time) {
-
     console.log('Done in ' + time + ' ms!');
 
 }
@@ -417,7 +430,9 @@ function optimizeFolder(dir, config, output) {
 
     var svgo = new SVGO(config);
 
-    console.log('Processing directory \'' + dir + '\':\n');
+    if (! config.quiet) {
+        console.log('Processing directory \'' + dir + '\':\n');
+    }
 
     // absoluted folder path
     var path = PATH.resolve(dir);
@@ -490,13 +505,15 @@ function optimizeFolder(dir, config, output) {
                                 return;
                             }
 
-                            console.log(file + ':');
+                            if (! config.quiet) {
+                                console.log(file + ':');
 
-                            // print time info
-                            printTimeInfo(time);
+                                // print time info
+                                printTimeInfo(time);
 
-                            // print optimization profit info
-                            printProfitInfo(inBytes, outBytes);
+                                // print optimization profit info
+                                printProfitInfo(inBytes, outBytes);
+                            }
 
                             //move on to the next file
                             if (++i < files.length) {


### PR DESCRIPTION
I trust that svgo works, and the output of my build process is overly long as it is. Add a `-q` / `--quiet` option to suppress all the chatter and only show important / error messages.