### PR TITLE
Fix 'cleanupIDs' minify bug due to preserved IDs

### DIFF
--- a/plugins/cleanupIDs.js
+++ b/plugins/cleanupIDs.js
@@ -121,13 +121,18 @@ exports.fn = function(data, params) {
         return data;
     }
 
+    const idPreserved = id => preserveIDs.has(id) || idMatchesPrefix(preserveIDPrefixes, id);
+
     for (var ref of referencesIDs) {
         var key = ref[0];
 
         if (IDs.has(key)) {
             // replace referenced IDs with the minified ones
-            if (params.minify && !preserveIDs.has(key) && !idMatchesPrefix(preserveIDPrefixes, key)) {
-                currentIDstring = getIDstring(currentID = generateID(currentID), params);
+            if (params.minify && !idPreserved(key)) {
+                do {
+                    currentIDstring = getIDstring(currentID = generateID(currentID), params);
+                } while (idPreserved(currentIDstring));
+
                 IDs.get(key).attr('id').value = currentIDstring;
 
                 for (var attr of ref[1]) {
@@ -143,7 +148,7 @@ exports.fn = function(data, params) {
     // remove non-referenced IDs attributes from elements
     if (params.remove) {
         for(var keyElem of IDs) {
-            if (!preserveIDs.has(keyElem[0]) && !idMatchesPrefix(preserveIDPrefixes, keyElem[0])) {
+            if (!idPreserved(keyElem[0])) {
                 keyElem[1].removeAttr('id');
             }
         }

--- a/test/plugins/cleanupIDs.16.svg
+++ b/test/plugins/cleanupIDs.16.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="a" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="rect" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use xlink:href="#a"/>
+    <use href="#rect"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="a" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="b" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use xlink:href="#a"/>
+    <use href="#b"/>
+</svg>
+
+@@@
+
+{"preserve": "a"}

--- a/test/plugins/cleanupIDs.17.svg
+++ b/test/plugins/cleanupIDs.17.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="a" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="rect" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use xlink:href="#a"/>
+    <use xlink:href="#rect"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="a" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="b" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use xlink:href="#a"/>
+    <use xlink:href="#b"/>
+</svg>
+
+@@@
+
+{"preservePrefixes": "a"}

--- a/test/plugins/cleanupIDs.18.svg
+++ b/test/plugins/cleanupIDs.18.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="abc" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="rect" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use href="#abc"/>
+    <use href="#rect"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 230 120">
+    <defs>
+        <circle id="abc" fill="red" cx="60" cy="60" r="50"/>
+        <rect id="b" fill="blue" x="120" y="10" width="100" height="100"/>
+    </defs>
+    <use href="#abc"/>
+    <use href="#b"/>
+</svg>
+
+@@@
+
+{"preservePrefixes": "a"}


### PR DESCRIPTION
Prevent 'cleanupIDs' plugin from producing a preserved ID, including one
which matches a preserved prefix, when minifying.

Closes #1158