### PR TITLE
ES6 -> ES8

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,5 +26,5 @@
     "loopfunc": true,
     "trailing": true,
     "lastsemic": true,
-    "esversion": 6
+    "esversion": 8
 }


### PR DESCRIPTION
I'm developing an SVGO plugin, this plugin will be quite computationally expensive and is therefore not going to be something everyone wants to enable and at the minute it's just a POC. There is a strong case to be made for using `async` and `await`in development of this plugin as this would allow for inclusion of parallelism in a readable way. 

`async` and `await` are provided by ES8 and [supported by Node 7.6.0](https://node.green) which was [released on 2017-02-21](https://nodejs.org/en/download/releases).

Is this (potentially breaking) change something that the project would be willing to consider?