### PR TITLE
Make removeDimensions add viewBox if it's missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Today we have:
 | [mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js) | merge multiple Paths into one |
 | [convertShapeToPath](https://github.com/svg/svgo/blob/master/plugins/convertShapeToPath.js) | convert some basic shapes to `<path>` |
 | [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability (disabled by default) |
-| [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` attributes if `viewBox` is present (opposite to removeViewBox, disable it first) (disabled by default) |
+| [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` and add `viewBox` if it's missing (opposite to removeViewBox, disable it first) (disabled by default) |
 | [removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) | remove attributes by pattern (disabled by default) |
 | [removeAttributesBySelector](https://github.com/svg/svgo/blob/master/plugins/removeAttributesBySelector.js) | removes attributes of elements that match a css selector (disabled by default) |
 | [removeElementsByAttr](https://github.com/svg/svgo/blob/master/plugins/removeElementsByAttr.js) | remove arbitrary elements by ID or className (disabled by default) |

--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -7,12 +7,12 @@ exports.active = false;
 exports.description = 'removes width and height in presence of viewBox (opposite to removeViewBox, disable it first)';
 
 /**
- * Remove width/height attributes when a viewBox attribute is present.
+ * Remove width/height attributes and add the viewBox attribute if it's missing
  *
  * @example
- * <svg width="100" height="50" viewBox="0 0 100 50">
+ * <svg width="100" height="50" />
  *   ↓
- * <svg viewBox="0 0 100 50">
+ * <svg viewBox="0 0 100 50" />
  *
  * @param {Object} item current iteration item
  * @return {Boolean} if true, with and height will be filtered out
@@ -21,12 +21,29 @@ exports.description = 'removes width and height in presence of viewBox (opposite
  */
 exports.fn = function(item) {
 
-    if (
-        item.isElem('svg') &&
-        item.hasAttr('viewBox')
-    ) {
-        item.removeAttr('width');
-        item.removeAttr('height');
+    if (item.isElem('svg')) {
+        if (item.hasAttr('viewBox')) {
+            item.removeAttr('width');
+            item.removeAttr('height');
+        } else if (
+            item.hasAttr('width') &&
+            item.hasAttr('height') &&
+            !isNaN(Number(item.attr('width').value)) &&
+            !isNaN(Number(item.attr('height').value))
+        ) {
+            item.addAttr({
+                name: 'viewBox',
+                value:
+                    '0 0 ' +
+                    Number(item.attr('width').value) +
+                    ' ' +
+                    Number(item.attr('height').value),
+                prefix: '',
+                local: 'viewBox'
+            });
+            item.removeAttr('width');
+            item.removeAttr('height');
+        }
     }
 
 };

--- a/test/plugins/removeDimensions.04.svg
+++ b/test/plugins/removeDimensions.04.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+    test
+</svg>

--- a/test/plugins/removeDimensions.05.svg
+++ b/test/plugins/removeDimensions.05.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100.5" height="0.5">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100.5 0.5">
+    test
+</svg>


### PR DESCRIPTION
This change allows removeDimensions on SVG's that lack the viewBox attribute but has valid width and height attributes.

I have such SVG's in my project and I prefer to not edit them by hand.
This change is backwards compatible, I did not change any of the previous unit tests, but added two additional ones for the new functionality.