### PR TITLE
Added plugin for adding width and height attributes.

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -53,6 +53,7 @@ plugins:
   - removeTitle
   - removeDesc
   - removeDimensions
+  - addDimensions
   - removeAttrs
   - removeElementsByAttr
   - addClassesToSVGElement

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Today we have:
 | [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability (disabled by default) |
 | [transformsWithOnePath](https://github.com/svg/svgo/blob/master/plugins/transformsWithOnePath.js) | apply transforms, crop by real width, center vertical alignment, and resize SVG with one Path inside (disabled by default) |
 | [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` attributes if `viewBox` is present (disabled by default) |
+| [addDimensions](https://github.com/svg/svgo/blob/master/plugins/addDimensions.js) | add `width`/`height` attributes based on value of `viewBox` attribute (disabled by default) |
 | [removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) | remove attributes by pattern (disabled by default) |
 | [removeElementsByAttr](https://github.com/svg/svgo/blob/master/plugins/removeElementsByAttr.js) | remove arbitrary elements by ID or className (disabled by default) |
 | [addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) | add classnames to an outer `<svg>` element (disabled by default) |

--- a/plugins/addDimensions.js
+++ b/plugins/addDimensions.js
@@ -1,0 +1,59 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'adds width and height attributes based on value of viewBox attribute';
+
+exports.params = {
+    replaceExistingAttributes: false,
+    addPixelUnits: true
+};
+
+/**
+ * Add width and height attributes to an outer <svg> element.
+ * Values are extracted from the viewBox attribute.
+ *
+ * This allows the SVG to display at the correct size when rendered in a web browser without additional CSS.
+ *
+ * @author Keegan Street
+ */
+exports.fn = function(data, params) {
+    var svg = data.content[0],
+        viewBox,
+        width,
+        height;
+
+    if (
+        svg.isElem('svg') &&
+        svg.hasAttr('viewBox') &&
+        (params.replaceExistingAttributes || (!svg.hasAttr('height') && !svg.hasAttr('width')))
+    ) {
+        viewBox = svg.attr('viewBox').value.split(' ');
+        width = viewBox[2];
+        height = viewBox[3];
+
+        if (params.addPixelUnits) {
+            width += 'px';
+            height += 'px';
+        }
+
+        svg.addAttr({
+            name: 'width',
+            prefix: '',
+            local: 'width',
+            value: width
+        });
+
+        svg.addAttr({
+            name: 'height',
+            prefix: '',
+            local: 'height',
+            value: height
+        });
+    }
+
+    return data;
+
+};

--- a/test/plugins/addDimensions.01.svg
+++ b/test/plugins/addDimensions.01.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 10 20">
+    test
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 10 20" width="10px" height="20px">
+    test
+</svg>

--- a/test/plugins/addDimensions.02.svg
+++ b/test/plugins/addDimensions.02.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 10 20" width="5" height="10">
+    test
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 10 20" width="5" height="10">
+    test
+</svg>

--- a/test/plugins/addDimensions.03.svg
+++ b/test/plugins/addDimensions.03.svg
@@ -1,0 +1,13 @@
+<svg version="1.1" viewBox="0 0 10 20" width="5" height="10">
+    test
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 10 20" width="10px" height="20px">
+    test
+</svg>
+
+@@@
+
+{ "replaceExistingAttributes": true }

--- a/test/plugins/addDimensions.04.svg
+++ b/test/plugins/addDimensions.04.svg
@@ -1,0 +1,13 @@
+<svg version="1.1" viewBox="0 0 10 20">
+    test
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 10 20" width="10" height="20">
+    test
+</svg>
+
+@@@
+
+{ "addPixelUnits": false }


### PR DESCRIPTION
Add `width` and `height` attributes to an outer `<svg>` element.
Values are extracted from the `viewBox` attribute.

This allows the SVG to display at the correct size when rendered in a web browser without additional CSS.