### PR TITLE
Add multipassCount to info object; skip subsequent passes in prefixIds plugin

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -38,6 +38,7 @@ SVGO.prototype.optimize = function(svgstr, info) {
                     return;
                 }
 
+                info.multipassCount = counter;
                 if (++counter < maxPassCount && svgjs.data.length < prevResultSize) {
                     prevResultSize = svgjs.data.length;
                     this._optimizeOnce(svgjs.data, info, optimizeOnceCallback);

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -125,6 +125,11 @@ var addPrefixToUrlAttr = function(attr) {
  */
 exports.fn = function(node, opts, extra) {
 
+    // skip subsequent passes when multipass is used
+    if(extra.multipassCount && extra.multipassCount > 0) {
+        return node;
+    }
+
     // prefix, from file name or option
     var prefix = 'prefix';
     if (opts.prefix) {


### PR DESCRIPTION
This PR adds `multipassCount` to the `info` object that is passed to the plugins.
This allows plugins to know whether they already processed a SVG node/document and how many times. This is necessary for the `prefixIds` plugin to skip in subsequent passes when multipass is used to prevent unintended, multiple prefixing (see https://github.com/svg/svgo/issues/1148).

The `info` object is perfectly suited for this kind of extra/runtime information for the plugins, 
and it is already used by `prefixIds` plugin for obtaining the path of the SVG (node) it is processing.