### PR TITLE
🔧fix: update js-yalm for DoS warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "css-tree": "1.0.0-alpha.28",
     "css-url-regex": "^1.1.0",
     "csso": "^3.5.1",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.0",
     "mkdirp": "~0.5.1",
     "object.values": "^1.1.0",
     "sax": "~1.2.4",


### PR DESCRIPTION
fix npm moderate DoS vulnerability warning patched in version 3.13.0