### PR TITLE
Fix #176: Don't escape special character inside `<script>` or `<style>` tag.

### DIFF
--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -108,7 +108,7 @@ JS2SVG.prototype.convert = function(data) {
             if (item.elem) {
                svg += this.createElem(item);
             } else if (item.text) {
-               svg += this.createText(item.text);
+               svg += this.createText(item.text, data.elem);
             } else if (item.doctype) {
                 svg += this.createDoctype(item.doctype);
             } else if (item.processinginstruction) {
@@ -341,11 +341,14 @@ JS2SVG.prototype.createAttrs = function(elem) {
  *
  * @return {String}
  */
-JS2SVG.prototype.createText = function(text) {
+JS2SVG.prototype.createText = function(text, elem) {
+    if (elem !== 'script' && elem !== 'style') {
+        text = text.replace(this.config.regEntities, this.config.encodeEntity);
+    }
 
     return  this.createIndent() +
             this.config.textStart +
-            text.replace(this.config.regEntities, this.config.encodeEntity) +
+            text +
             (this.textContext ? '' : this.config.textEnd);
 
 };


### PR DESCRIPTION
I break `createText` return, since using ternary operator would be too long.