### PR TITLE
Add keepAriaAttrs to removeUnknownsAndDefaults

### DIFF
--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -11,7 +11,8 @@ exports.params = {
     unknownAttrs: true,
     defaultAttrs: true,
     uselessOverrides: true,
-    keepDataAttrs: true
+    keepDataAttrs: true,
+    keepAriaAttrs: true
 };
 
 var collections = require('./_collections'),
@@ -105,7 +106,8 @@ exports.fn = function(item, params) {
                 if (
                     attr.name !== 'xmlns' &&
                     (attr.prefix === 'xml' || !attr.prefix) &&
-                    (!params.keepDataAttrs || attr.name.indexOf('data-') != 0)
+                    (!params.keepDataAttrs || attr.name.indexOf('data-') != 0) &&
+                    (!params.keepAriaAttrs || attr.name.indexOf('aria-') != 0)
                 ) {
                     if (
                         // unknown attrs

--- a/test/plugins/removeUnknownsAndDefaults.11.svg
+++ b/test/plugins/removeUnknownsAndDefaults.11.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="title">
+    <title id="title">
+        Title
+    </title>
+    <g aria-label="foo">
+        test
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="title">
+    <title id="title">
+        Title
+    </title>
+    <g aria-label="foo">
+        test
+    </g>
+</svg>

--- a/test/plugins/removeUnknownsAndDefaults.12.svg
+++ b/test/plugins/removeUnknownsAndDefaults.12.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-labelledby="title">
+    <title id="title">
+        Title
+    </title>
+    <g aria-label="foo">
+        test
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title id="title">
+        Title
+    </title>
+    <g>
+        test
+    </g>
+</svg>
+
+@@@
+
+{ "keepAriaAttrs": false }


### PR DESCRIPTION
Closes #684.

Adds a `keepAriaAttrs` option to `removeUnknownsAndDefaults`, with a default value of `true`. And adds two cases to make sure it works.

