### PR TITLE
Prefix ids plugin don't add prefix if prefix is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/svgo-profiling
 *.sublime-*
 *.log
 .DS_Store
+.idea

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -123,6 +123,8 @@ exports.fn = function(node, opts, extra) {
         } else {
             prefix = opts.prefix;
         }
+    } else if (opts.prefix === false) {
+        prefix = false;
     } else if (extra && extra.path && extra.path.length > 0) {
         var filename = path.basename(extra.path);
         prefix = filename;
@@ -131,6 +133,9 @@ exports.fn = function(node, opts, extra) {
 
     // prefixes a normal value
     addPrefix = function(name) {
+        if(prefix === false){
+            return escapeIdentifierName(name);
+        }
         return escapeIdentifierName(prefix + opts.delim + name);
     };
 


### PR DESCRIPTION
i use it like this:
```
plugins: [
          {convertPathData: false},
          {prefixIds: {
            prefix: node => {
              const elementName = node && node.elem
              if(!elementName || elementName === 'svg' || elementName === 'use'){
                return false
              }

              return 'some-prefix'
            }
          }}
        ]
```

and i expect no prefix when i return prefix as false.

it can also be used as

```
plugins: [
          {convertPathData: false},
          {prefixIds: {prefix: false}}
        ]
```
