### PR TITLE
Bump css-tree version to 1.0.0-alpha.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -280,9 +280,9 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-tree": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
       "requires": {
         "mdn-data": "~1.1.0",
         "source-map": "^0.5.3"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "coa": "^2.0.2",
     "css-select": "^2.0.0",
     "css-select-base-adapter": "^0.1.1",
-    "css-tree": "1.0.0-alpha.28",
+    "css-tree": "^1.0.0-alpha.29",
     "css-url-regex": "^1.1.0",
     "csso": "^3.5.1",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
Bumps `css-tree` to latest version, which will in turn bump `mdn-data` to latest, which has a better open-source license. More info here: https://github.com/csstree/csstree/issues/94.