### PR TITLE
Fix erroneus omission of attribute corrections

### DIFF
--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -61,12 +61,8 @@ exports.fn = function(item, params) {
 
                 // convert absolute values to pixels
                 if (params.convertToPx && units && (units in absoluteLengths)) {
-                    var pxNum = +(absoluteLengths[units] * match[1]).toFixed(floatPrecision);
-
-                    if (String(pxNum).length < match[0].length) {
-                        num = pxNum;
-                        units = 'px';
-                    }
+                    num = +(absoluteLengths[units] * match[1]).toFixed(floatPrecision);
+                    units = 'px';
                 }
 
                 // and remove leading zero

--- a/test/plugins/cleanupNumericValues.03.svg
+++ b/test/plugins/cleanupNumericValues.03.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20.53in" height="20in" viewBox="0, 0, 20, 20">
+    <rect width="20" height="20" fill="rgba(255,255,255,.85)" rx="20"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1970.88" height="1920" viewBox="0 0 20 20">
+    <rect width="20" height="20" fill="rgba(255,255,255,.85)" rx="20"/>
+</svg>

--- a/test/plugins/cleanupNumericValues.04.svg
+++ b/test/plugins/cleanupNumericValues.04.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20.53mm" height="20mm" viewBox="0, 0, 20, 20">
+    <rect width="20" height="20" fill="rgba(255,255,255,.85)" rx="20"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="77.594" height="75.591" viewBox="0 0 20 20">
+    <rect width="20" height="20" fill="rgba(255,255,255,.85)" rx="20"/>
+</svg>


### PR DESCRIPTION
The cleanupNumericValues plugin contained a condition that causes the
correction of values to be scrapped even though the correction should be
applied. A simply example would be the omission to change the value of
the width attribute, if the value is "20mm".
This condition was removed and the remaining three lines simplified into
two.

The commit adds two test files to verify the new behaviour (these files would fail without the fix).