### PR TITLE
tweak: do not collapse group properties to children if they contain filters.

### DIFF
--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -50,7 +50,7 @@ exports.fn = function(item) {
                 if (g.hasAttr() && g.content.length === 1) {
                     var inner = g.content[0];
 
-                    if (inner.isElem() && !inner.hasAttr('id') &&
+                    if (inner.isElem() && !inner.hasAttr('id') && !g.hasAttr('filter') &&
                         !(g.hasAttr('class') && inner.hasAttr('class')) && (
                             !g.hasAttr('clip-path') && !g.hasAttr('mask') ||
                             inner.isElem('g') && !g.hasAttr('transform') && !inner.hasAttr('transform')

--- a/test/plugins/collapseGroups.16.svg
+++ b/test/plugins/collapseGroups.16.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#...)">
+        <g>
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#...)">
+        <path d="..."/>
+    </g>
+</svg>


### PR DESCRIPTION
Some CSS filters have layout properties, a canonical example being:

```
<svg>
  <defs>
    <filter id="a">
      <feOffset dx="10" />
      <feGaussianBlur …/>
      <feColorMatrix …/>
    </filter>
  </defs>
  <g filter="url(#a)">
    <circle … />
  </g>
</svg>
```

(This happens to be how Figma does drop shadows, which is how I noticed this.)

When `svgo` pushes the `filter` attribute down to the `<circle />`, the gaussian blur gets awkwardly clipped on the top-left edges of the circle's bounding box. Based on this, I concluded it's best to not push down filters, just like `clip-path` and so forth.