### PR TITLE
Export config function to enable to use

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -81,6 +81,8 @@ SVGO.prototype.createContentItem = function(data) {
     return new JSAPI(data);
 };
 
+SVGO.Config = CONFIG;
+
 module.exports = SVGO;
 // Offer ES module interop compatibility.
 module.exports.default = SVGO;


### PR DESCRIPTION
This change could be convenience which allows developers to use `config()`.

In my case, I want to initialize config object using `config()` in [vscode SVGO plugin](https://github.com/1000ch/vscode-svgo). I can import it by calling `require('svgo/lib/svgo/config');`, but it's not a provided way and we have to set `noImplicitAny: true` to use in TypeScript project. If this is merged, I'll make a pull request to update type definition in DefinitelyTyped.