### PR TITLE
Add test for invoking svgo.optimize without an info object

### DIFF
--- a/test/svgo/_index.js
+++ b/test/svgo/_index.js
@@ -41,6 +41,39 @@ describe('indentation', function() {
 
 });
 
+describe('invocation', function() {
+
+    it('should optimize without an info object', function(done) {
+
+        var filepath = PATH.resolve(__dirname, './test.svg'),
+            svgo;
+
+        FS.readFile(filepath, 'utf8', function(err, data) {
+            if (err) {
+                throw err;
+            }
+
+            var splitted = normalize(data).split(/\s*@@@\s*/),
+                orig     = splitted[0],
+                should   = splitted[1];
+
+            svgo = new SVGO({
+                full    : true,
+                plugins : [],
+                js2svg  : { pretty: true, indent: 2 }
+            });
+
+            svgo.optimize(orig, null).then(function(result) {
+                normalize(result.data).should.be.equal(should);
+                done();
+            });
+
+        });
+
+    });
+
+});
+
 function normalize(file) {
     return file.trim().replace(regEOL, '\n');
 }

--- a/test/svgo/_index.js
+++ b/test/svgo/_index.js
@@ -63,7 +63,7 @@ describe('invocation', function() {
                 js2svg  : { pretty: true, indent: 2 }
             });
 
-            svgo.optimize(orig, null).then(function(result) {
+            svgo.optimize(orig, undefined).then(function(result) {
                 normalize(result.data).should.be.equal(should);
                 done();
             });


### PR DESCRIPTION
This PR adds a test (albeit retroactively) for invoking `svgo.optimize()` without passing it an `info` object.

Related issue: https://github.com/svg/svgo/issues/1174