### PR TITLE
Update removeDesc.js

### DIFF
--- a/plugins/removeDesc.js
+++ b/plugins/removeDesc.js
@@ -10,7 +10,7 @@ exports.params = {
 
 exports.description = 'removes <desc> (only non-meaningful by default)';
 
-var standardDescs = /^Created with/;
+var standardDescs = /^(Created with|Created using)/;
 
 /**
  * Removes <desc>.


### PR DESCRIPTION
Expand default config to remove <desc> tags that start with "Created using" (in addition to "Created with").

Change is due to Figma using "Created using Figma" as their default SVG description. Sketch and others use "Created with Sketch.".