### PR TITLE
Add option to indent when pretty printing svg

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -107,6 +107,13 @@ module.exports = require('coa').Cmd()
         .flag()
         .end()
     .opt()
+        .name('indent').title('Indent number when pretty printing SVGs')
+        .long('indent')
+        .val(function(val) {
+            return !isNaN(val) ? val : this.reject("Option '--indent' must be an integer number");
+        })
+        .end()
+    .opt()
         .name('quiet').title('Only output error messages, not regular status messages')
         .short('q').long('quiet')
         .flag()
@@ -216,6 +223,7 @@ module.exports = require('coa').Cmd()
 
             config.js2svg = config.js2svg || {};
             config.js2svg.pretty = true;
+            config.js2svg.indent = parseInt(opts.indent, 10);
 
         }
 

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -22,7 +22,7 @@ var defaults = {
     cdataEnd: ']]>',
     textStart: '',
     textEnd: '',
-    indent: '    ',
+    indent: 4,
     regEntities: /[&'"<>]/g,
     regValEntities: /[&"<>]/g,
     encodeEntity: encodeEntity,
@@ -58,6 +58,10 @@ function JS2SVG(config) {
         this.config = EXTEND(true, {}, defaults, config);
     } else {
         this.config = defaults;
+    }
+
+    if (this.config.indent && !isNaN(this.config.indent)) {
+        this.config.indent = new Array(this.config.indent + 1).join(' ');
     }
 
     if (this.config.pretty) {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,3 +4,4 @@ test/config
 test/svg2js
 test/plugins
 test/jsapi
+test/svgo

--- a/test/svgo/_index.js
+++ b/test/svgo/_index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var FS = require('fs'),
+    PATH = require('path'),
+    SVGO = require(process.env.COVERAGE ?
+                   '../../lib-cov/svgo':
+                   '../../lib/svgo');
+
+describe('indentation', function() {
+
+    it('should create indent with 2 spaces', function(done) {
+
+        var filepath = PATH.resolve(__dirname, './test.svg'),
+            svgo;
+
+        FS.readFile(filepath, 'utf8', function(err, data) {
+            if (err) {
+                throw err;
+            }
+
+            var splitted = data.trim().split(/\s*@@@\s*/),
+                orig     = splitted[0],
+                should   = splitted[1];
+
+            svgo = new SVGO({
+                full    : true,
+                plugins : [],
+                js2svg  : { pretty: true, indent: 2 }
+            });
+
+            svgo.optimize(orig, function(result) {
+                ( result.data.trim() ).should.be.equal(should);
+                done();
+            });
+
+        });
+
+    });
+
+});

--- a/test/svgo/test.svg
+++ b/test/svgo/test.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g attr2="val2">
+            <path attr2="val3" d="..."/>
+        </g>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g attr1="val1">
+    <g attr2="val2">
+      <path attr2="val3" d="..."/>
+    </g>
+    <path d="..."/>
+  </g>
+</svg>


### PR DESCRIPTION
I took a stab at adding an option to indent svgs for #465 

##### CLI

```bash
svgo --pretty --indent 2 image.svg
```

##### JS API

```js
new svgo({ 
  full: true, 
  plugins: [], 
  js2svg : { 
    pretty: true,
    indent: 2 
  }
}).optimize(file, function(out) { ... });
```

It defaults to 4 to stick with the existing convention, but hopefully provides a little more flexibility to those who are looking to have different indention settings.