### PR TITLE
Fix collapsing of repeated commands in convertPathData plugin

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -514,7 +514,7 @@ function filters(path, params) {
                 instruction == prev.instruction.toLowerCase() &&
                 (
                     (instruction != 'h' && instruction != 'v') ||
-                    (prev.data[0] >= 0) == (item.data[0] >= 0)
+                    (prev.data[0] >= 0) == (data[0] >= 0)
             )) {
                 prev.data[0] += data[0];
                 if (instruction != 'h' && instruction != 'v') {


### PR DESCRIPTION
This fixes #1166. In the example reported in that bug, `data` was updated at line 460, but writing back to `item.data` doesn't happen until later, which is why line 517 ended up using outdated data.