### PR TITLE
Default `info` on SVGO.optimize API

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -22,6 +22,7 @@ var SVGO = function(config) {
 };
 
 SVGO.prototype.optimize = function(svgstr, info) {
+    info = info || {};
     return new Promise((resolve, reject) => {
         if (this.config.error) {
             reject(this.config.error);


### PR DESCRIPTION
As per PR #1173, and commit https://github.com/svg/svgo/commit/71c7fe74b9a6cbbbe6d8e4f318a0d6fb35c1d727, passing `info` to the `SVGO.optimize` function is no longer optional. Without setting `info`, the following error is thrown:
`Cannot set property 'multipassCount' of undefined`

I'm not entirely sure if this was ever meant to be optional, but, it's worked that way up until 1.3.0, and you can find hundreds of examples on GitHub of people using it this way: https://github.com/search?l=JavaScript&q=%22svgo.optimize%22&type=Code

This PR simply sets `info` to an empty object if it's not set, which enables backwards compatibility with 1.3.0 and other versions, which will save people who use "compatible with" versions in their package.json declarations. If you have a better suggestion for how to solve this, I'm open to it.

Fixes #1174 