### PR TITLE
Copy plugin params when initializing plugin by name

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -100,6 +100,9 @@ function preparePluginsArray(plugins) {
 
             plugin = Object.assign({}, require('../../plugins/' + item));
             plugin.name = item;
+            if (typeof plugin.params === 'object') {
+                plugin.params = Object.assign({}, plugin.params);
+            }
 
         }
 


### PR DESCRIPTION
Fix for issue https://github.com/svg/svgo/issues/1026

`plugin.params` is referenced when plug-in is initialised by name, which causes any modification to parameters affect all images when parsing multiple images.