### PR TITLE
Add removeAttributesBySelector plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -55,6 +55,7 @@ plugins:
   - removeDesc
   - removeDimensions
   - removeAttrs
+  - removeAttributesBySelector
   - removeElementsByAttr
   - addClassesToSVGElement
   - removeStyleElement

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Today we have:
 | [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability (disabled by default) |
 | [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` attributes if `viewBox` is present (opposite to removeViewBox, disable it first) (disabled by default) |
 | [removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) | remove attributes by pattern (disabled by default) |
+| [removeAttributesBySelector](https://github.com/svg/svgo/blob/master/plugins/removeAttributesBySelector.js) | removes attributes of elements that match a css selector (disabled by default) |
 | [removeElementsByAttr](https://github.com/svg/svgo/blob/master/plugins/removeElementsByAttr.js) | remove arbitrary elements by ID or className (disabled by default) |
 | [addClassesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addClassesToSVGElement.js) | add classnames to an outer `<svg>` element (disabled by default) |
 | [addAttributesToSVGElement](https://github.com/svg/svgo/blob/master/plugins/addAttributesToSVGElement.js) | adds attributes to an outer `<svg>` element (disabled by default) |

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -1,0 +1,71 @@
+'use strict';
+
+exports.type = 'perItem'
+
+exports.active = false
+
+exports.description = 'removes attributes of elements that match a css selector'
+
+
+/**
+ * Removes attributes of elements that match a css selector.
+ *
+ * @param {Object} item current iteration item
+ * @param {Object} params plugin params
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @example
+ * <caption>A selector removing a single attribute</caption>
+ * plugins:
+ *   - removeAttributesBySelector:
+ *       selector: "[fill='#00ff00']"
+ *       attributes: "fill"
+ *
+ * <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+ *   ↓
+ * <rect x="0" y="0" width="100" height="100" stroke="#00ff00"/>     
+ *
+ * <caption>A selector removing multiple attributes</caption>
+ * plugins:
+ *   - removeAttributesBySelector:
+ *       selector: "[fill='#00ff00']"
+ *       attributes:
+ *         - fill
+ *         - stroke
+ *
+ * <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+ *   ↓
+ * <rect x="0" y="0" width="100" height="100"/>     
+ *
+ * <caption>Multiple selectors removing attributes</caption>
+ * plugins:
+ *   - removeAttributesBySelector:
+ *       selectors:
+ *         - selector: "[fill='#00ff00']"
+ *           attributes: "fill"
+ *
+ *         - selector: "#remove"
+ *           attributes:
+ *             - stroke
+ *             - id
+ *
+ * <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+ *   ↓
+ * <rect x="0" y="0" width="100" height="100"/>
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors|MDN CSS Selectors}
+ *
+ * @author Bradley Mease
+ */
+exports.fn = function(item, params) {
+
+    var selectors = Array.isArray(params.selectors)
+                         ? params.selectors
+                         : [params]
+
+    selectors.map(function(i) {
+        if (item.matches(i.selector)) {
+            item.removeAttr(i.attributes)
+        }
+    })
+}

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -1,10 +1,10 @@
 'use strict';
 
-exports.type = 'perItem'
+exports.type = 'perItem';
 
-exports.active = false
+exports.active = false;
 
-exports.description = 'removes attributes of elements that match a css selector'
+exports.description = 'removes attributes of elements that match a css selector';
 
 
 /**
@@ -59,13 +59,12 @@ exports.description = 'removes attributes of elements that match a css selector'
  */
 exports.fn = function(item, params) {
 
-    var selectors = Array.isArray(params.selectors)
-                         ? params.selectors
-                         : [params]
+    var selectors = Array.isArray(params.selectors) ? params.selectors : [params];
 
     selectors.map(function(i) {
         if (item.matches(i.selector)) {
-            item.removeAttr(i.attributes)
+            item.removeAttr(i.attributes);
         }
-    })
-}
+    });
+
+};

--- a/test/plugins/removeAttributesBySelector.01.svg
+++ b/test/plugins/removeAttributesBySelector.01.svg
@@ -1,0 +1,13 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+{ "selector": "[fill='#00ff00']", "attributes": "fill" }

--- a/test/plugins/removeAttributesBySelector.02.svg
+++ b/test/plugins/removeAttributesBySelector.02.svg
@@ -1,0 +1,13 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100"/>
+</svg>
+
+@@@
+
+{ "selector": "[fill='#00ff00']", "attributes": ["fill", "stroke"] }

--- a/test/plugins/removeAttributesBySelector.03.svg
+++ b/test/plugins/removeAttributesBySelector.03.svg
@@ -1,0 +1,13 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect id="remove" x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100"/>
+</svg>
+
+@@@
+
+{ "selectors": [{ "selector": "[fill='#00ff00']", "attributes": "fill" }, { "selector": "#remove", "attributes": ["stroke", "id"] }] }


### PR DESCRIPTION
This pull request adds the `removeAttributesBySelector` plugin. Allowing the removal of attributes in elements found by a css selector.

For a project I'm currently working on, I need to remove the attribute `fill` only if it has the value `#00ff00`. The `removeAttrs` plugin only queries the element name and is not able to meet this need.

I'm happy to add other plugins like `addAttributesBySelector`, or refactor `removeAttrs`, or create another plugin that combines all this functionality. For now, I've just left it as a separate plugin.

```
plugins:
  - removeAttributesBySelector:
    selector: "[fill='#00ff00']"
    attributes: "fill"

<rect x="0" y="0" width="100" height="100" fill="#00ff00" />
  ↓
<rect x="0" y="0" width="100" height="100"/>
```