### PR TITLE
addClassesToSVGElement: avoid repeating classnames

### DIFF
--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -42,11 +42,13 @@ exports.fn = function(data, params) {
 
     if (svg.isElem('svg')) {
         if (svg.hasAttr('class')) {
-            svg.attr('class').value =
-                svg.attr('class').value
-                    .split(' ')
-                    .concat(classNames)
-                    .join(' ');
+            var classes = svg.attr('class').value.split(' ');
+            classNames.forEach(function(className){
+                if (classes.indexOf(className) < 0) {
+                    classes.push(className);
+                }
+            });
+            svg.attr('class').value = classes.join(' ');
         } else {
             svg.addAttr({
                 name: 'class',


### PR DESCRIPTION
If you run `svgo` repeatedly over a set of files it will continue to add the same class over and over:

```yaml
plugins:
  - addClassesToSVGElement:
     className: icon
```

```svg
<svg class="icon icon icon icon icon">...
```

This commit changes `addClassesToSVGElement` to only add classes that are not already present.