### PR TITLE
Improve sortAttrs plugin

### DIFF
--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -8,14 +8,12 @@ exports.description = 'sorts element attributes (disabled by default)';
 
 exports.params = {
 	order: [
-		'xmlns',
 		'id',
 		'width', 'height',
 		'x', 'x1', 'x2',
 		'y', 'y1', 'y2',
 		'cx', 'cy', 'r',
-		'fill', 'fill-opacity', 'fill-rule',
-		'stroke', 'stroke-opacity', 'stroke-width', 'stroke-miterlimit', 'stroke-dashoffset',
+		'fill', 'stroke', 'marker',
 		'd', 'points'
 	]
 };
@@ -41,8 +39,35 @@ exports.fn = function(item, params) {
 		});
 
 		attrs.sort(function(a, b) {
-			return ((a = params.order.indexOf(a.name)) > -1 ? a : orderlen) -
-				((b = params.order.indexOf(b.name)) > -1 ? b : orderlen);
+			if (a.prefix != b.prefix) {
+				// xmlns attributes implicitly have the prefix xmlns
+				if (a.prefix == 'xmlns')
+					return -1;
+				if (b.prefix == 'xmlns')
+					return 1;
+				return a.prefix < b.prefix ? -1 : 1;
+			}
+
+			var aindex = orderlen;
+			var bindex = orderlen;
+
+			for (var i = 0; i < params.order.length; i++) {
+				if (a.name == params.order[i]) {
+					aindex = i;
+				} else if (a.name.indexOf(params.order[i] + '-') === 0) {
+					aindex = i + .5;
+				}
+				if (b.name == params.order[i]) {
+					bindex = i;
+				} else if (b.name.indexOf(params.order[i] + '-') === 0) {
+					bindex = i + .5;
+				}
+			}
+
+			if (aindex != bindex) {
+				return aindex - bindex;
+			}
+			return a.name < b.name ? -1 : 1;
 		});
 
 		attrs.forEach(function (attr) {

--- a/test/plugins/sortAttrs.01.svg
+++ b/test/plugins/sortAttrs.01.svg
@@ -1,9 +1,11 @@
 <svg foo="bar" xmlns="http://www.w3.org/2000/svg" height="10" baz="quux" width="10" hello="world">
+    <rect x="0" y="0" width="100" height="100" stroke-width="1" stroke-linejoin="round" fill="red" stroke="orange" xmlns="http://www.w3.org/2000/svg"/>
     test
 </svg>
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" foo="bar" baz="quux" hello="world">
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" baz="quux" foo="bar" hello="world">
+    <rect xmlns="http://www.w3.org/2000/svg" width="100" height="100" x="0" y="0" fill="red" stroke="orange" stroke-linejoin="round" stroke-width="1"/>
     test
 </svg>


### PR DESCRIPTION
This fixes some annoyances with sortAttrs:

- Attributes such as `stroke-linejoin` were not included with `stroke-width`, `stroke-miterlimit` etc.. Now all attributes that begin with `stroke-` are sorted alphabetically immediately after `stroke`. Same for fill and marker attributes.
- Prefixed attributes are moved to the end of the list, except `xmlns`, which is still at the start.
- Any attributes not listed in the order are sorted alphabetically.