### PR TITLE
Selectively remove matched style/attr

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -6,7 +6,10 @@ exports.active = true;
 
 exports.params = {
     onlyMatchedOnce: true,
-    removeMatchedSelectors: true,
+    removeMatchedSelectors: {
+        style: true,
+        attr:  true,
+    },
     useMqs: ['', 'screen'],
     usePseudos: ['']
 };
@@ -158,7 +161,7 @@ exports.fn = function(document, opts) {
             }});
         }
 
-        if (opts.removeMatchedSelectors && selector.selectedEls !== null && selector.selectedEls.length > 0) {
+        if ((opts.removeMatchedSelectors === true || opts.removeMatchedSelectors.style) && selector.selectedEls !== null && selector.selectedEls.length > 0) {
             // clean up matching simple selectors if option removeMatchedSelectors is enabled
             selector.rule.prelude.children.remove(selector.item);
         }
@@ -171,30 +174,32 @@ exports.fn = function(document, opts) {
 
 
     // clean up matched class + ID attribute values
-    for (selector of sortedSelectors) {
-        if(!selector.selectedEls) {
-            continue;
-        }
-
-        if (opts.onlyMatchedOnce && selector.selectedEls !== null && selector.selectedEls.length > 1) {
-            // skip selectors that match more than once if option onlyMatchedOnce is enabled
-            continue;
-        }
-
-        for (selectedEl of selector.selectedEls) {
-            // class
-            var firstSubSelector = selector.item.data.children.first();
-            if(firstSubSelector.type === 'ClassSelector') {
-                selectedEl.class.remove(firstSubSelector.name);
-            }
-            // clean up now empty class attributes
-            if(typeof selectedEl.class.item(0) === 'undefined') {
-                selectedEl.removeAttr('class');
+    if((opts.removeMatchedSelectors === true || opts.removeMatchedSelectors.attr)) {
+        for (selector of sortedSelectors) {
+            if(!selector.selectedEls) {
+                continue;
             }
 
-            // ID
-            if(firstSubSelector.type === 'IdSelector') {
-                selectedEl.removeAttr('id', firstSubSelector.name);
+            if (opts.onlyMatchedOnce && selector.selectedEls !== null && selector.selectedEls.length > 1) {
+                // skip selectors that match more than once if option onlyMatchedOnce is enabled
+                continue;
+            }
+
+            for (selectedEl of selector.selectedEls) {
+                // class
+                var firstSubSelector = selector.item.data.children.first();
+                if(firstSubSelector.type === 'ClassSelector') {
+                    selectedEl.class.remove(firstSubSelector.name);
+                }
+                // clean up now empty class attributes
+                if(typeof selectedEl.class.item(0) === 'undefined') {
+                    selectedEl.removeAttr('class');
+                }
+
+                // ID
+                if(firstSubSelector.type === 'IdSelector') {
+                    selectedEl.removeAttr('id', firstSubSelector.name);
+                }
             }
         }
     }

--- a/test/plugins/inlineStyles.20.svg
+++ b/test/plugins/inlineStyles.20.svg
@@ -1,0 +1,22 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue;}
+        .st1{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0"/>
+    <rect width="100" height="100" class="st1"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect width="100" height="100" class="st0" style="fill:blue"/>
+    <rect width="100" height="100" class="st1" style="fill:red"/>
+</svg>
+
+@@@
+
+{"removeMatchedSelectors":{
+    "style":true,
+    "attr": false
+}}

--- a/test/plugins/inlineStyles.21.svg
+++ b/test/plugins/inlineStyles.21.svg
@@ -1,0 +1,25 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue;}
+        .st1{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0"/>
+    <rect width="100" height="100" class="st1"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue}.st1{fill:red}
+    </style>
+    <rect width="100" height="100" style="fill:blue"/>
+    <rect width="100" height="100" style="fill:red"/>
+</svg>
+
+@@@
+
+{"removeMatchedSelectors":{
+    "style":false,
+    "attr": true
+}}

--- a/test/plugins/inlineStyles.22.svg
+++ b/test/plugins/inlineStyles.22.svg
@@ -1,0 +1,22 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue;}
+        .st1{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0"/>
+    <rect width="100" height="100" class="st1"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect width="100" height="100" style="fill:blue"/>
+    <rect width="100" height="100" style="fill:red"/>
+</svg>
+
+@@@
+
+{"removeMatchedSelectors":{
+    "style":true,
+    "attr": true
+}}

--- a/test/plugins/inlineStyles.23.svg
+++ b/test/plugins/inlineStyles.23.svg
@@ -1,0 +1,25 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue;}
+        .st1{fill:red;}
+    </style>
+    <rect width="100" height="100" class="st0"/>
+    <rect width="100" height="100" class="st1"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue}.st1{fill:red}
+    </style>
+    <rect width="100" height="100" class="st0" style="fill:blue"/>
+    <rect width="100" height="100" class="st1" style="fill:red"/>
+</svg>
+
+@@@
+
+{"removeMatchedSelectors":{
+    "style":false,
+    "attr": false
+}}

--- a/test/plugins/inlineStyles.24.svg
+++ b/test/plugins/inlineStyles.24.svg
@@ -1,0 +1,30 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red {
+            fill: red;
+        }
+        .blue {
+            fill: blue;
+        }
+    </style>
+    <rect width="100" height="100" class="red blue"/>
+    <rect width="100" height="100" class="blue red"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red{fill:red}.blue{fill:blue}
+    </style>
+    <rect width="100" height="100" style="fill:blue"/>
+    <rect width="100" height="100" style="fill:blue"/>
+</svg>
+
+@@@
+
+{"onlyMatchedOnce":false,
+ "removeMatchedSelectors":{
+    "style":false,
+    "attr": true
+}}

--- a/test/plugins/inlineStyles.25.svg
+++ b/test/plugins/inlineStyles.25.svg
@@ -1,0 +1,27 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red {
+            fill: red;
+        }
+        .blue {
+            fill: blue;
+        }
+    </style>
+    <rect width="100" height="100" class="red blue"/>
+    <rect width="100" height="100" class="blue red"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect width="100" height="100" class="red blue" style="fill:blue"/>
+    <rect width="100" height="100" class="blue red" style="fill:blue"/>
+</svg>
+
+@@@
+
+{"onlyMatchedOnce":false,
+ "removeMatchedSelectors":{
+    "style":true,
+    "attr": false
+}}

--- a/test/plugins/inlineStyles.26.svg
+++ b/test/plugins/inlineStyles.26.svg
@@ -1,0 +1,27 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red {
+            fill: red;
+        }
+        .blue {
+            fill: blue;
+        }
+    </style>
+    <rect width="100" height="100" class="red blue"/>
+    <rect width="100" height="100" class="blue red"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect width="100" height="100" style="fill:blue"/>
+    <rect width="100" height="100" style="fill:blue"/>
+</svg>
+
+@@@
+
+{"onlyMatchedOnce":false,
+ "removeMatchedSelectors":{
+    "style":true,
+    "attr": true
+}}

--- a/test/plugins/inlineStyles.27.svg
+++ b/test/plugins/inlineStyles.27.svg
@@ -1,0 +1,30 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red {
+            fill: red;
+        }
+        .blue {
+            fill: blue;
+        }
+    </style>
+    <rect width="100" height="100" class="red blue"/>
+    <rect width="100" height="100" class="blue red"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .red{fill:red}.blue{fill:blue}
+    </style>
+    <rect width="100" height="100" class="red blue" style="fill:blue"/>
+    <rect width="100" height="100" class="blue red" style="fill:blue"/>
+</svg>
+
+@@@
+
+{"onlyMatchedOnce":false,
+ "removeMatchedSelectors":{
+    "style":false,
+    "attr": false
+}}


### PR DESCRIPTION
This PR adds options to `removeMatchedSelectors` option for selectively removing style and/or attr.
This can be useful if the attrs should be kept for selecting or styling with pseudo-classes (e.g. `:hover`).