### PR TITLE
Cleanup layers IDs in SVG exported from Adobe Illustrator

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -25,6 +25,7 @@ plugins:
   - cleanupAttrs
   - minifyStyles
   - convertStyleToAttrs
+  - cleanupAiLayerIDs
   - cleanupIDs
   - removeRasterImages
   - removeUselessDefs

--- a/plugins/cleanupAiLayerIDs.js
+++ b/plugins/cleanupAiLayerIDs.js
@@ -1,0 +1,40 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = true;
+
+exports.description = 'cleanup .classes or #ids in layer names exported from Adobe Illustrator';
+
+/**
+ * Cleanup .classes or #ids in layer names exported from Adobe Illustrator.
+ *
+ * @param {Object} item current iteration item
+ *
+ * @author Daniel Bayley
+ */
+exports.fn = function(item) {
+
+    function update(_prefix, name) {
+        item.addAttr({
+            name: name,
+            value: layer.replace(_prefix,''),
+            prefix: '',
+            local: name
+        });
+    }
+    if (item.hasAttr('id')) {
+
+        var layer = item.attr('id').value,
+            _class = '_x2E_', // .class
+            _id = '_x23_'; // #id
+
+        if (layer.startsWith(_class)) {
+            update(_class, 'class');
+            item.removeAttr('id');
+        }
+        else if (layer.startsWith(_id)) {
+            update(_id, 'id');
+        }
+    }
+};

--- a/test/plugins/cleanupAiLayerIDs.01.svg
+++ b/test/plugins/cleanupAiLayerIDs.01.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="_x23_id"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="id"/>
+</svg>

--- a/test/plugins/cleanupAiLayerIDs.02.svg
+++ b/test/plugins/cleanupAiLayerIDs.02.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="_x2E_class"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g class="class"/>
+</svg>


### PR DESCRIPTION
Layer IDs exported from Adobe Illustrator are corrected, allowing .class or #id attributes to be specified as layer names.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>