### PR TITLE
Optimize repeated commands

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -951,7 +951,19 @@ function findArcAngle(curve, relCircle) {
  */
 
 function data2Path(params, pathData) {
+    var previousInstruction = null;
     return pathData.reduce(function(pathString, item) {
-        return pathString + item.instruction + (item.data ? cleanupOutData(roundData(item.data.slice()), params) : '');
+        const data = item.data ? cleanupOutData(roundData(item.data.slice())) : '';
+        
+        // For repeated instructions, if the first number of the next command is negative,
+        // the instruction can be omitted.
+        if (!(previousInstruction === item.instruction && data && data.startsWith('-')))
+          pathString += item.instruction;
+
+        if (data)
+          pathString += data;
+
+        previousInstruction = item.instruction;
+        return pathString;
     }, '');
 }


### PR DESCRIPTION
According to the SVG spec, repeated commands can be omitted. While this is not shorter if a space is needed in its place, the space can be omitted if the next number is negative. This optimization does exactly that. The reduction in file size is very small, in my tests much less than 1%, but it does help and it's a relatively small change.