### PR TITLE
Add currentColor param to convertColors plugin

### DIFF
--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -19,7 +19,7 @@ var collections = require('./_collections'),
     rComma = '\\s*,\\s*',
     regRGB = new RegExp('^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$'),
     regHEX = /^\#(([a-fA-F0-9])\2){3}$/,
-    none = /none/i;
+    none = /\bnone\b/i;
 
 /**
  * Convert different colors formats in element attributes to hex.

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -7,6 +7,7 @@ exports.active = true;
 exports.description = 'converts colors: rgb() to #rrggbb and #rrggbb to #rgb';
 
 exports.params = {
+    currentColor: false,
     names2hex: true,
     rgb2hex: true,
     shorthex: true,
@@ -17,7 +18,8 @@ var collections = require('./_collections'),
     rNumber = '([+-]?(?:\\d*\\.\\d+|\\d+\\.?)%?)',
     rComma = '\\s*,\\s*',
     regRGB = new RegExp('^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$'),
-    regHEX = /^\#(([a-fA-F0-9])\2){3}$/;
+    regHEX = /^\#(([a-fA-F0-9])\2){3}$/,
+    none = /none/i;
 
 /**
  * Convert different colors formats in element attributes to hex.
@@ -55,6 +57,11 @@ exports.fn = function(item, params) {
 
                 var val = attr.value,
                     match;
+
+                // Convert colors to currentColor
+                if (params.currentColor && (match = !val.match(none))) {
+                    val = 'currentColor';
+                }
 
                 // Convert color name keyword to long hex
                 if (params.names2hex && val.toLowerCase() in collections.colorsNames) {

--- a/test/plugins/convertColors.04.svg
+++ b/test/plugins/convertColors.04.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="black"/>
+    <g color="BLACK"/>
+    <g color="none"/>
+    <path fill="rgb(64, 64, 64)"/>
+    <path fill="rgb(86.27451%,86.666667%,87.058824%)"/>
+    <path fill="rgb(-255,100,500)"/>
+    <path fill="none"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="currentColor"/>
+    <g color="currentColor"/>
+    <g color="none"/>
+    <path fill="currentColor"/>
+    <path fill="currentColor"/>
+    <path fill="currentColor"/>
+    <path fill="none"/>
+</svg>
+
+@@@
+
+{ "currentColor": true }


### PR DESCRIPTION
This is related to #497, but instead of creating a new plugin it adds an additional param to the existing `convertColors` plugin. 

Part of the issue that this addresses, if a color is defined within an SVG you can't override the color easily in CSS without manually editing the SVG. With this new param, you can automatically convert colors to `currentColor` allowing CSS overrides.

The only downside of it being a param within `convertColors`, is that it will override any other params when set to true. That's why initially `currentColor` defaults to `false`.

The only other potential change I could see is to take into account `transparent` values. I'm not sure if transparent values should or should not be converted. For my use case, if a color value is transparent we don't need it changed, but I could see it being different for someone else.