### PR TITLE
fix excessive defs tag

### DIFF
--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -121,25 +121,27 @@ exports.fn = function(data) {
     }
     item = convertToUse(item, hasSeen.elem.attr('id').value);
   });
-  const defsTag = new JSAPI({
-    elem: 'defs', prefix: '', local: 'defs', content: [], attrs: []}, data);
-  data.content[0].spliceContent(0, 0, defsTag);
-  for (let def of defs) {
-    // Remove class and style before copying to avoid circular refs in
-    // JSON.stringify. This is fine because we don't actually want class or
-    // style information to be copied.
-    const style = def.style;
-    const defClass = def.class;
-    delete def.style;
-    delete def.class;
-    const defClone = def.clone();
-    def.style = style;
-    def.class = defClass;
-    defClone.removeAttr('transform');
-    defsTag.spliceContent(0, 0, defClone);
-    // Convert the original def to a use so the first usage isn't duplicated.
-    def = convertToUse(def, defClone.attr('id').value);
-    def.removeAttr('id');
+  if (defs.length > 0) {
+    const defsTag = new JSAPI({
+      elem: 'defs', prefix: '', local: 'defs', content: [], attrs: []}, data);
+    data.content[0].spliceContent(0, 0, defsTag);
+    for (let def of defs) {
+      // Remove class and style before copying to avoid circular refs in
+      // JSON.stringify. This is fine because we don't actually want class or
+      // style information to be copied.
+      const style = def.style;
+      const defClass = def.class;
+      delete def.style;
+      delete def.class;
+      const defClone = def.clone();
+      def.style = style;
+      def.class = defClass;
+      defClone.removeAttr('transform');
+      defsTag.spliceContent(0, 0, defClone);
+      // Convert the original def to a use so the first usage isn't duplicated.
+      def = convertToUse(def, defClone.attr('id').value);
+      def.removeAttr('id');
+    }
   }
   return data;
 };

--- a/test/plugins/reusePaths.03.svg
+++ b/test/plugins/reusePaths.03.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text>
+        text element
+    </text>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text>
+        text element
+    </text>
+</svg>


### PR DESCRIPTION
Fixes #1186

By checking whether there are any defs before making an element, it doesn't create an empty `<defs/>` element.