### PR TITLE
Used chars plugin

### DIFF
--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var jsAPI = require('../lib/svgo/jsAPI');
-
-
 exports.type = 'full';
 
 exports.active = false;
 
-exports.description = 'used text';
+exports.description = 'add list of used characters as style comment for further use.';
 
 var styleOrScript = ['style', 'script'];
+
+var jsAPI = require('../lib/svgo/jsAPI');
 
 exports.fn = function(data, params) {
 

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var jsAPI = require('../lib/svgo/jsAPI');
+
+
 exports.type = 'full';
 
 exports.active = false;
@@ -41,18 +44,22 @@ exports.fn = function(data, params) {
     }
     monkeys(data);
 
-    var text  = texts.join('');
-    var chars = text.split('').filter(function(item, i, ar){ return ar.indexOf(item) === i; });
-    var charsStr = chars.join('');
- 
-    var charsStrEsc = charsStr.replace(/'/g, "&#39;");
-    var svgElem = data.content[0];
-    svgElem.addAttr({
-      name:   'used-chars',
-      value:  charsStrEsc,
-      prefix: '',
-      local:  'used-chars'
-    });
+
+    var text = texts.join('');
+
+    // Escape CSS multiline comment termination characters ('*/' -> '/*')
+    var textEsc = text.replace('*\/', '\/*');
+
+    var svgElem  = data.content[0];
+    var stylesEl = new jsAPI({
+      elem:    'style',
+      prefix:  '',
+      local:   'style',
+      content: [{
+        text: '/* Text:' + "\n" + textEsc + "\n" + '*/'
+      }]
+    }, svgElem);
+    svgElem.content.unshift(stylesEl);
 
     return data;
 };

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -47,8 +47,11 @@ exports.fn = function(data, params) {
 
     var text = texts.join('');
 
+    var chars = text.split('').filter(function(item, i, ar){ return ar.indexOf(item) === i; });
+    var charsStr = chars.join('');
+
     // Escape CSS multiline comment termination characters ('*/' -> '/*')
-    var textEsc = text.replace('*\/', '\/*');
+    var charsEsc = charsStr.replace('*\/', '\/*');
 
     var svgElem  = data.content[0];
     var stylesEl = new jsAPI({
@@ -56,7 +59,7 @@ exports.fn = function(data, params) {
       prefix:  '',
       local:   'style',
       content: [{
-        text: '/* Text:' + "\n" + textEsc + "\n" + '*/'
+        text: '/* Characters used:' + "\n" + charsEsc + "\n" + '*/'
       }]
     }, svgElem);
     svgElem.content.unshift(stylesEl);

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -58,7 +58,7 @@ exports.fn = function(data) {
       prefix:  '',
       local:   'style',
       content: [{
-        text: '/* Characters used:' + '\n' + charsEsc + '\n' + '*/'
+        text: '/* Characters used:' + '\n' + charsEsc + '\n        ' + '*/'
       }]
     }, svgElem);
     svgElem.content.unshift(stylesEl);

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -1,0 +1,58 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'used text';
+
+var styleOrScript = ['style', 'script'];
+
+exports.fn = function(data, params) {
+
+
+    var texts = [];
+
+    /**
+     * Bananas!
+     *
+     * @param {Array} items input items
+     * @return {Array} output items
+     */
+    function monkeys(items) {
+        for (var i = 0; i < items.content.length; i++) {
+            var item = items.content[i];
+
+            if (item.isElem(styleOrScript)) {
+                continue;
+            }
+            if (item.isElem()) {
+                if(item.content && typeof item.content[0] && typeof item.content[0].text !== 'undefined') {
+                  texts.push(item.content[0].text);
+                }
+            }
+
+            // go deeper
+            if (item.content) {
+                monkeys(item);
+            }
+        }
+        return items;
+    }
+    monkeys(data);
+
+    var text  = texts.join('');
+    var chars = text.split('').filter(function(item, i, ar){ return ar.indexOf(item) === i; });
+    var charsStr = chars.join('');
+ 
+    var charsStrEsc = charsStr.replace(/'/g, "&#39;");
+    var svgElem = data.content[0];
+    svgElem.addAttr({
+      name:   'used-chars',
+      value:  charsStrEsc,
+      prefix: '',
+      local:  'used-chars'
+    });
+
+    return data;
+};

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -50,7 +50,7 @@ exports.fn = function(data) {
     var charsStr = chars.join('');
 
     // Escape CSS multiline comment termination characters ('*/' -> '/*')
-    var charsEsc = charsStr.replace('*\/', '\/*');
+    var charsStrEsc = charsStr.replace('*\/', '\/*');
 
     var svgElem  = data.content[0];
     var stylesEl = new JsAPI({
@@ -58,7 +58,7 @@ exports.fn = function(data) {
       prefix:  '',
       local:   'style',
       content: [{
-        text: '/* Characters used:' + '\n' + charsEsc + '\n        ' + '*/'
+        text: '/* Characters used:' + '\n' + charsStrEsc + '\n        ' + '*/'
       }]
     }, svgElem);
     svgElem.content.unshift(stylesEl);

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -4,12 +4,16 @@ exports.type = 'full';
 
 exports.active = false;
 
-exports.description = 'add list of used characters as style comment for further use.';
+exports.description = 'add list of used characters as style comment for further use';
 
 var styleOrScript = ['style', 'script'];
 
 var JsAPI = require('../lib/svgo/jsAPI');
 
+/**
+ * Add list of used characters as style comment for further use.
+ * @author strarsis <strarsis@gmail.com>
+ */
 exports.fn = function(data) {
 
 

--- a/plugins/usedChars.js
+++ b/plugins/usedChars.js
@@ -8,9 +8,9 @@ exports.description = 'add list of used characters as style comment for further 
 
 var styleOrScript = ['style', 'script'];
 
-var jsAPI = require('../lib/svgo/jsAPI');
+var JsAPI = require('../lib/svgo/jsAPI');
 
-exports.fn = function(data, params) {
+exports.fn = function(data) {
 
 
     var texts = [];
@@ -53,12 +53,12 @@ exports.fn = function(data, params) {
     var charsEsc = charsStr.replace('*\/', '\/*');
 
     var svgElem  = data.content[0];
-    var stylesEl = new jsAPI({
+    var stylesEl = new JsAPI({
       elem:    'style',
       prefix:  '',
       local:   'style',
       content: [{
-        text: '/* Characters used:' + "\n" + charsEsc + "\n" + '*/'
+        text: '/* Characters used:' + '\n' + charsEsc + '\n' + '*/'
       }]
     }, svgElem);
     svgElem.content.unshift(stylesEl);

--- a/test/plugins/usedChars.01.svg
+++ b/test/plugins/usedChars.01.svg
@@ -13,7 +13,7 @@
     <style>
         /* Characters used:
 I loveSVG!Tst.
-*/
+        */
     </style>
     <text x="0" y="15" fill="red">
         I love SVG!

--- a/test/plugins/usedChars.01.svg
+++ b/test/plugins/usedChars.01.svg
@@ -11,8 +11,8 @@
 
 <svg height="30" width="200">
     <style>
-        /* Text:
-I love SVG!Test.
+        /* Characters used:
+I loveSVG!Tst.
 */
     </style>
     <text x="0" y="15" fill="red">

--- a/test/plugins/usedChars.01.svg
+++ b/test/plugins/usedChars.01.svg
@@ -1,11 +1,24 @@
 <svg height="30" width="200">
-  <text x="0" y="15" fill="red">I love SVG!</text>
+    <text x="0" y="15" fill="red">
+        I love SVG!
+    </text>
+    <text x="0" y="15" fill="red">
+        Test.
+    </text>
 </svg>
 
 @@@
 
-<svg height="30" width="200" used-chars="I loveSVG!">
+<svg height="30" width="200">
+    <style>
+        /* Text:
+I love SVG!Test.
+*/
+    </style>
     <text x="0" y="15" fill="red">
         I love SVG!
+    </text>
+    <text x="0" y="15" fill="red">
+        Test.
     </text>
 </svg>

--- a/test/plugins/usedChars.01.svg
+++ b/test/plugins/usedChars.01.svg
@@ -1,0 +1,11 @@
+<svg height="30" width="200">
+  <text x="0" y="15" fill="red">I love SVG!</text>
+</svg>
+
+@@@
+
+<svg height="30" width="200" used-chars="I loveSVG!">
+    <text x="0" y="15" fill="red">
+        I love SVG!
+    </text>
+</svg>


### PR DESCRIPTION
This PR adds the usedChars plugin which adds a list of used characters in the text of a SVG document as 
style comment which is helpful for adding/embedding tailored fonts with 
reduced character set (e.g. Google Fonts text parameter or by a local font optimization technique).

E.g. a SVG document that contains the texts `I love SVG!` and `Test.` 
would result in a list of used characters like so:
```svg
[...]
    <style>
        /* Characters used:
I loveSVG!Tst.
        */
    </style>
````

Then e.g. a font can be added using the Google Fonts API and 
the API additional text parameter (`&` escaped to `&amp;`) for a reduced, tailored character set:
```css
@import url('https://fonts.googleapis.com/css?family=Roboto&amp;test=I loveSVG!Tst.');
````
Note that for usage in a parameter like this escaping may be necessary in some cases and 
be wary of hidden/less obvious unicode characters and that the space character is also important.

Fonts in SVGs are supported by browser when the SVG document is embedded as `<object>` on page, 
see https://github.com/marians/test-webfonts-in-svg/pull/1 .

It doesn't work when just inlining the whole SVG into the HTML page.

Alternatively, font-face is also interpreted when the font file has 
been embedded into the CSS (using base64 encoding). - This seems to be also a candidate for a plugin.

TODO:
- Also look for text in styles (notably content: "").
- Group used text by their font (family, weight, variant).