### PR TITLE
Add addViewBox plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Today we have:
 | [removeEmptyText](https://github.com/svg/svgo/blob/master/plugins/removeEmptyText.js) | remove empty Text elements |
 | [removeEmptyContainers](https://github.com/svg/svgo/blob/master/plugins/removeEmptyContainers.js) | remove empty Container elements |
 | [removeViewBox](https://github.com/svg/svgo/blob/master/plugins/removeViewBox.js) | remove `viewBox` attribute when possible |
+| [addViewBox](https://github.com/svg/svgo/blob/master/plugins/addViewBox.js) | add `viewBox` attribute when possible for IE compatibility (disabled by default) |
 | [cleanupEnableBackground](https://github.com/svg/svgo/blob/master/plugins/cleanupEnableBackground.js) | remove or cleanup `enable-background` attribute when possible |
 | [minifyStyles](https://github.com/svg/svgo/blob/master/plugins/minifyStyles.js) | minify `<style>` elements content with [CSSO](https://github.com/css/csso) |
 | [convertStyleToAttrs](https://github.com/svg/svgo/blob/master/plugins/convertStyleToAttrs.js) | convert styles into attributes |

--- a/plugins/addViewBox.js
+++ b/plugins/addViewBox.js
@@ -1,0 +1,45 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = false;
+
+exports.description = 'adds viewBox attribute when possible';
+
+var viewBoxElems = ['svg', 'pattern', 'symbol'];
+
+/**
+ * Add viewBox attr which coincides with a width/height box. Prevent SVGs from breaking in IE9+. Disabled by default.
+ *
+ * @see http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute
+ *
+ * @example
+ * <svg width="100" height="50">
+ *             ⬇
+ * <svg width="100" height="50" viewBox="0 0 100 50">
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Andrew M
+ */
+exports.fn = function(item) {
+
+    if (
+        item.isElem(viewBoxElems) &&
+        !item.hasAttr('viewBox') &&
+        item.hasAttr('width') &&
+        item.hasAttr('height')
+    ) {
+        var width = parseFloat(item.attr('width').value);
+        var height = parseFloat(item.attr('height').value);
+
+        item.addAttr({
+            name: 'viewbox',
+            value: [0, 0, width, height].join(' '),
+            prefix: '',
+            local: 'viewbox'
+        });
+    }
+
+};

--- a/test/plugins/addViewBox.01.svg
+++ b/test/plugins/addViewBox.01.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewbox="0 0 100 100">
+    test
+</svg>

--- a/test/plugins/addViewBox.02.svg
+++ b/test/plugins/addViewBox.02.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50px" height="50px">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="50px" height="50px" viewbox="0 0 50 50">
+    test
+</svg>

--- a/test/plugins/addViewBox.03.svg
+++ b/test/plugins/addViewBox.03.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 50">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 100 50">
+    test
+</svg>

--- a/test/plugins/addViewBox.04.svg
+++ b/test/plugins/addViewBox.04.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100.5" height=".5">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100.5" height=".5" viewbox="0 0 100.5 0.5">
+    test
+</svg>

--- a/test/plugins/addViewBox.05.svg
+++ b/test/plugins/addViewBox.05.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="50">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" height="50">
+    test
+</svg>


### PR DESCRIPTION
Added a new plugin that will add the viewbox attribute. 

The default configuration for svgo is to remove the viewbox attribute.  Unfortunately, this can lead to unexpected behavior when viewing the SVG in IE because there's no viewbox attribute (see #139)

The plugin checks if there is a height and width , and no viewbox defined.  If that condition is met then it grabs the height and width and sets the viewbox to `0 0 [width] [height]`.

Also added tests and updated the README.

Usage:
```bash
$ svgo --enable=addViewBox --disable=removeViewBox *.svg
```

