### PR TITLE
Created illustratorLayerIdsToClasses plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -24,6 +24,7 @@ plugins:
   - cleanupAttrs
   - minifyStyles
   - convertStyleToAttrs
+  - illustratorLayerIdsToClasses
   - cleanupIDs
   - removeRasterImages
   - removeUselessDefs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Today we have:
 * [ [ removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) ] remove attributes by pattern (disabled by default)
 * [ [ addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) ] add classnames to an outer `<svg>` element (disabled by default)
 * [ [ removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) ] remove `<style>` elements (disabled by default)
-* [ [ illustratorLayerIdsToClasses](https://github.com/svg/svgo/blob/master/plugins/illustratorLayerIdsToClasses.js) ] copy `data-id` or `id` attribute to `class`. This is useful when exporting from Adobe Illustrator and using "Object IDs: Layer Names" in the export settings (disabled by default)
+* [ [ illustratorLayerIdsToClasses](https://github.com/svg/svgo/blob/master/plugins/illustratorLayerIdsToClasses.js) ] copy `data-id` or `id` attribute to `class`. This is useful when exporting from Adobe Illustrator and using "Object IDs: Layer Names" in the export settings. For more information on the intended use, see [this blog post](https://codingwithspike.wordpress.com/2016/05/01/css-styling-illustrator-svgs/). (disabled by default)
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md).
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Today we have:
 * [ [ removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) ] remove attributes by pattern (disabled by default)
 * [ [ addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) ] add classnames to an outer `<svg>` element (disabled by default)
 * [ [ removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) ] remove `<style>` elements (disabled by default)
+* [ [ illustratorLayerIdsToClasses](https://github.com/svg/svgo/blob/master/plugins/illustratorLayerIdsToClasses.js) ] copy `data-id` or `id` attribute to `class`. This is useful when exporting from Adobe Illustrator and using "Object IDs: Layer Names" in the export settings (disabled by default)
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md).
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -57,6 +57,7 @@ SVGO имеет расширяемую архитектуру, в которой
 * [ [ removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) ] удаляет атрибуты по указанному паттерну (выключено по умолчанию)
 * [ [ addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) ] добавляет имена классов корневому элементу `<svg>` (выключено по умолчанию)
 * [ [ removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) ] удаляет элементы `<style>` (выключено по умолчанию)
+* [ [ illustratorLayerIdsToClasses](https://github.com/svg/svgo/blob/master/plugins/illustratorLayerIdsToClasses.js) ] скопировать `data-id` или `id` атрибут `class`. Это полезно при экспорте из Adobe Illustrator и с помощью "Object IDs: Layer Name" в настройках экспорта (выключено по умолчанию)
 
 Хотите узнать, как это работает и как написать свой плагин? [Конечно же, да!](https://github.com/svg/svgo/blob/master/docs/how-it-works/ru.md).
 

--- a/plugins/illustratorLayerIdsToClasses.js
+++ b/plugins/illustratorLayerIdsToClasses.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/*
+In Adobe Illustrator, the only way to get it to export SVGs with meaningul class="" attributes is to use named Graphical Styles.
+This is inconvenient to use as some things can't be done with Graphical Styles alone.
+
+Instead, assign a meaningful name to a layer instead. When exporting an SVG, you can choose to use Layer Names as Object IDs.
+This SVGO plugin will then copy the Object IDs over to the class attribute.
+
+Since IDs are to be unique, if you name multiple layer with the same name, Illustrator will put the original in a data-name="" attribute.
+
+Example where 2 lines are both named "line1":
+  <line id="line1" class="cls-1" x1="0.3" y1="64.93" x2="71.14" y2="10.76"/>
+  <line id="line1-2" data-name="line1" class="cls-1" x1="79.47" y1="100.35" x2="158.64" y2="8.68"/>
+
+So this plugin will first look for a data-name attribute, then fall back to the ID and generate the output:
+  <line id="line1" class="cls-1 line1" x1="0.3" y1="64.93" x2="71.14" y2="10.76"/>
+  <line id="line1-2" data-name="line1" class="cls-1 line1" x1="79.47" y1="100.35" x2="158.64" y2="8.68"/>
+("line1" is added to the class names for both elements)
+*/
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'Export SVG in Illustrator with layer names as object IDs and this plugin will move them to class names.';
+
+exports.params = {
+    remove: true,
+    minify: true,
+    prefix: ''
+};
+
+function shouldSkip(element) {
+    return !element.isElem() || !element.hasAttr('id');
+}
+
+function findLayerName(element) {
+    return (element.attr('data-name') || element.attr('id')).value;
+}
+
+function findExistingClasses(element) {
+    return element.attr('class') || {
+        name: 'class',
+        value: undefined,
+        prefix: '',
+        local: ''
+    };
+}
+
+function mergeClasses(classAttr, className) {
+    classAttr.value = classAttr.value ? (classAttr.value + ' ' + className) : className;
+}
+
+exports.fn = function(data) {
+    if(shouldSkip(data)) {
+        return data;
+    }
+
+    var layerName = findLayerName(data);
+    var classAttr = findExistingClasses(data);
+    mergeClasses(classAttr, layerName);
+    data.addAttr(classAttr);
+
+    return data;
+};

--- a/test/plugins/illustratorLayerIdsToClasses.01.svg
+++ b/test/plugins/illustratorLayerIdsToClasses.01.svg
@@ -1,0 +1,31 @@
+<svg id="ex" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 159.02 100.67">
+    <defs>
+        <style>
+            .cls-1{fill:none;stroke:#231f20;stroke-miterlimit:10;}
+        </style>
+    </defs>
+    <title>
+        Untitled-1
+    </title>
+    <line id="line2" class="cls-1" x1="4.47" y1="0.35" x2="72.18" y2="70.39"/>
+    <line id="line1" class="cls-1" x1="0.3" y1="64.93" x2="71.14" y2="10.76"/>
+    <line id="line2-2" data-name="line2" class="cls-1" x1="99.26" y1="8.68" x2="145.1" y2="97.22"/>
+    <line id="line1-2" data-name="line1" class="cls-1" x1="79.47" y1="100.35" x2="158.64" y2="8.68"/>
+</svg>
+
+@@@
+
+<svg id="ex" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 159.02 100.67" class="ex">
+    <defs>
+        <style>
+            .cls-1{fill:none;stroke:#231f20;stroke-miterlimit:10;}
+        </style>
+    </defs>
+    <title>
+        Untitled-1
+    </title>
+    <line id="line2" class="cls-1 line2" x1="4.47" y1="0.35" x2="72.18" y2="70.39"/>
+    <line id="line1" class="cls-1 line1" x1="0.3" y1="64.93" x2="71.14" y2="10.76"/>
+    <line id="line2-2" data-name="line2" class="cls-1 line2" x1="99.26" y1="8.68" x2="145.1" y2="97.22"/>
+    <line id="line1-2" data-name="line1" class="cls-1 line1" x1="79.47" y1="100.35" x2="158.64" y2="8.68"/>
+</svg>


### PR DESCRIPTION
Addition of a plugin that scans elements for `data-name` or `id` attributes and copies the value to the `class` attribute.

This is intended to be used with the Adobe Illustrator export option "Object IDs: Layer Names" to make it easier to get meaningful class names exported into SVGs from Illustrator.

I have a blog post that explains the intended use case: https://codingwithspike.wordpress.com/2016/05/01/css-styling-illustrator-svgs/

Since this is intended to be used with Illustrator exported SVGs, the plugin is disabled by default.

I updated the README.ru.md file with a Google translation from my english. Feel free to re-translate.
