### PR TITLE
Precision Scaling Plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -42,6 +42,7 @@ plugins:
   - moveGroupAttrsToElems
   - collapseGroups
   - convertPathData
+  - scalePrecision
   - convertTransform
   - removeEmptyAttrs
   - removeEmptyContainers

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Today we have:
 * [ [ removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) ] remove attributes by pattern (disabled by default)
 * [ [ addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) ] add classnames to an outer `<svg>` element (disabled by default)
 * [ [ removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) ] remove `<style>` elements (disabled by default)
+* [ [ scalePrecision](https://github.com/svg/svgo/blob/master/plugins/scalePrecision.js) ] scales decimal values into integers (disabled by default)
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md).
 

--- a/plugins/scalePrecision.js
+++ b/plugins/scalePrecision.js
@@ -1,0 +1,394 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.params = {
+    leadingZero: true,
+    negativeExtraSpace: true,
+    floatPrecision: 3,
+    applyViewBox: true
+};
+
+exports.description = 'scales decimal values to integers';
+
+var path2js = require('./_path.js').path2js,
+    js2path = require('./_path.js').js2path,
+    transform2js = require('./_transforms.js').transform2js,
+    cleanupOutData = require('../lib/svgo/tools').cleanupOutData,
+    regNumber = /[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g,
+
+    // Handler for simple values (width, height etc.)
+    simpleValueHandler = {
+        get: getPrecision,
+        set: scalePrecision
+    },
+
+    // Handler for value lists (viewBox, coordiates etc.)
+    valueListHandler = {
+        get: getValueListPrecision,
+        set: scaleValueList
+    },
+
+    // Handler for transforms
+    transformHandler = {
+        set: scaleTransform
+    },
+
+    attrs = {
+        'x': simpleValueHandler,
+        'y': simpleValueHandler,
+        'x1': simpleValueHandler,
+        'y1': simpleValueHandler,
+        'x2': simpleValueHandler,
+        'y2': simpleValueHandler,
+        'r': simpleValueHandler,
+        'rx': simpleValueHandler,
+        'ry': simpleValueHandler,
+        'cx': simpleValueHandler,
+        'cy': simpleValueHandler,
+        'dx': simpleValueHandler,
+        'dy': simpleValueHandler,
+        'fx': simpleValueHandler,
+        'fy': simpleValueHandler,
+        'width': simpleValueHandler,
+        'height': simpleValueHandler,
+        'stroke-width': simpleValueHandler,
+        'font-size': simpleValueHandler,
+        'stdDeviation': simpleValueHandler,
+        'viewBox': valueListHandler,
+        'points': valueListHandler,
+        'stroke-dasharray': valueListHandler,
+        'transform': transformHandler,
+        'gradientTransform': transformHandler
+    };
+
+/**
+ * Scales decimal values into integers.
+ *
+ * @example
+ * <svg width="100.25" height="50.25">
+ *             ⬇
+ * <svg width="10025" height="5025">
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Keith Clark
+ */
+exports.fn = function (data, params) {
+    var root = getSvgRoot(data),
+        precision, width, height;
+
+    if (!root) {
+        return data;
+    }
+
+    // determine the document percision
+    precision = Math.min(params.floatPrecision, getDocumentPrecision(data));
+
+    // store the original image dimensions
+    if (root.hasAttr('width')) {
+        width = root.attr('width').value;
+    }
+    if (root.hasAttr('height')) {
+        height = root.attr('height').value;
+    }
+
+    // We need to set a root `stroke-width` so that paths using the implied
+    // default value of `1` will render at the correct scale.
+    root.addAttr({
+        name: 'stroke-width',
+        value: 1,
+        local: 'stroke-width',
+        prefix: ''
+    });
+
+    // scale the document
+    scaleDocumentPrecision(data, precision, params);
+
+    // since we're scaling the image we need to add a viewBox and restore the
+    // root width/height attributes to ensure the image will render at the
+    // original size.
+    if (params.applyViewBox && root.isElem('svg') && width && height) {
+        setViewBox(root, 0, 0, root.attr('width').value, root.attr('height').value, params);
+        root.attr('width').value = width;
+        root.attr('height').value = height;
+    }
+
+    return data;
+};
+
+
+/**
+ * gets the root SVG element.
+ *
+ * @param {number} value    value to test
+ * @return {number} precision
+ */
+function getSvgRoot(data) {
+    for (var c = 0; c < data.content.length; c++) {
+        if (data.content[c].isElem('svg')) {
+            return data.content[c];
+        }
+    }
+}
+
+/**
+ * Determines the precision of the passed value.
+ *
+ * @param {number} value    value to test
+ * @return {number} precision
+ */
+function getPrecision(value) {
+    value = String(value);
+    var dp = value.indexOf('.');
+    return (dp > -1) ? value.substr(dp + 1).length : 0;
+}
+
+/**
+ * Scales the passed value by the specified power of ten.
+ *
+ * @param {number} value    value to scale
+ * @param {number} scale    scale factor (power of ten)
+ * @return {number} scaled value
+ */
+function scalePrecision(value, scale) {
+    // TODO: test for units
+    if (isNaN(value)) {
+        return value;
+    }
+    return +((+value) * Math.pow(10, scale)).toFixed();
+}
+
+/**
+ * Determines the maximum precision of values in the passed
+ * array.
+ *
+ * @param {number[]} arr   values to test
+ * @return {number} precision
+ */
+function getArrayPrecision(arr) {
+    var precision = 0;
+    arr.forEach(function (val) {
+        precision = Math.max(precision, getPrecision(val));
+    });
+    return precision;
+}
+
+/**
+ * Scales the values in the passed array to the specified
+ * power of ten.
+ *
+ * @param {number[]} arr   values to scale
+ * @param {number} scale   scale factor (power of ten)
+ * @return {number[]} scaled values
+ */
+function scaleArray(arr, scale) {
+    return arr.map(function (val) {
+        return scalePrecision(val, scale);
+    });
+}
+
+/**
+ * splits a list of values into an array of numbers
+ * values.
+ *
+ * @param {string} values    value list to split
+ * @return {number[]} numbers
+ */
+function valuesToArray(values) {
+    return values.match(regNumber) || [];
+}
+
+/**
+ * Determines the maximum precision of values in a list of
+ * values.
+ *
+ * @param {string} coords    values list to test
+ * @return {number} precision
+ */
+function getValueListPrecision(list) {
+    return getArrayPrecision(valuesToArray(list));
+}
+
+/**
+ * Scales the passed list of values to the specified power
+ * of ten.
+ *
+ * @param {string} list    values to scale
+ * @param {number} scale   scale factor (power of ten)
+ * @param {Object} params  plugin params
+ * @return {string} scaled scaled list
+ */
+function scaleValueList(list, scale, params) {
+    return cleanupOutData(scaleArray(valuesToArray(list), scale), params);
+}
+
+/**
+ * Scales the passed transform string to the specified power
+ * of ten.
+ *
+ * @param {string} transform   coordinates to scale
+ * @param {number} scale       scale factor (power of ten)
+ * @param {Object} params      plugin params
+ * @return {string} scaled transform
+ */
+function scaleTransform(transform, scale, params) {
+    var transforms = transform2js(transform);
+    transforms.forEach(function (transform) {
+        if (transform.name === 'translate') {
+            transform.data = scaleArray(transform.data, scale);
+        } else if (transform.name === 'matrix') {
+            transform.data[4] = scalePrecision(transform.data[4], scale);
+            transform.data[5] = scalePrecision(transform.data[5], scale);
+        }
+    });
+    return js2transform(transforms, params);
+}
+
+/**
+ * Converts a js object into a transform string.
+ *
+ * @param {Object[]} transformJS   object to convert
+ * @param {Object} params          plugin params
+ * @return {string}                converted string
+ */
+function js2transform(transformJS, params) {
+    var transformString = '';
+
+    // collect output value string
+    transformJS.forEach(function (transform) {
+        transformString += (transformString && ' ') + transform.name + '(' + cleanupOutData(transform.data, params) + ')';
+    });
+
+    return transformString;
+}
+
+/**
+ * Scales the passed path string to the specified power of ten.
+ *
+ * @param {string} path      path to scale
+ * @param {number} scale     scale factor (power of ten)
+ * @param {Object} params    plugin params
+ * @return {string} scaled path
+ */
+function getPathPrecision(path) {
+    var precision = 0;
+    var segments = path2js(path);
+    segments.forEach(function (segment) {
+        var instruction = segment.instruction;
+        if ('MmLlHhVvCcSsQqTt'.indexOf(instruction) > -1) {
+            precision = Math.max(precision, getArrayPrecision(segment.data));
+        } else if ('Aa'.indexOf(instruction) > -1) {
+            precision = Math.max(precision, getPrecision(segment.data[0]));
+            precision = Math.max(precision, getPrecision(segment.data[1]));
+            precision = Math.max(precision, getPrecision(segment.data[5]));
+            precision = Math.max(precision, getPrecision(segment.data[6]));
+        }
+    });
+    return precision;
+}
+
+/**
+ * Scales the passed path string to the specified power of ten.
+ *
+ * @param {string} path      path to scale
+ * @param {number} scale     scale factor (power of ten)
+ * @param {Object} params    plugin params
+ * @return {string} scaled path
+ */
+function scalePath(path, scale, params) {
+    var segments = path2js(path);
+    segments.forEach(function (segment) {
+        var instruction = segment.instruction;
+        if ('MmLlHhVvCcSsQqTt'.indexOf(instruction) > -1) {
+            segment.data = scaleArray(segment.data, scale);
+        } else if ('Aa'.indexOf(instruction) > -1) {
+            segment.data[0] = scalePrecision(segment.data[0], scale);
+            segment.data[1] = scalePrecision(segment.data[1], scale);
+            segment.data[5] = scalePrecision(segment.data[5], scale);
+            segment.data[6] = scalePrecision(segment.data[6], scale);
+        }
+    });
+    js2path(path, segments, params);
+}
+
+/**
+ * applies a viewBox to an element
+ *
+ * @param {Object} item      SVG element to apply viewbox to
+ * @param {number} minX      minimum x value
+ * @param {number} minY      minimum y value
+ * @param {number} width     rectangle width
+ * @param {number} height    rectangle height
+ * @param {Object} params    plugin params
+ */
+function setViewBox(item, minX, minY, width, height, params) {
+    if (!item.hasAttr('viewBox') && item.hasAttr('width') && item.hasAttr('height')) {
+        item.addAttr({
+            name: 'viewBox',
+            value: cleanupOutData([minX, minY, width, height], params),
+            prefix: '',
+            local: 'viewBox'
+        });
+    }
+}
+
+/**
+ * Determines the largest precision used in a document.
+ *
+ * @param {Object} items             SVG items to process
+ * @param {number} basePrecision     starting precision
+ * @return {string} precision
+ */
+function getDocumentPrecision(items, basePrecision) {
+    var precision = basePrecision || 0;
+
+    items.content.forEach(function (item) {
+        if (item.isElem()) {
+            Object.keys(attrs).forEach(function (key) {
+                if (item.hasAttr(key) && attrs[key].get) {
+                    precision = Math.max(precision, attrs[key].get(item.attr(key).value));
+                }
+            });
+            if (item.isElem('path')) {
+                precision = Math.max(precision, getPathPrecision(item));
+            }
+        }
+        if (item.content) {
+            precision = Math.max(precision, getDocumentPrecision(item, precision));
+        }
+    });
+    return precision;
+}
+
+/**
+ * Scales the passed document fragment to the specified power of ten.
+ *
+ * @param {Object} items     SVG items to process
+ * @param {number} scale     scale factor (power of ten)
+ * @param {Object} params    plugin params
+ */
+function scaleDocumentPrecision(items, scale, params) {
+    items.content.forEach(function (item) {
+        if (item.isElem()) {
+            Object.keys(attrs).forEach(function (key) {
+                var attr;
+                if (item.hasAttr(key) && attrs[key].set) {
+                    attr = item.attr(key);
+                    attr.value = attrs[key].set(attr.value, scale, params);
+                }
+            });
+
+            if (item.isElem('path')) {
+                scalePath(item, scale, params);
+            }
+        }
+
+        if (item.content) {
+            scaleDocumentPrecision(item, scale, params);
+        }
+    });
+}

--- a/test/plugins/scalePrecision.01.svg
+++ b/test/plugins/scalePrecision.01.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 103 292">
+    <defs>
+        <filter id="blur" color-interpolation-filters="sRGB">
+            <feGaussianBlur stdDeviation=".57"/>
+        </filter>
+        <filter id="dropShadow">
+            <feGaussianBlur in="SourceAlpha" stdDeviation=".57"/>
+            <feOffset dx="2.56" dy="4.56"/>
+            <feMerge>
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+        </filter>
+    </defs>
+    <rect x="10.12" y="10.12" width="30.12" height="30.12" stroke="black" fill="transparent" stroke-width="5" transform="translate(1.34,1.45)"/>
+    <rect x="60.12" y="10.12" rx="10.12" ry="10.12" width="30.12" height="30.12" stroke="black" fill="transparent" stroke-width="5" transform="matrix(1,0,0,1,1.34,1.45)"/>
+    <circle cx="25.12" cy="75.12" r="20.12" stroke="red" fill="transparent" stroke-width="5"/>
+    <ellipse cx="75.12" cy="75.12" rx="20.12" ry="5.12" stroke="red" fill="transparent" stroke-width="5"/>
+    <line x1="10.12" x2="50.12" y1="110.12" y2="150.12" stroke="orange" fill="transparent" stroke-width="5"/>
+    <polyline points="60.12 110.12 65.12 120.12 70.12 115.12 75.12 130.12 80.12 125.12 85.12 140.12 90.12 135.12 95.12 150.12 100.12 145.12" stroke="orange" fill="transparent" stroke-width="5"/>
+    <polygon points="50.12 160.12 55.12 180.12 70.12 180.12 60.12 190.12 65.12 205.12 50.12 195.12 35.12 205.12 40.12 190.12 30.12 180.12 45.12 180.12" stroke="green" fill="transparent" stroke-width="5"/>
+    <path d="M20.12,230.12 Q40.12,205.12 50.12,230.12 T90.12,230.12" fill="none" stroke="blue" stroke-width="5" filter="url('#dropShadow')"/>
+    <text x="10.12" y="285" font-size="50" filter="url('#blur')">
+        Text
+    </text>
+    <line stroke-dasharray="5.25 5.25" x1="10.12" y1="290.55" x2="102.5" y2="290.55" stroke="red" stroke-width="2"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10300 29200" stroke-width="100">
+    <defs>
+        <filter id="blur" color-interpolation-filters="sRGB">
+            <feGaussianBlur stdDeviation="57"/>
+        </filter>
+        <filter id="dropShadow">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="57"/>
+            <feOffset dx="256" dy="456"/>
+            <feMerge>
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+        </filter>
+    </defs>
+    <rect x="1012" y="1012" width="3012" height="3012" stroke="black" fill="transparent" stroke-width="500" transform="translate(134 145)"/>
+    <rect x="6012" y="1012" rx="1012" ry="1012" width="3012" height="3012" stroke="black" fill="transparent" stroke-width="500" transform="matrix(1 0 0 1 134 145)"/>
+    <circle cx="2512" cy="7512" r="2012" stroke="red" fill="transparent" stroke-width="500"/>
+    <ellipse cx="7512" cy="7512" rx="2012" ry="512" stroke="red" fill="transparent" stroke-width="500"/>
+    <line x1="1012" x2="5012" y1="11012" y2="15012" stroke="orange" fill="transparent" stroke-width="500"/>
+    <polyline points="6012 11012 6512 12012 7012 11512 7512 13012 8012 12512 8512 14012 9012 13512 9512 15012 10012 14512" stroke="orange" fill="transparent" stroke-width="500"/>
+    <polygon points="5012 16012 5512 18012 7012 18012 6012 19012 6512 20512 5012 19512 3512 20512 4012 19012 3012 18012 4512 18012" stroke="green" fill="transparent" stroke-width="500"/>
+    <path d="M2012 23012Q4012 20512 5012 23012T9012 23012" fill="none" stroke="blue" stroke-width="500" filter="url('#dropShadow')"/>
+    <text x="1012" y="28500" font-size="5000" filter="url('#blur')">
+        Text
+    </text>
+    <line stroke-dasharray="525 525" x1="1012" y1="29055" x2="10250" y2="29055" stroke="red" stroke-width="200"/>
+</svg>

--- a/test/plugins/scalePrecision.02.svg
+++ b/test/plugins/scalePrecision.02.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect x="10.12" y="10.12" width="79.76" height="79.76" stroke="black" fill="transparent"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" stroke-width="100" viewBox="0 0 10000 10000">
+    <rect x="1012" y="1012" width="7976" height="7976" stroke="black" fill="transparent"/>
+</svg>
+
+@@@
+
+{"applyViewBox": true}


### PR DESCRIPTION
This PR adds a new precision scaling plugin to SVGO. This plugin scales decimal values by powers of ten to remove the decimal point from the SVG source.

The plugin accepts a single boolean parameter, `applyViewBox`. If set to `true` (and the image has with/height attributes), a viewBox will be added to the root SVG element and the original width/height values will not be scaled. This allows a client to render the scaled image at the original size. If `false` the viewBox will be omitted and SVG clients will render the image at the scaled size.

Depending on the SVG, this plugin can shave up to 10% off the compressed output, resulting in an average 2-5% reduction of SVG when gzip'd. In some files, scaling precision can lead to a larger compressed image so this plugin is deactivated by default.

| Image                     |Original|Compressed|Compressed (scalePrecision)|Gzip  |Gzip (scalePrecision)|
|---------------------------|-------:|---------:|--------------------------:|-----:|--------------------:|
| [gallardo.svg][gallardo]  |340873  |130918    |__124607__                 |32071 |__31510__            |
| [svgo.svg][svgo]          |25791   |21679     |__21534__                  |3657  |__3573__             |
| [car.svg][car]            |527014  |200945    |__186465__                 |49849 |__48909__            |


## TODO:

### General
- [ ] Handle non-pixel values better in `getPrecision`/`scalePrecision`
- [ ] Finalise the list of attributes that can be scaled

### Enhancements
- [ ] Only add scaled `stroke-width` to the root element if shape/text elements use the default width



[gallardo]:https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/gallardo.svg 
[svgo]:https://github.com/svg/svgo/blob/master/logo.svg
[car]:https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/car.svg