### PR TITLE
Fix multiple prefixes in multipass

### DIFF
--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -125,6 +125,13 @@ var addPrefixToUrlAttr = function(attr) {
  */
 exports.fn = function(node, opts, extra) {
 
+    // prevent multiple prefixing in multipass
+    if(node.processedByPrefixIdsPlugin) {
+        return node;
+    }
+    node.processedByPrefixIdsPlugin = true;
+
+
     // prefix, from file name or option
     var prefix = 'prefix';
     if (opts.prefix) {


### PR DESCRIPTION
[`imagemin-svgo` enables `svgo` `multipass` by default](https://github.com/imagemin/imagemin-svgo/blob/master/index.js#L6), hence many users reports this issue (https://github.com/svg/svgo/issues/1148).

This PR will add a flag to the internal `svgo` AST for each node processed by the `prefixIds` plugin to prevent multiple prefixing, which currently happens in `multipass` mode.

(Originally the `prefixIds` plugin should check the beginning of each name and skip if it equals the prefix, but there can be occasions where the prefix is the same as a non-prefixed name, and this can result in collisions between SVGs because of skipped prefixing.)