### PR TITLE
moveGroupAttrsToElems: new transform attribute shouldn't be a reference

### DIFF
--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -44,10 +44,16 @@ exports.fn = function(item) {
         })
     ) {
         item.content.forEach(function(inner) {
+            var attr = item.attr('transform');
             if (inner.hasAttr('transform')) {
-                inner.attr('transform').value = item.attr('transform').value + ' ' + inner.attr('transform').value;
+                inner.attr('transform').value = attr.value + ' ' + inner.attr('transform').value;
             } else {
-                inner.addAttr(item.attr('transform'));
+                inner.addAttr({
+                    'name': attr.name,
+                    'local': attr.local,
+                    'prefix': attr.prefix,
+                    'value': attr.value
+                });
             }
         });
 


### PR DESCRIPTION
I'm writing a plugin that, among other things, makes changes to transform values. I've found that my plugin throws an error when used with `moveGroupAttrsToElems`.

moveGroupAttrsToElems is correctly copying transforms from a group to each child element, but it's assigning the "new" attribute to the element by referencing the original instead of creating a new copy of it. This results in my plugin making changes to the same referenced transform for each element.

This PR ensures a new version of the attribute is created, fixing the issue.