### PR TITLE
Fixes #915 for collapseGroups

### DIFF
--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -64,8 +64,13 @@ exports.fn = function(item) {
                             } else if (attr.name == 'transform') {
                                 inner.attr(attr.name).value = attr.value + ' ' + inner.attr(attr.name).value;
                             } else if (
-                                attrsInheritable.indexOf(attr.name) < 0 &&
-                                !inner.hasAttr(attr.name, attr.value)
+                                (
+                                    attrsInheritable.indexOf(attr.name) < 0 &&
+                                    !inner.hasAttr(attr.name, attr.value)
+                                ) || (
+                                    attrsInheritable.indexOf(attr.name) >= 0 &&
+                                    inner.hasAttr(attr.name, 'inherit')
+                                )
                             ) {
                                 return;
                             }

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -63,14 +63,11 @@ exports.fn = function(item) {
                                 inner.addAttr(attr);
                             } else if (attr.name == 'transform') {
                                 inner.attr(attr.name).value = attr.value + ' ' + inner.attr(attr.name).value;
+                            } else if (inner.hasAttr(attr.name, 'inherit')) {
+                                inner.attr(attr.name).value = attr.value;
                             } else if (
-                                (
-                                    attrsInheritable.indexOf(attr.name) < 0 &&
-                                    !inner.hasAttr(attr.name, attr.value)
-                                ) || (
-                                    attrsInheritable.indexOf(attr.name) >= 0 &&
-                                    inner.hasAttr(attr.name, 'inherit')
-                                )
+                                attrsInheritable.indexOf(attr.name) < 0 &&
+                                !inner.hasAttr(attr.name, attr.value)
                             ) {
                                 return;
                             }

--- a/test/plugins/collapseGroups.15.svg
+++ b/test/plugins/collapseGroups.15.svg
@@ -1,0 +1,15 @@
+<g color="red">
+	<g color="inherit" fill="none" stroke="none">
+		<circle cx="130" cy="80" r="60" fill="currentColor"/>
+		<circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
+	</g>
+</g>
+
+@@@
+
+<g color="red">
+    <g color="inherit" fill="none" stroke="none">
+        <circle cx="130" cy="80" r="60" fill="currentColor"/>
+        <circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
+    </g>
+</g>

--- a/test/plugins/collapseGroups.15.svg
+++ b/test/plugins/collapseGroups.15.svg
@@ -1,15 +1,17 @@
-<g color="red">
-	<g color="inherit" fill="none" stroke="none">
-		<circle cx="130" cy="80" r="60" fill="currentColor"/>
-		<circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
+<svg xmlns="http://www.w3.org/2000/svg">
+	<g color="red">
+		<g color="inherit" fill="none" stroke="none">
+			<circle cx="130" cy="80" r="60" fill="currentColor"/>
+			<circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
+		</g>
 	</g>
-</g>
+</svg>
 
 @@@
 
-<g color="red">
-    <g color="inherit" fill="none" stroke="none">
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="red" fill="none" stroke="none">
         <circle cx="130" cy="80" r="60" fill="currentColor"/>
         <circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
     </g>
-</g>
+</svg>


### PR DESCRIPTION
When the inner element has the `inherit` value, overwrite with the value from the parent `<g>` element.