### PR TITLE
Fix multipassCount initialization

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -38,10 +38,10 @@ SVGO.prototype.optimize = function(svgstr, info) {
                     reject(svgjs.error);
                     return;
                 }
-
-                info.multipassCount = counter;
+                
                 if (++counter < maxPassCount && svgjs.data.length < prevResultSize) {
                     prevResultSize = svgjs.data.length;
+                    info.multipassCount = counter;
                     this._optimizeOnce(svgjs.data, info, optimizeOnceCallback);
                 } else {
                     if (config.datauri) {
@@ -54,6 +54,7 @@ SVGO.prototype.optimize = function(svgstr, info) {
                 }
             };
 
+        info.multipassCount = counter;
         this._optimizeOnce(svgstr, info, optimizeOnceCallback);
     });
 };


### PR DESCRIPTION
The previous implementation initialized `info.multipassCount` in the optimize callback, and before counter is incremented. Thus, on the first pass, it is `undefined`, on the second it is 0, third it is 1, etc.

This is problematic since the prefixIds plugin multipass check will pass for both undefined and 0, causing it to run twice (as opposed to once, which was the intention of this feature to prevent accumulating prefixes).