### PR TITLE
More options for setting "currentColor"

### DIFF
--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -59,8 +59,17 @@ exports.fn = function(item, params) {
                     match;
 
                 // Convert colors to currentColor
-                if (params.currentColor && (match = !val.match(none))) {
-                    val = 'currentColor';
+                if (params.currentColor) {
+                    if (typeof params.currentColor === 'string') {
+                        match = val === params.currentColor;
+                    } else if (params.currentColor.exec) {
+                        match = params.currentColor.exec(val);
+                    } else {
+                        match = !val.match(none);
+                    }
+                    if (match) {
+                        val = 'currentColor';
+                    }
                 }
 
                 // Convert color name keyword to long hex


### PR DESCRIPTION
In addition to the current behavior, the following options were added:
1) Set a color that should be replaced to `currentColor`, for example `convertColors: { currentColor: '#030303' }`, so all fills and strokes with `#030303` color value will be replaced to `currentColor`.
2) Set a color(s) to be replaced using a regexp, for example `convertColors: { currentColor: /#FF.{4}/ }`, so all colors with the red value of `FF` will be replaced to `currentColor`.