### PR TITLE
Resolves #690: Add option to process folders recursively.

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -114,6 +114,11 @@ module.exports = require('coa').Cmd()
         })
         .end()
     .opt()
+        .name('recursive').title('Use with \'-f\'. Optimizes *.svg files in folders recursively.')
+        .short('r').long('recursive')
+        .flag()
+        .end()
+    .opt()
         .name('quiet').title('Only output error messages, not regular status messages')
         .short('q').long('quiet')
         .flag()
@@ -195,6 +200,11 @@ module.exports = require('coa').Cmd()
         // --quiet
         if (opts.quiet) {
             config.quiet = opts.quiet;
+        }
+
+        // --recursive
+        if (opts.recursive) {
+            config.recursive = opts.recursive;
         }
 
         // --precision
@@ -418,7 +428,12 @@ function optimizeFolder(dir, config, output) {
         function optimizeFile(file) {
             // absoluted file path
             var filepath = PATH.resolve(path, file);
+            var fileStat = FS.lstatSync(filepath);
             var outfilepath = output ? PATH.resolve(output, file) : filepath;
+
+            if (config.recursive && fileStat.isDirectory()) {
+                optimizeFolder(filepath, config, output);
+            }
 
             // check if file name matches *.svg
             if (regSVGFile.test(filepath)) {


### PR DESCRIPTION
Resolves #690 

Added `--recursive/-r` flag to process folders recursively.

Usage: `svgo -f ./my-folder -r`

Just before checking if the "file" is an SVG, check if it's actually a directory and call `optimizeFolder()` on that directory.

Let me know if you require any further adjustments. I wanted to keep them as light as possible.