### PR TITLE
feat: add attribute that can add title and description and the according aria attributes

### DIFF
--- a/plugins/addAriaLabels.js
+++ b/plugins/addAriaLabels.js
@@ -1,0 +1,68 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'Adds an aria-labelledby and a referenced <title> and/or <description> section';
+
+exports.params = {
+    title: '',
+    desc: ''
+};
+
+exports.fn = function addAriaLabels(item, params) {
+    if (item.isElem('svg')) {
+        var ids = [];
+
+        ['desc', 'title'].forEach(function (elem) {
+            var value = params[elem];
+            if (value) {
+                var id;
+                if (typeof params.idFn === 'function') {
+                  id = params.idFn(elem);
+                } else {
+                  id = elem + '-' + uid();
+                }
+                ids.push(id);
+
+                var pos = 0;
+                var replace = 0;
+                item.content.forEach(function (subItem, index) {
+                    if (subItem.isElem(elem)) {
+                        pos = index;
+                        replace = 1;
+                    }
+                });
+                item.spliceContent(pos, replace, new item.constructor({
+                    elem: elem,
+                    local: elem,
+                    prefix: '',
+                    content: [new item.constructor({text: value})],
+                    attrs: [new item.constructor({
+                        name: 'id',
+                        local: 'id',
+                        prefix: '',
+                        value: id
+                    })]
+                }));
+            }
+        });
+
+        if (ids.length) {
+            if (item.hasAttr('aria-labelledby')) {
+                item.removeAttr('aria-labelledby');
+            }
+            item.addAttr({
+                name: 'aria-labelledby',
+                local: 'aria-labelledby',
+                prefix: '',
+                value: ids.join(' ')
+            });
+        }
+    }
+};
+
+function uid() {
+    return Math.random().toString(35).substr(2, 7);
+}

--- a/test/plugins/_index.js
+++ b/test/plugins/_index.js
@@ -36,7 +36,9 @@ describe('plugins tests', function() {
                         plugins = {},
                         svgo;
 
-                    plugins[name] = (params) ? JSON.parse(params) : true;
+                    /* jshint evil:true */
+                    plugins[name] = (params) ? eval('var x = ' + params + '; x;') : true;
+                    /* jshint evil:false */
 
                     svgo = new SVGO({
                         full    : true,

--- a/test/plugins/addAriaLabels.01.svg
+++ b/test/plugins/addAriaLabels.01.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+{}

--- a/test/plugins/addAriaLabels.02.svg
+++ b/test/plugins/addAriaLabels.02.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id">
+    <title id="fixture-id">
+        my-title
+    </title>
+    test
+</svg>
+
+@@@
+
+{"title": "my-title", "idFn": function() { return 'fixture-id'; }}

--- a/test/plugins/addAriaLabels.03.svg
+++ b/test/plugins/addAriaLabels.03.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id">
+    <desc id="fixture-id">
+        my-description
+    </desc>
+    test
+</svg>
+
+@@@
+
+{"desc": "my-description", "idFn": function() { return 'fixture-id'; }}

--- a/test/plugins/addAriaLabels.04.svg
+++ b/test/plugins/addAriaLabels.04.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id-desc fixture-id-title">
+    <title id="fixture-id-title">
+        my-title
+    </title>
+    <desc id="fixture-id-desc">
+        my-description
+    </desc>
+    test
+</svg>
+
+@@@
+
+{"desc": "my-description", "title": "my-title", "idFn": function(elem) { return 'fixture-id-' + elem; }}

--- a/test/plugins/addAriaLabels.05.svg
+++ b/test/plugins/addAriaLabels.05.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="xyz">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id">
+    <title id="fixture-id">
+        my-title
+    </title>
+    test
+</svg>
+
+@@@
+
+{"title": "my-title", "idFn": function() { return 'fixture-id'; }}

--- a/test/plugins/addAriaLabels.06.svg
+++ b/test/plugins/addAriaLabels.06.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title>
+        bla
+    </title>
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id">
+    <title id="fixture-id">
+        my-title
+    </title>
+    test
+</svg>
+
+@@@
+
+{"title": "my-title", "idFn": function() { return 'fixture-id'; }}

--- a/test/plugins/addAriaLabels.07.svg
+++ b/test/plugins/addAriaLabels.07.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title>
+        bla
+    </title>
+    <desc>
+        foo
+    </desc>
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="fixture-id-desc fixture-id-title">
+    <title id="fixture-id-title">
+        my-title
+    </title>
+    <desc id="fixture-id-desc">
+        my-description
+    </desc>
+    test
+</svg>
+
+@@@
+
+{"desc": "my-description", "title": "my-title", "idFn": function(elem) { return 'fixture-id-' + elem; }}

--- a/test/plugins/addAriaLabels.08.svg
+++ b/test/plugins/addAriaLabels.08.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title>
+        bla
+    </title>
+    <desc>
+        foo
+    </desc>
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title>
+        bla
+    </title>
+    <desc>
+        foo
+    </desc>
+    test
+</svg>
+
+@@@
+
+{}


### PR DESCRIPTION
This adds a plugin that transforms a given SVG to make it accessible. It allows passing `title` and/or `desc` and references them via `aria-labelledby` in the SVG element.

``` svg
<svg>
...
</svg>
```

with the plugin and a setting of

``` js
{title: 'my-title', desc: 'my-desc'}
```

becomes:

``` svg
<svg aria-labelledby="desc-abc title-xyz">
    <title id="title-xyz">my-title</title>
    <desc id="desc-abc">my-desc</desc>
...
</svg>
```

More info, see:
- https://www.paciellogroup.com/blog/2013/12/using-aria-enhance-svg-accessibility/
- https://www.sitepoint.com/tips-accessible-svg/
- https://css-tricks.com/accessible-svgs/
