### PR TITLE
added convertCircleToPath plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -38,6 +38,7 @@ plugins:
   - cleanupEnableBackground
   - removeHiddenElems
   - removeEmptyText
+  - convertCircleToPath
   - convertShapeToPath
   - moveElemsAttrsToGroup
   - moveGroupAttrsToElems

--- a/plugins/convertCircleToPath.js
+++ b/plugins/convertCircleToPath.js
@@ -22,12 +22,12 @@ exports.fn = function(item) {
         item.hasAttr('cy') &&
         item.hasAttr('r')
     ) {
+
         var cx = item.attr('cx').value,
             cy = item.attr('cy').value,
             r = item.attr('r').value,
             pathData =
             'M' + cx + ' ' + cy +
-            'm' + (-r) + ' 0' +
             'a' + r + ' ' + r + ' 0 1 0 ' + (r * 2) + ' 0' +
             'a' + r + ' ' + r + ' 0 1 0 ' + (-r * 2) + ' 0z';
 
@@ -40,5 +40,32 @@ exports.fn = function(item) {
                 local: 'd'
             });
 
+    } else if (
+        item.isElem('ellipse') &&
+        item.hasAttr('cx') &&
+        item.hasAttr('cy') &&
+        item.hasAttr('rx') &&
+        item.hasAttr('ry')
+    ) {
+
+        var cx = item.attr('cx').value,
+            cy = item.attr('cy').value,
+            rx = item.attr('rx').value,
+            ry = item.attr('ry').value,
+            pathData =
+            'M' + cx + ' ' + cy +
+            'a' + rx + ' ' + ry + ' 0 1 0 ' + (rx * 2) + ' 0' +
+            'a' + rx + ' ' + ry + ' 0 1 0 ' + (-rx * 2) + ' 0z';
+
+        item.renameElem('path');
+        item.removeAttr(['cx', 'cy', 'rx', 'ry']);
+        item.addAttr({
+                name: 'd',
+                value: pathData,
+                prefix: '',
+                local: 'd'
+            });
+
     }
+
 };

--- a/plugins/convertCircleToPath.js
+++ b/plugins/convertCircleToPath.js
@@ -1,0 +1,46 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = true;
+
+exports.description = 'converts circles to paths';
+
+/**
+ * Converts circles to paths. Useful if a lot of SVGs are used
+ * for icons on a webpage, so all styles can be applied to `path`.
+ *
+ * @param {Object} item current iteration item
+ * @param {Object} params plugin params
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Lev Solntsev, Dan Newcome, Peter Oesteritz
+ */
+exports.fn = function(item) {
+
+    if (
+        item.isElem('circle') &&
+        item.hasAttr('cx') &&
+        item.hasAttr('cy') &&
+        item.hasAttr('r')
+    ) {
+        var cx = item.attr('cx').value,
+            cy = item.attr('cy').value,
+            r = item.attr('r').value,
+            pathData =
+            'M' + cx + ' ' + cy +
+            'm' + (-r) + ' 0' +
+            'a' + r + ' ' + r + ' 0 1 0 ' + (r * 2) + ' 0' +
+            'a' + r + ' ' + r + ' 0 1 0 ' + (-r * 2) + ' 0z';
+
+        item.renameElem('path');
+        item.removeAttr(['cx', 'cy', 'r']);
+        item.addAttr({
+                name: 'd',
+                value: pathData,
+                prefix: '',
+                local: 'd'
+            });
+
+    }
+};

--- a/plugins/convertCircleToPath.js
+++ b/plugins/convertCircleToPath.js
@@ -11,8 +11,6 @@ exports.description = 'converts circles to paths';
  * for icons on a webpage, so all styles can be applied to `path`.
  *
  * @param {Object} item current iteration item
- * @param {Object} params plugin params
- * @return {Boolean} if false, item will be filtered out
  *
  * @author Lev Solntsev, Dan Newcome, Peter Oesteritz
  */


### PR DESCRIPTION
This is basically just the code from @dnewcome that he've tried to merge long time ago (#368).

This feature was asked a few times (#629, #65, #406, #362, ...), so I thought you could add it as a plugin. Especially because the icon-font-trend get's replaced by the just-SVG-trend:

- https://css-tricks.com/icon-fonts-vs-svg/
- https://www.sitepoint.com/icon-fonts-vs-svg-debate/
- https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4#.8mi0fg1rd
- https://cloudfour.com/thinks/seriously-dont-use-icon-fonts/
