### PR TITLE
(Fix #800) Add option to the mergePaths plugin, forcing all path attributes to be combined

### DIFF
--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -57,7 +57,7 @@ exports.fn = function(item, params) {
                 prevPathJS = path2js(prevContentItem),
                 curPathJS = path2js(contentItem);
 
-            if ((equalData && !intersects(prevPathJS, curPathJS)) || params.force) {
+            if (params.force || equalData && !intersects(prevPathJS, curPathJS)) {
                 js2path(prevContentItem, prevPathJS.concat(curPathJS), params);
                 return false;
             }

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -8,6 +8,7 @@ exports.description = 'merges multiple paths in one if possible';
 
 exports.params = {
     collapseRepeated: true,
+    force: false,
     leadingZero: true,
     negativeExtraSpace: true
 };
@@ -56,7 +57,7 @@ exports.fn = function(item, params) {
                 prevPathJS = path2js(prevContentItem),
                 curPathJS = path2js(contentItem);
 
-            if (equalData && !intersects(prevPathJS, curPathJS)) {
+            if ((equalData && !intersects(prevPathJS, curPathJS)) || params.force) {
                 js2path(prevContentItem, prevPathJS.concat(curPathJS), params);
                 return false;
             }


### PR DESCRIPTION
This request addresses the feature enhancement requested in #800. It allows a `force` option be passed to the `mergePaths` plugin, forcing it to combine all `<path>` attributes into a single one. The option is disabled by default.