### PR TITLE
Add replaceUse plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -59,6 +59,7 @@ plugins:
   - removeStyleElement
   - removeScriptElement
   - addAttributesToSVGElement
+  - replaceUse
 
 # configure the indent (default 4 spaces) used by `--pretty` here:
 #

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Today we have:
 | [addAttributesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addAttributesToSVGElement.js) | adds attributes to an outer `<svg>` element (disabled by default) |
 | [removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) | remove `<style>` elements (disabled by default) |
 | [removeScriptElement](https://github.com/svg/svgo/blob/master/plugins/removeScriptElement.js) | remove `<script>` elements (disabled by default) |
+| [replaceUse](https://github.com/svg/svgo/blob/master/plugins/replaceUse.js) | replace all <use> elements with the node they clone (disabled by default) |
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md). ([동작방법](https://github.com/svg/svgo/blob/master/docs/how-it-works/ko.md))
 

--- a/plugins/replaceUse.js
+++ b/plugins/replaceUse.js
@@ -1,0 +1,68 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'replace all <use> elements with the node they clone';
+
+/**
+ * Replace <use> elements with the nodes they clone and remove the top-level xlink attribute. While this doesn't "optimize" the SVG, it allows the contents to be used in SVG sprites within <symbol> elements. Goes great with removeUselessDefs.
+ *
+ * @param {Object} SVG-as-JS
+ *
+ * @author Tim Shedor
+ */
+exports.fn = function(data) {
+    var svg = data.content[0];
+    var defs = {};
+
+    function addToDefs(item) {
+        if (item.hasAttr('id')) {
+            defs['#' + item.attr('id').value] = item;
+            item.removeAttr('id')
+        }
+    }
+
+    function generateDefs(item) {
+        if (item.isElem('defs')) {
+            findItems(item, addToDefs);
+        }
+    }
+
+    findItems(data, generateDefs);
+
+    findItems(data, function(item) {
+        // xlink is no longer necessary
+        if (item.isElem('svg') && item.hasAttr('xmlns:xlink')) {
+            item.removeAttr('xmlns:xlink');
+        }
+
+        if (item.isElem('use') && (item.hasAttr('href') || item.hasAttr('xlink:href'))) {
+            var id = item.hasAttr('href') ? item.attr('href').value : item.attr('xlink:href').value
+            var def = defs[id];
+
+            item.removeAttr('xlink:href');
+            item.removeAttr('href');
+            item.renameElem(def.elem);
+            def.eachAttr(function(attr) {
+                item.addAttr(attr);
+            });
+            item.removeAttr('id');
+            if (def.content) item.content = def.content;
+        }
+    });
+
+    return data;
+};
+
+function findItems(items, fn) {
+    items.content.forEach(function(item) {
+        fn(item);
+
+        if (item.content) {
+            findItems(item, fn);
+        }
+    });
+    return items;
+}

--- a/test/plugins/replaceUse.01.svg
+++ b/test/plugins/replaceUse.01.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use xlink:href="#a"/>
+    <defs>
+        <path id="a" d="M0 0h100v10H0V0z"/>
+    </defs>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h100v10H0V0z"/>
+    <defs>
+        <path d="M0 0h100v10H0V0z"/>
+    </defs>
+</svg>

--- a/test/plugins/replaceUse.02.svg
+++ b/test/plugins/replaceUse.02.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use xlink:href="#a"/>
+    <defs>
+        <g id="a">
+            <path d="M0 0h100v10H0V0z"/>
+        </g>
+    </defs>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <path d="M0 0h100v10H0V0z"/>
+    </g>
+    <defs>
+        <g>
+            <path d="M0 0h100v10H0V0z"/>
+        </g>
+    </defs>
+</svg>

--- a/test/plugins/replaceUse.03.svg
+++ b/test/plugins/replaceUse.03.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use x="50" y="50" xlink:href="#a"/>
+    <defs>
+        <path id="a" d="M0 0h100v10H0V0z"/>
+    </defs>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path x="50" y="50" d="M0 0h100v10H0V0z"/>
+    <defs>
+        <path d="M0 0h100v10H0V0z"/>
+    </defs>
+</svg>


### PR DESCRIPTION
This plugin replaces all `<use>` elements with the nodes they clone and removes the top-level `xlink` attribute. While this doesn't "optimize" the SVG, it allows the contents to be used in SVG sprites within `<symbol>` elements. This plugin is best used in conjunction with [removeUselessDefs](https://github.com/svg/svgo/blob/master/plugins/removeUselessDefs.js).