### PR TITLE
Adds keepRoleAttr option for removeUnknownsAndDefaults

### DIFF
--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -12,7 +12,8 @@ exports.params = {
     defaultAttrs: true,
     uselessOverrides: true,
     keepDataAttrs: true,
-    keepAriaAttrs: true
+    keepAriaAttrs: true,
+    keepRoleAttr: true
 };
 
 var collections = require('./_collections'),
@@ -107,7 +108,8 @@ exports.fn = function(item, params) {
                     attr.name !== 'xmlns' &&
                     (attr.prefix === 'xml' || !attr.prefix) &&
                     (!params.keepDataAttrs || attr.name.indexOf('data-') != 0) &&
-                    (!params.keepAriaAttrs || attr.name.indexOf('aria-') != 0)
+                    (!params.keepAriaAttrs || attr.name.indexOf('aria-') != 0) &&
+                    (!params.keepRoleAttr || attr.name != 'role')
                 ) {
                     if (
                         // unknown attrs

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -13,7 +13,7 @@ exports.params = {
     uselessOverrides: true,
     keepDataAttrs: true,
     keepAriaAttrs: true,
-    keepRoleAttr: true
+    keepRoleAttr: false
 };
 
 var collections = require('./_collections'),

--- a/test/plugins/removeUnknownsAndDefaults.13.svg
+++ b/test/plugins/removeUnknownsAndDefaults.13.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img">
+    <g/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" role="img">
+    <g/>
+</svg>

--- a/test/plugins/removeUnknownsAndDefaults.13.svg
+++ b/test/plugins/removeUnknownsAndDefaults.13.svg
@@ -4,6 +4,6 @@
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg" role="img">
+<svg xmlns="http://www.w3.org/2000/svg">
     <g/>
 </svg>

--- a/test/plugins/removeUnknownsAndDefaults.14.svg
+++ b/test/plugins/removeUnknownsAndDefaults.14.svg
@@ -4,10 +4,10 @@
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" role="img">
     <g/>
 </svg>
 
 @@@
 
-{ "keepRoleAttr": false }
+{ "keepRoleAttr": true }

--- a/test/plugins/removeUnknownsAndDefaults.14.svg
+++ b/test/plugins/removeUnknownsAndDefaults.14.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img">
+    <g/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g/>
+</svg>
+
+@@@
+
+{ "keepRoleAttr": false }


### PR DESCRIPTION
Fixes https://github.com/svg/svgo/issues/787

Allows for the option to keep `role` attributes by setting `keepRoleAttr: true` within `removeUnknownsAndDefaults`.

This attribute is used for accessibility reasons and should be kept under some (but not all) circumstances.