### PR TITLE
Add workaround/fix for node v6 selector exception handling

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -109,7 +109,8 @@ exports.fn = function(document, opts) {
         try {
             selectedEls = document.querySelectorAll(selectorStr);
         } catch (selectError) {
-            if (selectError.constructor === SyntaxError) {
+            if (selectError.message.match(/^Unmatched selector/) || // node v6.x selectError.constructor is `Error` instead of `SyntaxError`!
+                selectError.constructor === SyntaxError) {
                 // console.warn('Warning: Syntax error when trying to select \n\n' + selectorStr + '\n\n, skipped. Error details: ' + selectError);
                 continue;
             }


### PR DESCRIPTION
@GreLI: This PR adds a workaround/fix for selector exception handling in node v6.
This fixes the currently failing build of current master (Travis node v6): https://travis-ci.org/svg/svgo/jobs/623319182#L880

The reason is that in node v6 the `constructor` property of an exception that is thrown by `css-select`, when a selector doesn't match (which normally happens all the time), is just `Error` instead of `SyntaxError`. All exceptions other than `SyntaxError` are re-thrown, but when the constructor is just `Error` in node v6, one is unable to differentiate. As an alternative for node v6, [the exception `message` is matched by the error message](https://github.com/svg/svgo/pull/1208/files#diff-894234f5731c2854476a58abcef9d1c4R112).