### PR TITLE
Fixing #504. Jspm compatibility and static declaration of dependencies

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -119,7 +119,7 @@ function preparePluginsArray(plugins) {
 
             } else {
               if (!pluginMap[key]) {
-                  throw new Error("Unknown plugin '" + key + "'");
+                  throw new Error('Unknown plugin "' + key + '"');
               }
 
               plugin = EXTEND({}, pluginMap[key]);

--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -5,6 +5,51 @@ var yaml = require('js-yaml');
 
 var EXTEND = require('whet.extend');
 
+var pluginMap = {
+    cleanupAttrs: require('../../plugins/cleanupAttrs.js'),
+    removeDoctype: require('../../plugins/removeDoctype.js'),
+    removeXMLProcInst: require('../../plugins/removeXMLProcInst.js'),
+    removeComments: require('../../plugins/removeComments.js'),
+    removeMetadata: require('../../plugins/removeMetadata.js'),
+    removeTitle: require('../../plugins/removeTitle.js'),
+    removeDesc: require('../../plugins/removeDesc.js'),
+    removeUselessDefs: require('../../plugins/removeUselessDefs.js'),
+    removeXMLNS: require('../../plugins/removeXMLNS.js'),
+    removeEditorsNSData: require('../../plugins/removeEditorsNSData.js'),
+    removeEmptyAttrs: require('../../plugins/removeEmptyAttrs.js'),
+    removeHiddenElems: require('../../plugins/removeHiddenElems.js'),
+    removeEmptyText: require('../../plugins/removeEmptyText.js'),
+    removeEmptyContainers: require('../../plugins/removeEmptyContainers.js'),
+    removeViewBox: require('../../plugins/removeViewBox.js'),
+    cleanupEnableBackground: require('../../plugins/cleanupEnableBackground.js'),
+    minifyStyles: require('../../plugins/minifyStyles.js'),
+    convertStyleToAttrs: require('../../plugins/convertStyleToAttrs.js'),
+    convertColors: require('../../plugins/convertColors.js'),
+    convertPathData: require('../../plugins/convertPathData.js'),
+    convertTransform: require('../../plugins/convertTransform.js'),
+    removeUnknownsAndDefaults: require('../../plugins/removeUnknownsAndDefaults.js'),
+    removeUnusedNS: require('../../plugins/removeUnusedNS.js'),
+    cleanupIDs: require('../../plugins/cleanupIDs.js'),
+    cleanupNumericValues: require('../../plugins/cleanupNumericValues.js'),
+    cleanupListOfValues: require('../../plugins/cleanupListOfValues.js'),
+    moveElemsAttrsToGroup: require('../../plugins/moveElemsAttrsToGroup.js'),
+    moveGroupAttrsToElems: require('../../plugins/moveGroupAttrsToElems.js'),
+    collapseGroups: require('../../plugins/collapseGroups.js'),
+    removeRasterImages: require('../../plugins/removeRasterImages.js'),
+    mergePaths: require('../../plugins/mergePaths.js'),
+    convertShapeToPath: require('../../plugins/convertShapeToPath.js'),
+    sortAttrs: require('../../plugins/sortAttrs.js'),
+    transformsWithOnePath: require('../../plugins/transformsWithOnePath.js'),
+    removeDimensions: require('../../plugins/removeDimensions.js'),
+    removeAttrs: require('../../plugins/removeAttrs.js'),
+    removeElementsByAttr: require('../../plugins/removeElementsByAttr.js'),
+    addClassesToSVGElement: require('../../plugins/addClassesToSVGElement.js'),
+    addAttributesToSVGElement: require('../../plugins/addAttributesToSVGElement.js'),
+    removeStyleElement: require('../../plugins/removeStyleElement.js'),
+    removeUselessStrokeAndFill: require('../../plugins/removeUselessStrokeAndFill.js'),
+    removeNonInheritableGroupAttrs: require('../../plugins/removeNonInheritableGroupAttrs.js'),
+};
+
 /**
  * Read and/or extend/replace default config file,
  * prepare and optimize plugins array.
@@ -73,8 +118,11 @@ function preparePluginsArray(plugins) {
                 plugin = setupCustomPlugin(key, item[key]);
 
             } else {
+              if (!pluginMap[key]) {
+                  throw new Error("Unknown plugin '" + key + "'");
+              }
 
-              plugin = EXTEND({}, require('../../plugins/' + key));
+              plugin = EXTEND({}, pluginMap[key]);
 
               // name: {}
               if (typeof item[key] === 'object') {


### PR DESCRIPTION
This fixes #504. There are definitely pros and cons to doing this, and am interested to hear your thoughts on what is best for the svgo project. My opinion, of course, is that this the pros outweigh the cons, but I can see the other side too.

**Pros:**
1. This makes svgo compatible with JSPM. Up until now, anybody who uses jspm and depends on svgo (directly or indirectly) has to create a configuration file in the jspm registry for _each version of svgo_. @MeoMix did this for svgo@0.6.1, and now I [have a pull request to do so for 0.7.1](https://github.com/jspm/registry/pull/987). Merging this svgo pull request will make it so that there will be no need anymore to create a configuration file in the jspm registry for each version of svgo.
2. This will make upgrading svgo to es6 modules (instead of commonjs) easier. I don't know if there are plans to do that or not, but once you switch to `import`, `System.import()`, or `import()`, you can no longer synchronously load dynamic plugin code like you can with `require`. Instead, you can either import all of the plugins upfront (similar to what I've done in this pull request) or you can change the [preparePluginsArray](https://github.com/svg/svgo/compare/master...joeldenning:issue-504?expand=1#diff-8f58d3f133adabc0050efa4a28cc5457R104) function to be an asynchronous function that returns a System.import() promise.

**Cons:**
1. The `pluginMap` is sort of an annoying manifesty thing that introduces one more step to the process of writing a new svgo plugin.
