### PR TITLE
Fixes for svgo's stdout mode in 1.0.x

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -399,8 +399,8 @@ function processSVGData(config, info, data, output, input) {
             processingTime = Date.now() - startTime;
 
         return writeOutput(input, output, result.data).then(function() {
-            if (!config.quiet) {
-                if (input && output != '-') {
+            if (!config.quiet && output != '-') {
+                if (input) {
                     console.log(`\n${PATH.basename(input)}:`);
                 }
                 printTimeInfo(processingTime);

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -420,7 +420,7 @@ function processSVGData(config, info, data, output, input) {
  */
 function writeOutput(input, output, data) {
     if (output == '-') {
-        console.log(data, '\n');
+        console.log(data);
         return Promise.resolve();
     }
     return writeFile(output, data, 'utf8').catch(error => checkWriteFileError(input, output, data, error));


### PR DESCRIPTION
1.0.x seems to have introduced some extra junk in the output if you use `svgo` in `stdout` mode (i.e. `-o -`). Using the "with STDIN / STDOUT" usage documented in the [README](https://github.com/svg/svgo/blob/master/README.md) as an example:

```
$ cat examples/test.svg | bin/svgo -i - -o - > test.min.svg

$ cat test.min.svg 
<svg width="10" height="20">test</svg> 

Done in 10 ms!
0.058 KiB - 35.6% = 0.037 KiB
```

Obviously that extra stuff doesn't belong in `test.min.svg`.

This worked correctly in v0.7.x, I *believe* because the [codepaths were more separated and process.stdout.write() was used instead of console.log()](https://github.com/svg/svgo/blob/v0.7.2/lib/svgo/coa.js#L312).

Two proposed changes here:

- don't call `printTimeInfo()`/`printProfitInfo()` unless `output != '-'`
- `console.log()` already prints a trailing newline *and* it prints spaces between its arguments, so `console.log(data, '\n')` means `<data><space><newline><newline>`; we probably just want `console.log(data)` instead so we get `<data><newline>`

Thank you for this wonderful project!