### PR TITLE
removeViewBox: Handle more forms

### DIFF
--- a/plugins/removeViewBox.js
+++ b/plugins/removeViewBox.js
@@ -6,7 +6,7 @@ exports.active = false;
 
 exports.description = 'removes viewBox attribute when possible (disabled by default)';
 
-var regViewBox = /^0\s0\s([\-+]?\d*\.?\d+([eE][\-+]?\d+)?)\s([\-+]?\d*\.?\d+([eE][\-+]?\d+)?)$/,
+var regViewBox = /^0,?\s0,?\s([\-+]?\d*\.?\d+([eE][\-+]?\d+)?),?\s([\-+]?\d*\.?\d+([eE][\-+]?\d+)?)$/,
     viewBoxElems = ['svg', 'pattern'];
 
 /**


### PR DESCRIPTION
The spec says that each term in viewBox is "separated by whitespace and/or a comma", but the regex here does not allow a comma.

This updated regex allows a comma. It is, however, still more strict that the spec, in that it requires a space (AFTER the comma, if it exists).