### PR TITLE
New plugin: classToInlineStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Today we have:
 
 | Plugin | Description |
 | ------ | ----------- | 
+| [classToInlineStyle](https://github.com/svg/svgo/blob/master/plugins/classToInlineStyle.js) | moves styles off style declaration to the element's inline style |
 | [cleanupAttrs](https://github.com/svg/svgo/blob/master/plugins/cleanupAttrs.js) | cleanup attributes from newlines, trailing, and repeating spaces |
 | [removeDoctype](https://github.com/svg/svgo/blob/master/plugins/removeDoctype.js) | remove doctype declaration |
 | [removeXMLProcInst](https://github.com/svg/svgo/blob/master/plugins/removeXMLProcInst.js) | remove XML processing instructions |

--- a/plugins/classToInlineStyle.js
+++ b/plugins/classToInlineStyle.js
@@ -1,0 +1,87 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = true;
+
+exports.description = 'moves a style from definition to an inline style';
+
+var csso = require('csso');
+
+exports.fn = function (data) {
+    var styles = [];
+    // prepare
+    perItem(data, fillStyles, styles);
+    // apply
+    return perItem(data, applyStyles, styles);
+};
+
+
+function fillStyles (item, styles) {
+    // Find styles
+    if (item.elem) {
+        if (item.isElem('style') && !item.isEmpty()) {
+            var styleCss = item.content[0].text || item.content[0].cdata || [],
+                Data = styleCss.indexOf('>') >= 0 || styleCss.indexOf('<') >= 0 ? 'cdata' : 'text';
+
+            if (styleCss.length > 0) {
+                styles.push(styleCss);
+                item.content[0][Data] = null;
+            }
+        }
+    }
+    return item;
+}
+
+function applyStyles (item, styles) {
+    if (item.elem && item.attrs) {
+        var id = item.attr('id') ? item.attr('id').value : undefined;
+        var elem = item.elem;
+        var classValues = item.attr('class') ? item.attr('class').value.split(' ') : [];
+        var textLine = item.attr('style') ? (item.attr('style').value + ';') : '';
+
+        styles.forEach(function (styleCss) {
+            var ast = csso.compress(csso.parse(styleCss), {
+                restructure: true,
+                usage: {
+                    classes: classValues,
+                    ids: [id],
+                    tags: [elem]
+                }
+            }).ast;
+            var style = csso.translate(ast);
+            var mt = style.match(/{[^}]*}/ig);
+            if (mt) {
+                textLine += mt.map(function (t) {
+                    return t.replace(/[{}]/g, '');
+                }).join(';');
+            }
+        });
+
+        if(textLine) {
+          item.attrs.style = {
+            name: 'style',
+            value: textLine,
+            local: 'style',
+            prefix: ''
+          };
+        }
+    }
+}
+
+function perItem (data, callback, params) {
+
+    function monkeys (items) {
+        items.content = items.content.filter(function (item) {
+            callback(item, params);
+            if (item.content) {
+                monkeys(item);
+            }
+            return true;
+
+        });
+        return items;
+    }
+
+    return monkeys(data);
+}

--- a/test/plugins/classToInlineStyle.01.svg
+++ b/test/plugins/classToInlineStyle.01.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
+    <style>
+        .hidden { display: none; }
+        .red { color: red; }
+        .brown { color: brown; }
+        #rect { color: red; }
+        oval { width: 5px;}
+    </style>
+    <circle id="circle" class="hidden" fill="red" cx="60" cy="60" r="50" style="color:white"/>
+    <rect id="rect" class="hidden" fill="blue" x="10" y="10" width="100" height="100"/>
+    <rect id="rect" fill="blue" x="10" y="10" width="100" height="100"/>
+    <rect class="red hidden brown"/>
+    <oval class="red" />
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
+    <style>
+    </style>
+    <circle id="circle" class="hidden" fill="red" cx="60" cy="60" r="50" style="color:white;display:none"/>
+    <rect id="rect" class="hidden" fill="blue" x="10" y="10" width="100" height="100" style="display:none;color:red"/>
+    <rect id="rect" fill="blue" x="10" y="10" width="100" height="100" style="color:red"/>
+    <rect class="red hidden brown" style="display:none;color:red;color:brown"/>
+    <oval class="red" style="color:red;width:5px"/>
+</svg>


### PR DESCRIPTION
So, all the things explained in test case. It just moves styles from <style> to inline style of some element.
The main question, you may ask - WHY?

Everything because CSP. You just cant manage styles inside SVG if you have strict CSP rules.
So solution is simple - first move styles from def to element inline style. Next use convertStyleAttrs to move styles to the attributes.

As result - your SVG file is not CSP compatible.

PS: Was discussed with @GreLI two years ago :) Used in production by YandexMaps. But nobody knew about this plugin.