### PR TITLE
Added test for addClassesToSVGElement (currently failing).

### DIFF
--- a/test/plugins/addClassesToSVGElement.01.svg
+++ b/test/plugins/addClassesToSVGElement.01.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" class="mySvg size-big">
+    test
+</svg>
+
+@@@
+
+{"classNames":["mySvg","size-big"]}


### PR DESCRIPTION
Added test for `addClassesToSVGElement` to demonstrate that this plugin is currently failing.

```
  1) plugins tests
       addClassesToSVGElement.01:

      AssertionError: expected '<svg xmlns="http://www.w3.org/2000/svg" class="">\n    test\n</svg>' to be '<svg xmlns="http://www.w3.org/2000/svg" class="mySvg size-big">\n    test\n</svg>'
      + expected - actual

      -<svg xmlns="http://www.w3.org/2000/svg" class="">
      +<svg xmlns="http://www.w3.org/2000/svg" class="mySvg size-big">
           test
       </svg>
```