### PR TITLE
Plugin for adding dimensions from viewbox

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -53,6 +53,7 @@ plugins:
   - removeTitle
   - removeDesc
   - removeDimensions
+  - addDimensions
   - removeAttrs
   - removeElementsByAttr
   - addClassesToSVGElement

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Today we have:
 | [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability (disabled by default) |
 | [transformsWithOnePath](https://github.com/svg/svgo/blob/master/plugins/transformsWithOnePath.js) | apply transforms, crop by real width, center vertical alignment, and resize SVG with one Path inside (disabled by default) |
 | [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` attributes if `viewBox` is present (disabled by default) |
+| [addDimensions](https://github.com/svg/svgo/blob/master/plugins/addDimensions.js) | add `width`/`height` attributes if `viewBox` is present (disabled by default) |
 | [removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) | remove attributes by pattern (disabled by default) |
 | [removeElementsByAttr](https://github.com/svg/svgo/blob/master/plugins/removeElementsByAttr.js) | remove arbitrary elements by ID or className (disabled by default) |
 | [addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) | add classnames to an outer `<svg>` element (disabled by default) |

--- a/plugins/addDimensions.js
+++ b/plugins/addDimensions.js
@@ -1,0 +1,61 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'adds width and height in presence of viewBox';
+
+var regSeparator = /\s+,?\s*|,\s*/;
+
+/**
+ * Add width/height attributes when a viewBox attribute is present.
+ *
+ * @example
+ * <svg viewBox="0 0 100 50">
+ *   ↓
+ * <svg width="100" height="50" viewBox="0 0 100 50">
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if true, with and height will be added
+ *
+ * @author Tom Longson
+ */
+exports.fn = function(item) {
+
+    if (
+        item.isElem('svg') &&
+        item.hasAttr('viewBox')
+    ) {
+        var dimensions = getDimensions(item.attrs.viewBox);
+        
+        if (dimensions != null) {
+            item.addAttr({
+                    name: "width",
+                    prefix: '',
+                    local: "width",
+                    value: dimensions[0]
+                });
+            item.addAttr({
+                    name: "height",
+                    prefix: '',
+                    local: "height",
+                    value: dimensions[1]
+                });
+        }
+    }
+
+    function getDimensions($prop){
+        var lists = $prop.value,
+            listsArr = lists.split(regSeparator),
+            width = listsArr[2] || null,
+            height = listsArr[3] || null;
+        
+        if (width && height) {
+            return [width, height];
+        } else {
+            return null;
+        }
+    }
+    return item;
+};

--- a/plugins/addDimensions.js
+++ b/plugins/addDimensions.js
@@ -31,15 +31,15 @@ exports.fn = function(item) {
         
         if (dimensions != null) {
             item.addAttr({
-                    name: "width",
+                    name: 'width',
                     prefix: '',
-                    local: "width",
+                    local: 'width',
                     value: dimensions[0]
                 });
             item.addAttr({
-                    name: "height",
+                    name: 'height',
                     prefix: '',
-                    local: "height",
+                    local: 'height',
                     value: dimensions[1]
                 });
         }


### PR DESCRIPTION
This is a simple plugin that allows you to add height and width dimensions based off the viewbox. It was made to deal with browser issues with rendering SVGs by default with 0x0 dimensions. This can be solved alternatively by giving the SVG a height / width through CSS. Setting a width/height in the SVG may not be desired.

Definitely open to thoughts and improvements! This was based off other plugins, removeDimensions and addAttributesToSVGElement.
