### PR TITLE
Input from STDIN is broken

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -151,7 +151,7 @@ module.exports = require('coa').Cmd()
             !opts.string &&
             !opts.stdin &&
             !opts.folder &&
-            process.stdin.isTTY !== false
+            process.stdin.isTTY === true
         ) return this.usage();
 
         if (typeof process == 'object' && process.versions && process.versions.node && PKG && PKG.engines.node) {

--- a/test/cli/_index.js
+++ b/test/cli/_index.js
@@ -1,0 +1,29 @@
+
+'use strict';
+
+var path = require('path');
+var spawn = require('child_process').spawn;
+var stream = require('stream');
+
+describe('cli', function() {
+
+    it('should process svgs from stdin', function(done) {
+        var svg = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+
+        var readable = new stream.Readable();
+        readable._read = function noop() {};
+        readable.push(svg);
+        readable.push(null);
+
+        var exec = path.join(__dirname, '..', '..', 'bin', 'svgo');
+        var child = spawn(exec, ['-i', '-', '-o', '-'], { stdio: 'pipe' });
+        child.stdout.once('data', function(output) {
+            //FIXME: resulting svg has a '\n' appended and should not
+            output.toString('utf-8').should.equal(svg + '\n');
+            done();
+        });
+
+        readable.pipe(child.stdin);
+    });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -5,3 +5,4 @@ test/svg2js
 test/plugins
 test/jsapi
 test/svgo
+test/cli


### PR DESCRIPTION
This is a modified pull request from https://github.com/svg/svgo/pull/692
Tested on linux/debian with nodejs 4.2, verified on Windows by pklingem  

[I suspect this piece of code](https://github.com/svg/svgo/commit/ece43a3f5598862341fd47e6937f8cf4e7869e6b#commitcomment-22235355) to have broken stdin (piping) support. This pull request should fix it, and also added back the tests written by pklingem.