### PR TITLE
feat: add default value for overflow attribute

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -163,7 +163,8 @@ exports.attrsGroupsDefaults = {
         'unicode-bidi': 'normal',
         'dominant-baseline': 'auto',
         'alignment-baseline': 'baseline',
-        'baseline-shift': 'baseline'
+        'baseline-shift': 'baseline',
+        overflow: 'visible'
     },
     transferFunction: {slope: '1', intercept: '0', amplitude: '1', exponent: '1', offset: '0'}
 };


### PR DESCRIPTION
Hello.

Adding the default value `visible` of `overflow`, let us remove this useless attribute set by inkScape, as mentionned in https://github.com/svg/svgo/issues/730

MDN ref: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow