### PR TITLE
Add localStyles plugin, tests and dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "svgo",
   "version": "0.5.6",
   "description": "Nodejs-based tool for optimizing SVG vector graphics files",
-  "keywords": [ "svgo", "svg", "optimize", "minify" ],
+  "keywords": [
+    "svgo",
+    "svg",
+    "optimize",
+    "minify"
+  ],
   "homepage": "https://github.com/svg/svgo",
   "bugs": {
     "url": "https://github.com/svg/svgo/issues",
@@ -13,15 +18,18 @@
     "email": "kir@soulshine.in",
     "url": "https://github.com/deepsweet"
   },
-  "contributors": [{
-    "name": "Sergey Belov",
-    "email": "peimei@ya.ru",
-    "url": "http://github.com/arikon"
-  }, {
-    "name": "Lev Solntsev",
-    "email": "lev.sun@ya.ru",
-    "url": "http://github.com/GreLI"
-  }],
+  "contributors": [
+    {
+      "name": "Sergey Belov",
+      "email": "peimei@ya.ru",
+      "url": "http://github.com/arikon"
+    },
+    {
+      "name": "Lev Solntsev",
+      "email": "lev.sun@ya.ru",
+      "url": "http://github.com/GreLI"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/svg/svgo.git"
@@ -39,14 +47,15 @@
     "test": "make test"
   },
   "dependencies": {
-    "sax": "~1.1.1",
     "coa": "~1.0.1",
-    "js-yaml": "~3.3.1",
     "colors": "~1.1.2",
-    "whet.extend": "~0.9.9",
-    "mkdirp": "~0.5.1",
     "css": "^2.2.1",
-    "uniq": "^1.0.1"
+    "js-yaml": "~3.3.1",
+    "mkdirp": "~0.5.1",
+    "remove-value": "^1.0.0",
+    "sax": "~1.1.1",
+    "uniq": "^1.0.1",
+    "whet.extend": "~0.9.9"
   },
   "devDependencies": {
     "mocha": "~2.2.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "js-yaml": "~3.3.1",
     "colors": "~1.1.2",
     "whet.extend": "~0.9.9",
-    "mkdirp": "~0.5.1"
+    "mkdirp": "~0.5.1",
+    "css": "^2.2.1",
+    "uniq": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "~2.2.5",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "coa": "~1.0.1",
     "colors": "~1.1.2",
     "css": "^2.2.1",
+    "inline-styles-parse": "^1.2.0",
     "js-yaml": "~3.3.1",
     "mkdirp": "~0.5.1",
     "remove-value": "^1.0.0",

--- a/plugins/localStyles.js
+++ b/plugins/localStyles.js
@@ -112,6 +112,8 @@ var generateLookup = function(item) {
      lookups              = [];
 
   styleCssRules.forEach(function(styleCssRule) {
+    if(styleCssRule.type != 'rule') { return; } // skip anything nested like mediaqueries
+
     styleCssDeclarations = getCssDeclarations(styleCssRule);
     styleCssRule.selectors.forEach(function(styleSelector) {
       lookups.push({ selector: styleSelector, declarations: styleCssDeclarations });

--- a/plugins/localStyles.js
+++ b/plugins/localStyles.js
@@ -7,12 +7,13 @@ exports.active = true;
 exports.description = 'copies styles from <style> to element styles';
 
 
-var cssParser   = require('css'),
-        uniq        = require('uniq'),
-        removeValue = require('remove-value'),
-        lookupRules = [],
-        svgElem     = {},
-        styleCssAst = {};
+var cssParser             = require('css'),
+        uniq              = require('uniq'),
+        removeValue       = require('remove-value'),
+	inlineStylesParse = require('inline-styles-parse'),
+        lookupRules       = [],
+        svgElem           = {},
+        styleCssAst       = {};
 
 
 // declarations (property-value paris) from rule
@@ -75,7 +76,7 @@ var cleanupRulesAst = function(rulesAst) {
 // parses css of a css rule (no selector)
 var parseRulesCss = function(str) {
     return cssParser
-                  .parse('.dummy { ' + str + ' }')
+                  .parse(inlineStylesParse.declarationsToRule(str))
                   .stylesheet.rules[0];
 };
 
@@ -109,7 +110,7 @@ var prepareCssDeclarationsAst = function(declarations) {
 // ast to rules css
 var cssAstToRulesCss = function(ast) {
     var cssDummy = cssParser.stringify(ast, { compress: true });
-    return extractRuleCss(cssDummy);
+    return inlineStylesParse.ruleToDeclarations(cssDummy);
 };
 // rules to rules css
 var stringifyCssRules = function(rules) {
@@ -128,11 +129,6 @@ var stringifyCssDeclarations = function(declarations) {
     dummyRule.declarations = prepareCssDeclarationsAst(declarations);
 
     return stringifyCssRules([dummyRule]);
-};
-// helper to extract rules css from full css
-var extractRuleCss = function(str) {
-    var strEx = str.match(/\.dummy{(.*)}/i)[1];
-    return strEx;
 };
 
 

--- a/plugins/localStyles.js
+++ b/plugins/localStyles.js
@@ -7,9 +7,9 @@ exports.active = true;
 exports.description = 'copies styles from <style> to element styles';
 
 
-var cssParser = require('css')
-  , uniq      = require('uniq')
-  , lookups   = [];
+var cssParser = require('css'),
+    uniq      = require('uniq'),
+    lookups   = [];
 
 
 // property-value pairs from rule ast
@@ -23,7 +23,7 @@ var getCssDeclarations = function(cssRule) {
 
 var _trim = function(s) {
   return s.trim();
-}
+};
 // parse class attribute value
 var parseClasses = function(item) {
   return item.attr('class').value.split(' ').map(_trim);
@@ -60,8 +60,8 @@ var prepareRulesAst = function(rules) {
 
 // generates an ast declaration per property-value pair
 var prepareDeclarationsAst = function(declarations) {
-  var declarationsAst = []
-    , declarationAst  = {};
+  var declarationsAst = [],
+      declarationAst  = {};
 
   declarations.forEach(function(declaration) {
     declarationAst = { type    : 'declaration',
@@ -105,11 +105,11 @@ var extractRuleCss = function(str) {
 
 // prepares css lookups table for selectors + styles
 var generateLookup = function(item) {
-  var styleCss             = item.content[0].text
-    , styleCssParsed       = cssParser.parse(styleCss)
-    , styleCssRules        = styleCssParsed.stylesheet.rules
-    , styleCssDeclarations = []
-    , lookups               = [];
+  var styleCss            = item.content[0].text,
+     styleCssParsed       = cssParser.parse(styleCss),
+     styleCssRules        = styleCssParsed.stylesheet.rules,
+     styleCssDeclarations = [],
+     lookups              = [];
 
   styleCssRules.forEach(function(styleCssRule) {
     styleCssDeclarations = getCssDeclarations(styleCssRule);
@@ -187,8 +187,8 @@ exports.fn = function(item) {
       uniq(newDeclarations, uniqueProperty, true);
 
       // apply new styles only when necessary
-      if(   newDeclarations  && newDeclarations.length  > 0
-         && itemDeclarations && itemDeclarations.length > 0) {
+      if(newDeclarations  && newDeclarations.length  > 0 &&
+         itemDeclarations && itemDeclarations.length > 0    ) {
         var newCss = stringifyDeclarations(newDeclarations);
         item.attr('style').value = newCss;
       }

--- a/plugins/localStyles.js
+++ b/plugins/localStyles.js
@@ -8,236 +8,236 @@ exports.description = 'copies styles from <style> to element styles';
 
 
 var cssParser   = require('css'),
-    uniq        = require('uniq'),
-    removeValue = require('remove-value'),
-    lookupRules = [],
-    svgElem     = {},
-    styleCssAst = {};
+        uniq        = require('uniq'),
+        removeValue = require('remove-value'),
+        lookupRules = [],
+        svgElem     = {},
+        styleCssAst = {};
 
 
 // declarations (property-value paris) from rule
 var getCssDeclarationsFromRule  = function(cssRule) {
-  var declarations = [];
-  cssRule.declarations.forEach(function(declaration) {
-    declarations.push({ property: declaration.property, value: declaration.value });
-  });
-  return declarations;
+    var declarations = [];
+    cssRule.declarations.forEach(function(declaration) {
+        declarations.push({ property: declaration.property, value: declaration.value });
+    });
+    return declarations;
 };
 // declarations from multiple rules
 var getCssDeclarationsFromRules = function(cssRules) {
-  var declarations = [];
-  cssRules.forEach(function(cssRule) {
-    declarations = declarations.concat(getCssDeclarationsFromRule(cssRule));
-  });
-  return declarations;
+    var declarations = [];
+    cssRules.forEach(function(cssRule) {
+        declarations = declarations.concat(getCssDeclarationsFromRule(cssRule));
+    });
+    return declarations;
 };
 
 var _trim = function(s) {
-  return s.trim();
+    return s.trim();
 };
 // parse class attribute value
 var parseClasses = function(item) {
-  return item.attr('class').value.split(' ').map(_trim);
+    return item.attr('class').value.split(' ').map(_trim);
 };
 
 // looks up style rules for passed selector
 var lookupCssSelector = function(selector) {
-  var matchedRules = [];
-  lookupRules.forEach(function(lookupRule) {
-    if(lookupRule.selector == selector) {
-      matchedRules = matchedRules.concat(lookupRule);
-    }
-  });
-  return matchedRules;
+    var matchedRules = [];
+    lookupRules.forEach(function(lookupRule) {
+        if(lookupRule.selector == selector) {
+            matchedRules = matchedRules.concat(lookupRule);
+        }
+    });
+    return matchedRules;
 };
 
 var processCssSelector = function(selectorFind) {
-  var matchedRules = lookupCssSelector(selectorFind);
-  cleanupSelectorAst(selectorFind, matchedRules);
-  return getCssDeclarationsFromRules(matchedRules);
+    var matchedRules = lookupCssSelector(selectorFind);
+    cleanupSelectorAst(selectorFind, matchedRules);
+    return getCssDeclarationsFromRules(matchedRules);
 };
 
 var cleanupSelectorAst = function(selectorFind, matchedRules) {
-  matchedRules.map(function(matchedRule) {
-    removeValue(matchedRule.astRule.selectors, selectorFind); // (global variable)
-    return matchedRule;
-  });
-  return;
+    matchedRules.map(function(matchedRule) {
+        removeValue(matchedRule.astRule.selectors, selectorFind); // (global variable)
+        return matchedRule;
+    });
+    return;
 };
 
 var cleanupRulesAst = function(rulesAst) {
-  return rulesAst.filter(function(matchedRule) { // (global variable)
-    return(matchedRule.type != 'rule' || matchedRule.selectors.length > 0);
-  });
+    return rulesAst.filter(function(matchedRule) { // (global variable)
+        return(matchedRule.type != 'rule' || matchedRule.selectors.length > 0);
+    });
 };
 
 
 // parses css of a css rule (no selector)
 var parseRulesCss = function(str) {
-  return cssParser
-         .parse('.dummy { ' + str + ' }')
-         .stylesheet.rules[0];
+    return cssParser
+                  .parse('.dummy { ' + str + ' }')
+                  .stylesheet.rules[0];
 };
 
 // prepares a full css ast from rules array
 var prepareCssRulesAst = function(rules) {
-  var ast =
-  { type      : 'stylesheet',
-    stylesheet: {
-      rules: rules
-    }
-  };
-  return ast;
+    var ast =
+    { type      : 'stylesheet',
+        stylesheet: {
+            rules: rules
+        }
+    };
+    return ast;
 };
 
 // generates an ast declaration per property-value pair
 var prepareCssDeclarationsAst = function(declarations) {
-  var declarationsAst = [],
-      declarationAst  = {};
+    var declarationsAst = [],
+            declarationAst  = {};
 
-  declarations.forEach(function(declaration) {
-    declarationAst = { type    : 'declaration',
-                       property: declaration.property,
-                       value   : declaration.value
-                     };
-    declarationsAst.push(declarationAst);
-  });
+    declarations.forEach(function(declaration) {
+        declarationAst = { type    : 'declaration',
+                                              property: declaration.property,
+                                              value   : declaration.value
+                                          };
+        declarationsAst.push(declarationAst);
+    });
 
-  return declarationsAst;
+    return declarationsAst;
 };
 
 // ast to rules css
 var cssAstToRulesCss = function(ast) {
-  var cssDummy = cssParser.stringify(ast, { compress: true });
-  return extractRuleCss(cssDummy);
+    var cssDummy = cssParser.stringify(ast, { compress: true });
+    return extractRuleCss(cssDummy);
 };
 // rules to rules css
 var stringifyCssRules = function(rules) {
-  var ast = prepareCssRulesAst(rules);
-  return cssAstToRulesCss(ast);
+    var ast = prepareCssRulesAst(rules);
+    return cssAstToRulesCss(ast);
 };
 // declarations to rules css
 var stringifyCssDeclarations = function(declarations) {
 
-  var dummyRule =
-    { type     : 'rule',
-      selectors: [ '.dummy' ],
-      declarations:
-      []
-    };
-  dummyRule.declarations = prepareCssDeclarationsAst(declarations);
+    var dummyRule =
+        { type     : 'rule',
+            selectors: [ '.dummy' ],
+            declarations:
+            []
+        };
+    dummyRule.declarations = prepareCssDeclarationsAst(declarations);
 
-  return stringifyCssRules([dummyRule]);
+    return stringifyCssRules([dummyRule]);
 };
 // helper to extract rules css from full css
 var extractRuleCss = function(str) {
-  var strEx = str.match(/\.dummy{(.*)}/i)[1];
-  return strEx;
+    var strEx = str.match(/\.dummy{(.*)}/i)[1];
+    return strEx;
 };
 
 
 // returns true when two compared declarations got the same property (name)
 var uniqueProperty = function(a,b) {
-  return (a.property == b.property) ? 0 : 1;
+    return (a.property == b.property) ? 0 : 1;
 };
 
 
 /**
- * Copy styles from <style> to element styles.
- *
- * (1) run this plugin before the removeStyleElement plugin
- * (2) this plugin won't remove the <style> element,
- *     use removeStyleElement after this plugin
- * (3) run convertStyleToAttrs after this plugin
- * (4) minify styles in <style> if necessary
- *     before this plugin (minified = "computed" styles)
- * (5) this plugin currently works only with class and id selectors,
- *     advanced css selectors (e.g. :nth-child) aren't currently supported
- * (6) inline styles will be written after the styles from <style>
- * (7) classes are inlined by the order of their names in class element attribute
- *
- * http://www.w3.org/TR/SVG/styling.html#StyleElement
- *
- * @param {Object} item current iteration item
- * @return {Boolean} if false, item will be filtered out
- *
- * @author strarsis <strarsis@gmail.com>
- */
+  * Copy styles from <style> to element styles.
+  *
+  * (1) run this plugin before the removeStyleElement plugin
+  * (2) this plugin won't remove the <style> element,
+  *     use removeStyleElement after this plugin
+  * (3) run convertStyleToAttrs after this plugin
+  * (4) minify styles in <style> if necessary
+  *     before this plugin (minified = "computed" styles)
+  * (5) this plugin currently works only with class and id selectors,
+  *     advanced css selectors (e.g. :nth-child) aren't currently supported
+  * (6) inline styles will be written after the styles from <style>
+  * (7) classes are inlined by the order of their names in class element attribute
+  *
+  * http://www.w3.org/TR/SVG/styling.html#StyleElement
+  *
+  * @param {Object} item current iteration item
+  * @return {Boolean} if false, item will be filtered out
+  *
+  * @author strarsis <strarsis@gmail.com>
+  */
 exports.fn = function(item) {
 
-    // TODO: although quite rarely used, add support for multiple <style> elements
-    if(item.elem && item.isElem('style')) {
-      // fetch global styles from style element
-          svgElem              = item;
-      var styleCss             = item.content[0].text;
-          styleCssAst          = cssParser.parse(styleCss);
+        // TODO: although quite rarely used, add support for multiple <style> elements
+        if(item.elem && item.isElem('style')) {
+            // fetch global styles from style element
+                    svgElem              = item;
+            var styleCss             = item.content[0].text;
+                    styleCssAst          = cssParser.parse(styleCss);
 
-      var styleCssRules        = styleCssAst.stylesheet.rules,
-          styleCssDeclarations = [];
+            var styleCssRules        = styleCssAst.stylesheet.rules,
+                    styleCssDeclarations = [];
 
-      styleCssRules.forEach(function(styleCssRule) {
-        if(styleCssRule.type != 'rule') { return; } // skip anything nested like mediaqueries
+            styleCssRules.forEach(function(styleCssRule) {
+                if(styleCssRule.type != 'rule') { return; } // skip anything nested like mediaqueries
 
-        styleCssDeclarations = getCssDeclarationsFromRule(styleCssRule);
-        styleCssRule.selectors.forEach(function(styleSelector) {
-          lookupRules.push({
-            selector:     styleSelector,
-            declarations: styleCssDeclarations,
-            astRule:      styleCssRule
-          });
-        });
-      });
-      return item;
-    }
-
-
-    if(lookupRules.length > 0 && item.elem) {
-
-      // primitive "selector engine"
-      var itemDeclarations = [];
-
-      // #id
-      if(item.hasAttr('id')) {
-        var idName       = item.attr('id').value;
-        var selectorFind = '#' + idName;
-        itemDeclarations = itemDeclarations.concat(processCssSelector(selectorFind));
-      }
-
-      // .class
-      if(item.hasAttr('class')) {
-        var classNames     = parseClasses(item);
-        classNames.forEach(function(className) {
-          var selectorFind = '.' + className;
-          itemDeclarations = itemDeclarations.concat(processCssSelector(selectorFind));
-        });
-      }
-
-      styleCssAst.stylesheet.rules = cleanupRulesAst(styleCssAst.stylesheet.rules);
+                styleCssDeclarations = getCssDeclarationsFromRule(styleCssRule);
+                styleCssRule.selectors.forEach(function(styleSelector) {
+                    lookupRules.push({
+                        selector:     styleSelector,
+                        declarations: styleCssDeclarations,
+                        astRule:      styleCssRule
+                    });
+                });
+            });
+            return item;
+        }
 
 
-      // existing inline styles
-      // TODO: Opportunity for cleaning up global styles that converge with style attribute stlyes?
-      var itemExistingDeclarations = [];
-      if(item.hasAttr('style')) {
-        var itemExistingCss      = item.attr('style').value;
-        var itemExistingCssAst   = parseRulesCss(itemExistingCss);
-        itemExistingDeclarations = getCssDeclarationsFromRule(itemExistingCssAst);
-      }
+        if(lookupRules.length > 0 && item.elem) {
+
+            // primitive "selector engine"
+            var itemDeclarations = [];
+
+            // #id
+            if(item.hasAttr('id')) {
+                var idName       = item.attr('id').value;
+                var selectorFind = '#' + idName;
+                itemDeclarations = itemDeclarations.concat(processCssSelector(selectorFind));
+            }
+
+            // .class
+            if(item.hasAttr('class')) {
+                var classNames     = parseClasses(item);
+                classNames.forEach(function(className) {
+                    var selectorFind = '.' + className;
+                    itemDeclarations = itemDeclarations.concat(processCssSelector(selectorFind));
+                });
+            }
+
+            styleCssAst.stylesheet.rules = cleanupRulesAst(styleCssAst.stylesheet.rules);
 
 
-      var newDeclarations = itemExistingDeclarations.concat(itemDeclarations);
-      uniq(newDeclarations, uniqueProperty, true);
+            // existing inline styles
+            // TODO: Opportunity for cleaning up global styles that converge with style attribute stlyes?
+            var itemExistingDeclarations = [];
+            if(item.hasAttr('style')) {
+                var itemExistingCss      = item.attr('style').value;
+                var itemExistingCssAst   = parseRulesCss(itemExistingCss);
+                itemExistingDeclarations = getCssDeclarationsFromRule(itemExistingCssAst);
+            }
 
-      // apply new styles only when necessary
-      if(newDeclarations  && newDeclarations.length  > 0 &&
-         itemDeclarations && itemDeclarations.length > 0    ) {
-        var newCss = stringifyCssDeclarations(newDeclarations);
-        item.attr('style').value = newCss;
-      }
 
-      var newStyleCss = cssParser.stringify(styleCssAst, { compress: true });
-      svgElem.content[0].text = newStyleCss;
-    }
+            var newDeclarations = itemExistingDeclarations.concat(itemDeclarations);
+            uniq(newDeclarations, uniqueProperty, true);
 
-    return item;
+            // apply new styles only when necessary
+            if(newDeclarations  && newDeclarations.length  > 0 &&
+                  itemDeclarations && itemDeclarations.length > 0    ) {
+                var newCss = stringifyCssDeclarations(newDeclarations);
+                item.attr('style').value = newCss;
+            }
+
+            var newStyleCss = cssParser.stringify(styleCssAst, { compress: true });
+            svgElem.content[0].text = newStyleCss;
+        }
+
+        return item;
 };

--- a/plugins/localStyles.js
+++ b/plugins/localStyles.js
@@ -1,0 +1,200 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = true;
+
+exports.description = 'copies styles from <style> to element styles';
+
+
+var cssParser = require('css')
+  , uniq      = require('uniq')
+  , lookups   = [];
+
+
+// property-value pairs from rule ast
+var getCssDeclarations = function(cssRule) {
+  var properties = [];
+  cssRule.declarations.forEach(function(declaration) {
+    properties.push({ property: declaration.property, value: declaration.value });
+  });
+  return properties;
+};
+
+var _trim = function(s) {
+  return s.trim();
+}
+// parse class attribute value
+var parseClasses = function(item) {
+  return item.attr('class').value.split(' ').map(_trim);
+};
+
+// looks up styles for selector
+var lookupsSelector = function(selector) {
+  var declarations = [];
+  lookups.forEach(function(lookup) {
+    if(lookup.selector == selector) {
+      declarations = declarations.concat(lookup.declarations);
+    }
+  });
+  return declarations;
+};
+
+// parses css of a css rule (no selector)
+var parseRulesCss = function(str) {
+  return cssParser
+         .parse('.dummy { ' + str + ' }')
+         .stylesheet.rules[0];
+};
+
+// prepares a full css ast from rules array
+var prepareRulesAst = function(rules) {
+  var ast =
+  { type      : 'stylesheet',
+    stylesheet: {
+      rules: rules
+    }
+  };
+  return ast;
+};
+
+// generates an ast declaration per property-value pair
+var prepareDeclarationsAst = function(declarations) {
+  var declarationsAst = []
+    , declarationAst  = {};
+
+  declarations.forEach(function(declaration) {
+    declarationAst = { type    : 'declaration',
+                       property: declaration.property,
+                       value   : declaration.value
+                     };
+    declarationsAst.push(declarationAst);
+  });
+
+  return declarationsAst;
+};
+
+// ast to rules css
+var astToRulesCss = function(ast) {
+  var cssDummy = cssParser.stringify(ast, { compress: true });
+  return extractRuleCss(cssDummy);
+};
+// rules to rules css
+var stringifyRules = function(rules) {
+  var ast = prepareRulesAst(rules);
+  return astToRulesCss(ast);
+};
+// declarations to rules css
+var stringifyDeclarations = function(declarations) {
+
+  var dummyRule =
+    { type     : 'rule',
+      selectors: [ '.dummy' ],
+      declarations:
+      []
+    };
+  dummyRule.declarations = prepareDeclarationsAst(declarations);
+
+  return stringifyRules([dummyRule]);
+};
+// helper to extract rules css from full css
+var extractRuleCss = function(str) {
+  var strEx = str.match(/\.dummy{(.*)}/i)[1];
+  return strEx;
+};
+
+// prepares css lookups table for selectors + styles
+var generateLookup = function(item) {
+  var styleCss             = item.content[0].text
+    , styleCssParsed       = cssParser.parse(styleCss)
+    , styleCssRules        = styleCssParsed.stylesheet.rules
+    , styleCssDeclarations = []
+    , lookups               = [];
+
+  styleCssRules.forEach(function(styleCssRule) {
+    styleCssDeclarations = getCssDeclarations(styleCssRule);
+    styleCssRule.selectors.forEach(function(styleSelector) {
+      lookups.push({ selector: styleSelector, declarations: styleCssDeclarations });
+    });
+  });
+  return lookups;
+};
+
+// returns true when two compared declarations got the same property (name)
+var uniqueProperty = function(a,b) {
+  return (a.property == b.property) ? 0 : 1;
+};
+
+
+/**
+ * Copy styles from <style> to element styles.
+ *
+ * (1) run this plugin before the removeStyleElement plugin
+ * (2) this plugin won't remove the <style> element,
+ *     use removeStyleElement after this plugin
+ * (3) run convertStyleToAttrs after this plugin
+ * (4) minify styles in <style> if necessary
+ *     before this plugin (minified = "computed" styles)
+ * (5) this plugin currently works only with class and id selectors,
+ *     advanced css selectors (e.g. :nth-child) aren't currently supported
+ * (6) inline styles will be written after the styles from <style>
+ * (7) classes are inlined by the order of their names in class element attribute
+ *
+ * http://www.w3.org/TR/SVG/styling.html#StyleElement
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author strarsis <strarsis@gmail.com>
+ */
+exports.fn = function(item) {
+
+    if(item.elem && item.isElem('style')) {
+      lookups = generateLookup(item);
+      return item;
+    }
+
+    if(lookups.length > 0 && item.elem) {
+
+      // primitive "selector engine"
+      var itemDeclarations = [];
+
+      // .class
+      if(item.hasAttr('class')) {
+        var classes = parseClasses(item);
+        classes.forEach(function(className) {
+          itemDeclarations = itemDeclarations.concat(lookupsSelector('.' + className));
+        });
+      }
+
+      // #id
+      if(item.hasAttr('id')) {
+        var id = item.attr('id');
+          itemDeclarations = itemDeclarations.concat(lookupsSelector('#' + id));
+      }
+
+
+      // existing inline styles
+      var itemExistingDeclarations = [];
+      if(item.hasAttr('style')) {
+        var itemExistingCss       = item.attr('style').value;
+        var itemExistingCssParsed = parseRulesCss(itemExistingCss);
+        itemExistingDeclarations  = getCssDeclarations(itemExistingCssParsed);
+      }
+
+
+      var newDeclarations     = itemExistingDeclarations.concat(itemDeclarations);
+      uniq(newDeclarations, uniqueProperty, true);
+
+      // apply new styles only when necessary
+      if(   newDeclarations  && newDeclarations.length  > 0
+         && itemDeclarations && itemDeclarations.length > 0) {
+        var newCss = stringifyDeclarations(newDeclarations);
+        item.attr('style').value = newCss;
+      }
+
+    }
+
+    return item;
+};
+

--- a/test/plugins/localStyles.01.svg
+++ b/test/plugins/localStyles.01.svg
@@ -1,0 +1,16 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
+</svg>
+

--- a/test/plugins/localStyles.01.svg
+++ b/test/plugins/localStyles.01.svg
@@ -9,7 +9,6 @@
 
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
 </svg>

--- a/test/plugins/localStyles.02.svg
+++ b/test/plugins/localStyles.02.svg
@@ -1,0 +1,16 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0,.st2{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0,.st2{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
+</svg>
+

--- a/test/plugins/localStyles.02.svg
+++ b/test/plugins/localStyles.02.svg
@@ -9,7 +9,7 @@
 
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <style>
-        .st0,.st2{fill:red;}
+        .st2{fill:red;}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
 </svg>

--- a/test/plugins/localStyles.03.svg
+++ b/test/plugins/localStyles.03.svg
@@ -10,7 +10,7 @@
 
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <style>
-        .st0,.st2{fill:red;} .st1{color: yellow;}
+        .st2{fill:red;}
     </style>
     <rect width="100" height="100" class="st0 st1" style="stroke-width:3;stroke:blue;fill:red;color:yellow;"/>
 </svg>

--- a/test/plugins/localStyles.03.svg
+++ b/test/plugins/localStyles.03.svg
@@ -1,0 +1,17 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0,.st2{fill:red;}
+        .st1{color: yellow;}
+    </style>
+    <rect width="100" height="100" class="st0 st1" style="stroke-width:3;stroke:blue;"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0,.st2{fill:red;} .st1{color: yellow;}
+    </style>
+    <rect width="100" height="100" class="st0 st1" style="stroke-width:3;stroke:blue;fill:red;color:yellow;"/>
+</svg>
+

--- a/test/plugins/localStyles.04.svg
+++ b/test/plugins/localStyles.04.svg
@@ -1,0 +1,16 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;fill:red;"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;fill:red;"/>
+</svg>
+

--- a/test/plugins/localStyles.04.svg
+++ b/test/plugins/localStyles.04.svg
@@ -9,7 +9,6 @@
 
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3;fill:red;"/>
 </svg>

--- a/test/plugins/localStyles.05.svg
+++ b/test/plugins/localStyles.05.svg
@@ -2,6 +2,9 @@
     <style>
         .st0{fill:red;} @media screen and (max-width: 200px) { .st1 { display: none; } }
     </style>
+    <style>
+        .st0{color:yellow;}
+    </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;"/>
 </svg>
 
@@ -11,6 +14,7 @@
     <style>
         @media screen and (max-width: 200px){.st1{display:none;}}
     </style>
-    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
+    <style></style>
+    <rect width="100" height="100" class="st0" style="fill:red;color:yellow;stroke-width:3;stroke:blue;"/>
 </svg>
 

--- a/test/plugins/localStyles.05.svg
+++ b/test/plugins/localStyles.05.svg
@@ -9,7 +9,7 @@
 
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <style>
-        .st0{fill:red;} @media screen and (max-width: 200px) { .st1 { display: none; } }
+        @media screen and (max-width: 200px){.st1{display:none;}}
     </style>
     <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
 </svg>

--- a/test/plugins/localStyles.05.svg
+++ b/test/plugins/localStyles.05.svg
@@ -1,0 +1,16 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;} @media screen and (max-width: 200px) { .st1 { display: none; } }
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:red;} @media screen and (max-width: 200px) { .st1 { display: none; } }
+    </style>
+    <rect width="100" height="100" class="st0" style="stroke-width:3;stroke:blue;fill:red;"/>
+</svg>
+


### PR DESCRIPTION
This PR adds the localStyles plugin which copies styles from style element to style attribute of the selected elements.

- run this plugin before the removeStyleElement plugin
- this plugin won't remove the style element, use removeStyleElement after this plugin
- run convertStyleToAttrs after this plugin
- minify styles in style element if necessary before this plugin (minified = "computed" styles)
- this plugin currently works only with class and id selectors, advanced css selectors (e.g. :nth-child) aren't currently supported
- inline styles will be written after the styles from style element
- classes are inlined by the order of their names in class element attribute