### PR TITLE
Pin css-tree version (fixes #813)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mkdirp": "~0.5.1",
     "css-select": "~1.3.0-rc0",
     "css-select-base-adapter": "~0.1.0",
-    "css-tree": "~1.0.0-alpha25",
+    "css-tree": "1.0.0-alpha25",
     "csso": "^3.3.1",
     "js-yaml": "~3.10.0",
     "object.values": "^1.0.4",


### PR DESCRIPTION
While `css-tree` is in alpha stage its version must be pinned, because with any new version API and AST format can change, and lead to issues with wrong version installation (see #813).
It may be relaxed when `css-tree` will out of alpha stage in the nearest future.