### PR TITLE
[plugin] sortAttrs: add xmlns order option

### DIFF
--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -30,7 +30,8 @@ exports.fn = function(item, params) {
 
 	var attrs = [],
 		sorted = {},
-		orderlen = params.order.length + 1;
+		orderlen = params.order.length + 1,
+		xmlnsOrder = params.xmlnsOrder || 'front';
 
 	if (item.elem) {
 
@@ -41,10 +42,12 @@ exports.fn = function(item, params) {
 		attrs.sort(function(a, b) {
 			if (a.prefix != b.prefix) {
 				// xmlns attributes implicitly have the prefix xmlns
-				if (a.prefix == 'xmlns')
-					return -1;
-				if (b.prefix == 'xmlns')
-					return 1;
+				if (xmlnsOrder == 'front') {
+                    if (a.prefix == 'xmlns')
+                        return -1;
+                    if (b.prefix == 'xmlns')
+                        return 1;
+                }
 				return a.prefix < b.prefix ? -1 : 1;
 			}
 

--- a/test/plugins/sortAttrs.02.svg
+++ b/test/plugins/sortAttrs.02.svg
@@ -1,0 +1,15 @@
+<svg foo="bar" xmlns="http://www.w3.org/2000/svg" height="10" baz="quux" width="10" hello="world">
+    <rect x="0" y="0" width="100" height="100" stroke-width="1" stroke-linejoin="round" fill="red" stroke="orange" xmlns="http://www.w3.org/2000/svg"/>
+    test
+</svg>
+
+@@@
+
+<svg width="10" height="10" baz="quux" foo="bar" hello="world" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" x="0" y="0" fill="red" stroke="orange" stroke-linejoin="round" stroke-width="1" xmlns="http://www.w3.org/2000/svg"/>
+    test
+</svg>
+
+@@@
+
+{ "xmlnsOrder": "alphabetical" }


### PR DESCRIPTION
i wanted this option so that `xmlns` attributes weren't always at the front of the node.