### PR TITLE
Add ellipseToCircle plugin

### DIFF
--- a/plugins/convertEllipseToCircle.js
+++ b/plugins/convertEllipseToCircle.js
@@ -12,12 +12,11 @@ exports.description = 'converts non-eccentric <ellipse>s to <circle>s';
  * @see http://www.w3.org/TR/SVG/shapes.html
  *
  * @param {Object} item current iteration item
- * @param {Object} params plugin params
  * @return {Boolean} if false, item will be filtered out
  *
  * @author Taylor Hunt
  */
-exports.fn = function(item, params) {
+exports.fn = function(item) {
     if (item.isElem('ellipse')) {
       var rx = item.attr('rx').value || 0;
       var ry = item.attr('ry').value || 0;

--- a/plugins/convertEllipseToCircle.js
+++ b/plugins/convertEllipseToCircle.js
@@ -1,0 +1,40 @@
+'use strict';
+
+exports.type = 'perItem';
+
+exports.active = true;
+
+exports.description = 'converts non-eccentric <ellipse>s to <circle>s';
+
+/**
+ * Converts non-eccentric <ellipse>s to <circle>s.
+ *
+ * @see http://www.w3.org/TR/SVG/shapes.html
+ *
+ * @param {Object} item current iteration item
+ * @param {Object} params plugin params
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Taylor Hunt
+ */
+exports.fn = function(item, params) {
+    if (item.isElem('ellipse')) {
+      var rx = item.attr('rx').value || 0;
+      var ry = item.attr('ry').value || 0;
+
+      if (rx === ry ||
+          rx === 'auto' || ry === 'auto' // SVG2
+         ) {
+        var radius = rx !== 'auto' ? rx : ry;
+        item.renameElem('circle');
+        item.removeAttr(['rx', 'ry']);
+        item.addAttr({
+            name: 'r',
+            value: radius,
+            prefix: '',
+            local: 'r',
+          });
+      }
+  }
+  return;
+};

--- a/test/plugins/convertEllipseToCircle.01.svg
+++ b/test/plugins/convertEllipseToCircle.01.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <ellipse rx="5" ry="5"/>
+    <ellipse rx="auto" ry="5"/>
+    <ellipse rx="5" ry="auto"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle r="5"/>
+    <circle r="5"/>
+    <circle r="5"/>
+</svg>


### PR DESCRIPTION
This converts non-eccentric ellipse elements to circle elements.
Adobe Illustrator seems to be fond of using ellipses even if their rx === ry.