### PR TITLE
config: fix datauri config object name

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -41,7 +41,7 @@ module.exports = function(config) {
     }
 
     if ('datauri' in config) {
-        defaults.config = config.datauri;
+        defaults.datauri = config.datauri;
     }
 
     if (Array.isArray(defaults.plugins)) {


### PR DESCRIPTION
Introduced in #735, change `defaults.config` assignation to `defaults.datauri`; otherwise, property is not read.