### PR TITLE
Use explicit file types

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -10,11 +10,11 @@
  * @license MIT https://raw.githubusercontent.com/svg/svgo/master/LICENSE
  */
 
-var CONFIG = require('./svgo/config'),
-    SVG2JS = require('./svgo/svg2js'),
-    PLUGINS = require('./svgo/plugins'),
+var CONFIG = require('./svgo/config.js'),
+    SVG2JS = require('./svgo/svg2js.js'),
+    PLUGINS = require('./svgo/plugins.js'),
     JSAPI = require('./svgo/jsAPI.js'),
-    JS2SVG = require('./svgo/js2svg');
+    JS2SVG = require('./svgo/js2svg.js');
 
 var SVGO = module.exports = function(config) {
 


### PR DESCRIPTION
It's good practice to declare the file type being required. This will help svgo play nice with JSPM. Additionally, one of the requires was already declaring its file type. So, this PR adds consistency, too.