### PR TITLE
Update csso to 4.0.2 (+semicola in styles test)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,19 +322,12 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "mdn-data": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-          "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
-        }
+        "source-map": "^0.6.1"
       }
     },
     "css-what": {
@@ -1661,9 +1654,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,21 +343,26 @@
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "csso": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+      "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
       "requires": {
-        "css-tree": "1.0.0-alpha.29"
+        "css-tree": "1.0.0-alpha.37"
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.0.0-alpha.29",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-          "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+          "version": "1.0.0-alpha.37",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+          "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
           "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "2.0.4",
+            "source-map": "^0.6.1"
           }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -1071,9 +1076,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "mem": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "coa": "^2.0.2",
     "css-select": "^2.0.0",
     "css-select-base-adapter": "^0.1.1",
-    "css-tree": "1.0.0-alpha.33",
+    "css-tree": "^1.0.0-alpha.37",
     "csso": "^4.0.2",
     "js-yaml": "^3.13.1",
     "mkdirp": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "css-select": "^2.0.0",
     "css-select-base-adapter": "^0.1.1",
     "css-tree": "1.0.0-alpha.33",
-    "csso": "^3.5.1",
+    "csso": "^4.0.2",
     "js-yaml": "^3.13.1",
     "mkdirp": "~0.5.1",
     "object.values": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "coa": "^2.0.2",
     "css-select": "^2.0.0",
     "css-select-base-adapter": "^0.1.1",
-    "css-tree": "^1.0.0-alpha.37",
+    "css-tree": "1.0.0-alpha.37",
     "csso": "^4.0.2",
     "js-yaml": "^3.13.1",
     "mkdirp": "~0.5.1",

--- a/test/plugins/minifyStyles.10.svg
+++ b/test/plugins/minifyStyles.10.svg
@@ -1,0 +1,19 @@
+<svg viewBox="0 0 2203 1777" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+        .st6{font-family:Helvetica LT Std, Helvetica, Arial; font-size:118px;; stroke-opacity:0; fill-opacity:0;}
+    </style>
+    <text class="st6" transform="translate(353.67 1514)">
+        tell stories in 250 characters
+    </text>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 2203 1777" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+        .st6{font-family:Helvetica LT Std,Helvetica,Arial;font-size:118px;stroke-opacity:0;fill-opacity:0}
+    </style>
+    <text class="st6" transform="translate(353.67 1514)">
+        tell stories in 250 characters
+    </text>
+</svg>


### PR DESCRIPTION
This PR adds a test for reproducing the `csso` error in and 
fixes https://github.com/svg/svgo/issues/1097 by updating to [latest `csso` `4.0.2`](https://github.com/svg/svgo/issues/1097#issuecomment-547193439).