### PR TITLE
ReplaceUse plugin

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -29,7 +29,6 @@ plugins:
   - cleanupIDs
   - prefixIds
   - removeRasterImages
-  - replaceUse
   - removeUselessDefs
   - cleanupNumericValues
   - cleanupListOfValues
@@ -66,7 +65,8 @@ plugins:
   - addAttributesToSVGElement
   - removeOffCanvasPaths
   - reusePaths
-
+  - replaceUse
+  
 # configure the indent (default 4 spaces) used by `--pretty` here:
 #
 # @see https://github.com/svg/svgo/blob/master/lib/svgo/js2svg.js#L6 for more config options

--- a/.svgo.yml
+++ b/.svgo.yml
@@ -29,6 +29,7 @@ plugins:
   - cleanupIDs
   - prefixIds
   - removeRasterImages
+  - replaceUse
   - removeUselessDefs
   - cleanupNumericValues
   - cleanupListOfValues

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Today we have:
 | [removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js) | remove `<style>` elements (disabled by default) |
 | [removeScriptElement](https://github.com/svg/svgo/blob/master/plugins/removeScriptElement.js) | remove `<script>` elements (disabled by default) |
 | [reusePaths](https://github.com/svg/svgo/blob/master/plugins/reusePaths.js) | Find duplicated <path> elements and replace them with <use> links (disabled by default) |
+| [replaceUse](https://github.com/svg/svgo/blob/master/plugins/replaceUse.js) | replace all <use> elements with the node they clone (disabled by default) |
 
 Want to know how it works and how to write your own plugin? [Of course you want to](https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md). ([동작방법](https://github.com/svg/svgo/blob/master/docs/how-it-works/ko.md))
 

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -42,7 +42,7 @@ function hasAnimatedAttr(item) {
 exports.fn = function(item) {
 
     // non-empty elements
-    if (item.isElem() && !item.isElem('switch') && !item.isEmpty()) {
+    if (item.isElem() && (!item.isElem('switch') || isFeaturedSwitch(item)) && !item.isEmpty()) {
         item.content.forEach(function(g, i) {
             // non-empty groups
             if (g.isElem('g') && !g.isEmpty()) {
@@ -81,7 +81,15 @@ exports.fn = function(item) {
                 if (!g.hasAttr() && !g.content.some(function(item) { return item.isElem(animationElems) })) {
                     item.spliceContent(i, 1, g.content);
                 }
+            } else if (isFeaturedSwitch(g)) {
+                item.spliceContent(i, 1, g.content);
             }
         });
     }
 };
+
+function isFeaturedSwitch(elem) {
+    return elem.isElem('switch') && !elem.isEmpty() && !elem.content.some(child =>
+        child.hasAttr('systemLanguage') || child.hasAttr('requiredFeatures') || child.hasAttr('requiredExtensions')
+    );
+}

--- a/plugins/replaceUse.js
+++ b/plugins/replaceUse.js
@@ -72,6 +72,9 @@ function removeItem(item) {
 }
 
 function findItems(items, fn) {
+    if (items.content) {
+        return undefined
+    }
     items.content.forEach(function(item) {
         fn(item);
 

--- a/plugins/replaceUse.js
+++ b/plugins/replaceUse.js
@@ -41,14 +41,16 @@ exports.fn = function(data) {
             var id = item.hasAttr('href') ? item.attr('href').value : item.attr('xlink:href').value;
             var def = defs[id];
 
-            item.removeAttr('xlink:href');
-            item.removeAttr('href');
-            item.renameElem(def.elem);
-            def.eachAttr(function(attr) {
-                item.addAttr(attr);
-            });
-            item.removeAttr('id');
-            if (def.content) item.content = def.content;
+            if (def) {
+                item.removeAttr('xlink:href');
+                item.removeAttr('href');
+                item.renameElem(def.elem);
+                def.eachAttr(function(attr) {
+                    item.addAttr(attr);
+                });
+                item.removeAttr('id');
+                if (def.content) item.content = def.content;
+            }
         }
     });
 

--- a/plugins/replaceUse.js
+++ b/plugins/replaceUse.js
@@ -1,0 +1,83 @@
+'use strict';
+
+exports.type = 'full';
+
+exports.active = false;
+
+exports.description = 'replace all <use> elements with the node they clone';
+
+/**
+ * Replace <use> elements with the nodes they clone and remove the top-level xlink attribute and remove their referenced element if it's within <defs>. While this doesn't "optimize" the SVG, it allows the contents to be used in SVG sprites within <symbol> elements.
+ *
+ * @param {Object} SVG-as-JS
+ *
+ * @author Tim Shedor
+ */
+exports.fn = function(data) {
+    var defs = {};
+    var usedDefs = [];
+
+    function addToDefs(item) {
+        if (item.hasAttr('id')) {
+            defs['#' + item.attr('id').value] = item;
+        }
+    }
+
+    findItems(data, addToDefs);
+
+    findItems(data, function(item) {
+        // xlink is no longer necessary
+        if (item.isElem('svg') && item.hasAttr('xmlns:xlink')) {
+            item.removeAttr('xmlns:xlink');
+        }
+
+        if (item.isElem('use') && (item.hasAttr('href') || item.hasAttr('xlink:href'))) {
+            var id = item.hasAttr('href') ? item.attr('href').value : item.attr('xlink:href').value;
+            var def = defs[id];
+            var replacement = def.clone();
+            replacement.removeAttr('id');
+
+            item.removeAttr('xlink:href');
+            item.removeAttr('href');
+            item.renameElem('g');
+
+            if (usedDefs.indexOf(def) === -1) {
+                usedDefs.push(def);
+            }
+
+            item.content = [replacement];
+        }
+    });
+
+    usedDefs.forEach(removeItem);
+
+    return data;
+};
+
+/**
+ * Remove the referenced node if it's within <defs> and <defs> if it's ultimately empty
+ * @param  {Node} item
+ */
+function removeItem(item) {
+    var parent = item.parentNode;
+
+    if (parent && (parent.isElem('defs') || item.isElem('defs'))) {
+        var idx = parent.content.indexOf(item);
+        parent.content.splice(idx, 1);
+
+        if (parent.isEmpty() && parent.isElem('defs')) {
+            removeItem(parent);
+        }
+    }
+}
+
+function findItems(items, fn) {
+    items.content.forEach(function(item) {
+        fn(item);
+
+        if (item.content) {
+            findItems(item, fn);
+        }
+    });
+    return items;
+}

--- a/test/plugins/collapseGroups.14.svg
+++ b/test/plugins/collapseGroups.14.svg
@@ -10,22 +10,16 @@
             <g/>
         </g>
     </switch>
-
+    
 </svg>
 
 @@@
 
 
 <svg xmlns="http://www.w3.org/2000/svg">
-    <switch>
-        <g id="a">
-            <g class="i"/>
-        </g>
-        <g id="b" class="n">
-            <g class="i"/>
-        </g>
-        <g>
-            <g/>
-        </g>
-    </switch>
+    <g class="i" id="a"/>
+    <g id="b" class="n">
+        <g class="i"/>
+    </g>
+    <g/>
 </svg>


### PR DESCRIPTION
Referring to https://github.com/svg/svgo/pull/808, this is an updated version of the replaceUse plugin. Indeed I have run this plugin for a long time.

So far my service has been running this plugin for more than a year of time and perform well indeed. The usage is to remove some <symbol> or <def> tag, and merge into the corresponding <use> tag.

I run it with multi-pass settings on, on thousands of noun project icon, and it really cleanup many redundant icons with lots of <use>.