### PR TITLE
addAttributesToSVGElement: accept function values

### DIFF
--- a/plugins/addAttributesToSVGElement.js
+++ b/plugins/addAttributesToSVGElement.js
@@ -43,7 +43,7 @@ plugins:
  *
  * @author April Arcus
  */
-exports.fn = function(data, params) {
+exports.fn = function(data, params, info) {
     if (!params || !(Array.isArray(params.attributes) || params.attribute)) {
         console.error(ENOCLS);
         return data;
@@ -64,10 +64,14 @@ exports.fn = function(data, params) {
                 }
             } else if (typeof attribute === 'object') {
                 Object.keys(attribute).forEach(function (key) {
+                    var value = attribute[key];
+                    if (typeof value === 'function') {
+                        value = value(svg, data, params, info);
+                    }
                     if (!svg.hasAttr(key)) {
                         svg.addAttr({
                             name: key,
-                            value: attribute[key],
+                            value: value,
                             prefix: '',
                             local: key
                         });

--- a/test/plugins/_index.js
+++ b/test/plugins/_index.js
@@ -28,15 +28,15 @@ describe('plugins tests', function() {
 
                 return readFile(file)
                 .then(function(data) {
-                    var splitted = normalize(data).split(/\s*@@@\s*/),
-                        orig     = splitted[0],
-                        should   = splitted[1],
-                        params   = splitted[2],
+                    var splitted  = normalize(data).split(/\s*@@@\s*/),
+                        orig      = splitted[0],
+                        should    = splitted[1],
+                        paramsStr = splitted[2],
 
                         plugins = {},
                         svgo;
 
-                    plugins[name] = (params) ? JSON.parse(params) : true;
+                    eval('plugins[name] = ' + (paramsStr || true));
 
                     svgo = new SVGO({
                         full    : true,

--- a/test/plugins/addAttributesToSVGElement.04.svg
+++ b/test/plugins/addAttributesToSVGElement.04.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    test
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" four="4">
+    test
+</svg>
+
+@@@
+
+{"attributes":[{"four": () => 4 }]}


### PR DESCRIPTION
This updates the addAttributesToSVGElement plugin to accept functions in addition to strings.

For reference, here's an example of giving the `id` a string value fo `"my-icon"`.

```javascript
addAttributesToSVGElement: {
  attributes: [
    {
      'id': 'my-icon'
    }
  ]
}
```

Here is the exact use case I needed this for.  I'm building a Web Component for displaying SVG icons, and it has usage like `<my-icon name="icon-web">`.  Inside the component is a use element: `<use href="/icons/svgs/icon-web.svg#???" />`.  The `???` is where the `id` should go, but that's the crux of the problem, beacuse the SVGs don't have perfectly consistent and predictable `id`s.  Rather than edit each SVG individually, I wanted svgo to programmaticaly make the id match the filename.  For instance, I wanted svgo to give `/icons/svgs/icon-web.svg` an id of `icon-web`.

This PR allows that through the following config.

```javascript
addAttributesToSVGElement: {
  attributes: [
    {
      'id': function(svg, data, params, info) {
        const srcPath = info.srcPath;
        const filename = path.basename(srcPath);
        const extension = path.extname(filename);
        const filenameNoExt = filename.replace(new RegExp(`${extension}$`), '');

        return filenameNoExt;
      }
    }
  ]
}
```

As an example with this configuration, an svg `icons/icon-web.svg` would be transformed like:

Before:

```svg
<svg> <!-- stuff --> </svg>
```

After:

```svg
<svg id="icon-web"> <!-- stuff --> </svg>
```

Now that the id can be inferred from the filename, I can provide a simple name like "icon-web" and programmatically create a full `<use>` element like `<use href="icons/icon-web.svg#icon-web"/>`.

The ability to pass in a function is probably useful in other ways as well.

### Note about the arguments passed into the function

I set this up to pass four arguments in to the function.

```javascript
function(svg, data, params, info) {}
```

`svg` is the svg object being processed.  The other three are the same arguments that are passed into all plugins.  I'm open to suggestions here.  What I needed was in `info`, but I figured the more information available to this function, the better.

### Note about `test/plugins/_index.js`

The current test system uses JSON to define configurations, and you can't put a function into a JSON string.  Here's the test I wrote:

```
<svg xmlns="http://www.w3.org/2000/svg">
    test
</svg>

@@@

<svg xmlns="http://www.w3.org/2000/svg" four="4">
    test
</svg>

@@@

{"attributes":[{"four": () => 4 }]}
```

`() => 4` not being valid JSON, I had to figure out a way to declare the test.  To do that, I replaced `JSON.stringify` with `eval`.  This is the first time I've ever been tempted to use eval, and I'm aware it'll probably be controversial to accept.  I'm very open to other approaches, I just used eval because it allowed for by far the smallest diff.  Existing tests are unaffected, since `eval` can function as a JSON parser.
