### PR TITLE
fix for references nonexistent transformsWithOnePath plugin

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -70,8 +70,6 @@ var FS = require('fs'),
         },{
           sortAttrs: true,
         },{
-          transformsWithOnePath: false,
-        },{
           removeDimensions: true,
         },{
           removeAttrs: {attrs: '(stroke|fill)'},


### PR DESCRIPTION
Update test.js (which incorrectly references nonexistent transformsWithOnePath plugin)