### PR TITLE
Add charset handling on Data URI

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -42,22 +42,24 @@ exports.encodeSVGDatauri = function(str, type) {
  */
 exports.decodeSVGDatauri = function(str) {
 
-    var prefix = 'data:image/svg+xml';
+    var regexp = /data:image\/svg\+xml(;charset=[^;,]*)?(;base64)?,(.*)/;
+    var match = regexp.exec(str);
+    var data = match[3];
 
     // base64
-    if (str.substring(0, 26) === (prefix + ';base64,')) {
+    if (match[2]) {
 
-        str = new Buffer(str.substring(26), 'base64').toString('utf8');
+        str = new Buffer(data, 'base64').toString('utf8');
 
     // URI encoded
-    } else if (str.substring(0, 20) === (prefix + ',%')) {
+    } else if (data.charAt(0) === '%') {
 
-        str = decodeURIComponent(str.substring(19));
+        str = decodeURIComponent(data);
 
     // unencoded
-    } else if (str.substring(0, 20) === (prefix + ',<')) {
+    } else if (data.charAt(0) === '<') {
 
-        str = str.substring(19);
+        str = data;
 
     }
 


### PR DESCRIPTION
Handle data URI scheme containing optional charset field like `data:image/svg+xml;charset=US-ASCII,%3C%3Fxml%20...` .