### PR TITLE
add removeXMLNS plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -20,6 +20,7 @@ plugins:
   - removeXMLProcInst
   - removeComments
   - removeMetadata
+  - removeXMLNS
   - removeEditorsNSData
   - cleanupAttrs
   - minifyStyles

--- a/plugins/removeXMLNS.js
+++ b/plugins/removeXMLNS.js
@@ -1,0 +1,28 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'removes xmlns attribute (for inline svg, disabled by default)';
+
+/**
+ * Remove the xmlns attribute when present.
+ *
+ * @example
+ * <svg viewBox="0 0 100 50" xmlns="http://www.w3.org/2000/svg">
+ *   ↓
+ * <svg viewBox="0 0 100 50">
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if true, xmlns will be filtered out
+ *
+ * @author Ricardo Tomasi
+ */
+exports.fn = function(item) {
+
+    if (item.isElem('svg') && item.hasAttr('xmlns')) {
+        item.removeAttr('xmlns');
+    }
+
+};


### PR DESCRIPTION
Previously seen in #409.

This is useful for cases where you are inlining `<svg>` elements - [HTML5 does not support namespaces](https://www.w3.org/TR/html5/syntax.html#foreign-elements).