### PR TITLE
Added plugin for focusable="false" attribute.

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -59,6 +59,7 @@ plugins:
   - removeStyleElement
   - removeScriptElement
   - addAttributesToSVGElement
+  - addFocusableFalseAttribute
 
 # configure the indent (default 4 spaces) used by `--pretty` here:
 #

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Today we have:
 | [addAttributesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addAttributesToSVGElement.js) | adds attributes to an outer `<svg>` element (disabled by default) |
 | [removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) | remove `<style>` elements (disabled by default) |
 | [removeScriptElement](https://github.com/svg/svgo/blob/master/plugins/removeScriptElement.js) | remove `<script>` elements (disabled by default) |
+| [addFocusableFalseAttribute](https://github.com/svg/svgo/blob/master/plugins/addFocusableFalseAttribute.js) | add `focusable="false"` attribute to `<svg>` elements (disabled by default) |
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md). ([동작방법](https://github.com/svg/svgo/blob/master/docs/how-it-works/ko.md))
 

--- a/plugins/addFocusableFalseAttribute.js
+++ b/plugins/addFocusableFalseAttribute.js
@@ -1,0 +1,33 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'adds focusable="false" attribute to an outer <svg> element';
+
+/**
+ * Add focusable="false" attribute to an outer <svg> element.
+ *
+ * Internet Explorer and Edge (prior to version 14) make all embedded <svg> elements
+ * keyboard focusable by default, which is not consistent with the SVG specification.
+ * To prevent this behaviour, you can add focusable="false" to the <svg>.
+ *
+ * @see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/
+ *
+ * @author Keegan Street
+ */
+exports.fn = function(data) {
+    var svg = data.content[0];
+
+    if (svg.isElem('svg')) {
+        svg.addAttr({
+            name: 'focusable',
+            prefix: '',
+            local: 'focusable',
+            value: 'false'
+        });
+    }
+
+    return data;
+};

--- a/test/plugins/addFocusableFalseAttribute.01.svg
+++ b/test/plugins/addFocusableFalseAttribute.01.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" width="10" height="20">
+    test
+</svg>
+
+@@@
+
+<svg version="1.1" width="10" height="20" focusable="false">
+    test
+</svg>


### PR DESCRIPTION
Internet Explorer and Edge (prior to version 14) make all embedded <svg> elements keyboard focusable by default, which is not consistent with the SVG specification. To prevent this behaviour, you can add `focusable="false"` to the `<svg>`.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8090208/