### PR TITLE
removeAttrs: Added optional value filter

### DIFF
--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -21,10 +21,11 @@ exports.params = {
  *
  * @param attrs:
  *
- *   format: [ element* : attribute* ]
+ *   format: [ element* : attribute* : value* ]
  *
- *   element   : regexp (wrapped into ^...$), single * or omitted > all elements
+ *   element   : regexp (wrapped into ^...$), single * or omitted > all elements (must be present when value is used)
  *   attribute : regexp (wrapped into ^...$)
+ *   value     : regexp (wrapped into ^...$), single * or omitted > all values
  *
  *   examples:
  *
@@ -36,6 +37,10 @@ exports.params = {
  *     > remove fill attribute on path element
  *     ---
  *       attrs: 'path:fill'
+ *
+ *     > remove fill attribute on path element where value is none
+ *     ---
+ *       attrs: 'path:fill:none'
  *
  *
  *     > remove all fill and stroke attribute
@@ -55,6 +60,10 @@ exports.params = {
  *     [is same as]
  *
  *       attrs: '.*:(fill|stroke)'
+ *
+ *     [is same as]
+ *
+ *       attrs: '.*:(fill|stroke):.*'
  *
  *
  *     > remove all stroke related attributes
@@ -81,12 +90,16 @@ exports.fn = function(item, params) {
             // prepare patterns
         var patterns = params.attrs.map(function(pattern) {
 
-                // apply to all elements if specifc element is omitted
+                // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
             if (pattern.indexOf(elemSeparator) === -1) {
-                pattern = ['.*', elemSeparator, pattern].join('');
+                pattern = ['.*', elemSeparator, pattern, elemSeparator, '.*'].join('');
+
+                // if only 1 separator, assume it's element and attribute name, and apply regardless of attribute value
+            } else if (pattern.split(elemSeparator).length < 3) {
+                pattern = [pattern, elemSeparator, '.*'].join('');
             }
 
-                // create regexps for element and attribute name
+                // create regexps for element, attribute name, and attribute value
             return pattern.split(elemSeparator)
                 .map(function(value) {
 
@@ -110,7 +123,11 @@ exports.fn = function(item, params) {
 
                         // matches attribute name
                     if (pattern[1].test(name)) {
-                        item.removeAttr(name);
+
+                            // matches attribute value
+                        if (pattern[2].test(attr.value)) {
+                            item.removeAttr(name);
+                        }
                     }
 
                 });

--- a/test/plugins/removeAttrs.03.svg
+++ b/test/plugins/removeAttrs.03.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle fill="red" stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path fill="red" stroke="red" d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+{"attrs":"*:(stroke|fill):red"}

--- a/test/plugins/removeAttrs.04.svg
+++ b/test/plugins/removeAttrs.04.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle fill="red" stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path fill="red" stroke="red" d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+{"attrs":"*:(stroke|fill):((?!^#FFF$).)*"}


### PR DESCRIPTION
Example:

Remove all "fill" attributes that the value is "none"
```
{
  removeAttrs: {
    attrs: '*:fill:none'
  }
}
```

Remove all "fill" attributes where the value is NOT "none"
```
{
  removeAttrs: {
    attrs: '*:fill:((?!^none$).)*'
  }
}
```

Remove all "fill" attributes except when the value is white (white, #fff, rgb(255,255,255), etc.)
```
attrs: [
  "*:fill:((?!^\\s*white\\s*$|^\\s*#(f{3}|f{4}|f{6}|f{8})\\s*$|^\\s*rgba?\\(\\s*(255|100%)\\s*([,\\s]\\s*\\3\\s*){2}([,\\s]\\s*(1|100%)\\s*)?\\)\\s*$|^\\s*hsla?\\(\\s*[\\w.]+\\s*[,\\s]\\s*\\d{1,3}%\\s*[,\\s]\\s*100%\\s*([/,\\s]\\s*(1|100%)\\s*)?).)*",
  ...
]
```