### PR TITLE
Preserve whitespace in elements containing text

### DIFF
--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var EOL = require('os').EOL,
-    textElem = require('../../plugins/_collections.js').elemsGroups.textContent.concat('title');
+    textElems = require('../../plugins/_collections.js').textElems;
 
 var defaults = {
     doctypeStart: '<!DOCTYPE',
@@ -258,7 +258,7 @@ JS2SVG.prototype.createElem = function(data) {
             tagCloseStart = this.config.tagCloseStart,
             tagCloseEnd = this.config.tagCloseEnd,
             openIndent = this.createIndent(),
-            textIndent = '',
+            closeIndent = this.createIndent(),
             processedData = '',
             dataEnd = '';
 
@@ -268,10 +268,10 @@ JS2SVG.prototype.createElem = function(data) {
             tagCloseStart = defaults.tagCloseStart;
             tagCloseEnd = defaults.tagCloseEnd;
             openIndent = '';
-        } else if (data.isElem(textElem)) {
-            if (this.config.pretty) {
-                textIndent += openIndent + this.config.indent;
-            }
+        } else if (data.isElem(textElems)) {
+            tagOpenEnd = defaults.tagOpenEnd;
+            tagCloseStart = defaults.tagCloseStart;
+            closeIndent = '';
             this.textContext = data;
         }
 
@@ -279,7 +279,6 @@ JS2SVG.prototype.createElem = function(data) {
 
         if (this.textContext == data) {
             this.textContext = null;
-            if (this.config.pretty) dataEnd = EOL;
         }
 
         return  openIndent +
@@ -287,10 +286,9 @@ JS2SVG.prototype.createElem = function(data) {
                 data.elem +
                 this.createAttrs(data) +
                 tagOpenEnd +
-                textIndent +
                 processedData +
                 dataEnd +
-                this.createIndent() +
+                closeIndent +
                 tagCloseStart +
                 data.elem +
                 tagCloseEnd;

--- a/lib/svgo/svg2js.js
+++ b/lib/svgo/svg2js.js
@@ -4,8 +4,8 @@ var SAX = require('sax'),
     JSAPI = require('./jsAPI.js'),
     CSSClassList = require('./css-class-list'),
     CSSStyleDeclaration = require('./css-style-declaration'),
-    entityDeclaration = /<!ENTITY\s+(\S+)\s+(?:'([^']+)'|"([^"]+)")\s*>/g,
-    textElems = require('../../plugins/_collections.js').textElems;
+    textElems = require('../../plugins/_collections.js').textElems,
+    entityDeclaration = /<!ENTITY\s+(\S+)\s+(?:'([^']+)'|"([^"]+)")\s*>/g;
 
 var config = {
     strict: true,
@@ -117,7 +117,7 @@ module.exports = function(data) {
         current = elem;
 
         // Save info about tags containing text to prevent trimming of meaningful whitespace
-        if (textElems.indexOf(data.name) !== -1 && !data.prefix) {
+        if (textElems.includes(data.name) && !data.prefix) {
             textContext = current;
         }
 

--- a/lib/svgo/svg2js.js
+++ b/lib/svgo/svg2js.js
@@ -4,12 +4,13 @@ var SAX = require('sax'),
     JSAPI = require('./jsAPI.js'),
     CSSClassList = require('./css-class-list'),
     CSSStyleDeclaration = require('./css-style-declaration'),
-    entityDeclaration = /<!ENTITY\s+(\S+)\s+(?:'([^']+)'|"([^"]+)")\s*>/g;
+    entityDeclaration = /<!ENTITY\s+(\S+)\s+(?:'([^']+)'|"([^"]+)")\s*>/g,
+    textElems = require('../../plugins/_collections.js').textElems;
 
 var config = {
     strict: true,
     trim: false,
-    normalize: true,
+    normalize: false,
     lowercase: true,
     xmlns: true,
     position: true
@@ -115,8 +116,8 @@ module.exports = function(data) {
         elem = pushToContent(elem);
         current = elem;
 
-        // Save info about <text> tag to prevent trimming of meaningful whitespace
-        if (data.name == 'text' && !data.prefix) {
+        // Save info about tags containing text to prevent trimming of meaningful whitespace
+        if (textElems.indexOf(data.name) !== -1 && !data.prefix) {
             textContext = current;
         }
 
@@ -143,9 +144,7 @@ module.exports = function(data) {
 
         var last = stack.pop();
 
-        // Trim text inside <text> tag.
         if (last == textContext) {
-            trim(textContext);
             textContext = null;
         }
         current = stack[stack.length - 1];
@@ -166,22 +165,6 @@ module.exports = function(data) {
         return root;
     } catch (e) {
         return { error: e.message };
-    }
-
-    function trim(elem) {
-        if (!elem.content) return elem;
-
-        var start = elem.content[0],
-            end = elem.content[elem.content.length - 1];
-
-        while (start && start.content && !start.text) start = start.content[0];
-        if (start && start.text) start.text = start.text.replace(/^\s+/, '');
-
-        while (end && end.content && !end.text) end = end.content[end.content.length - 1];
-        if (end && end.text) end.text = end.text.replace(/\s+$/, '');
-
-        return elem;
-
     }
 
 };

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -15,6 +15,8 @@ exports.elemsGroups = {
     filterPrimitive: ['feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite', 'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap', 'feFlood', 'feGaussianBlur', 'feImage', 'feMerge', 'feMorphology', 'feOffset', 'feSpecularLighting', 'feTile', 'feTurbulence']
 };
 
+exports.textElems = exports.elemsGroups.textContent.concat('title');
+
 exports.pathElems = ['path', 'glyph', 'missing-glyph'];
 
 // http://www.w3.org/TR/SVG11/intro.html#Definitions

--- a/test/plugins/cleanupIDs.09.svg
+++ b/test/plugins/cleanupIDs.09.svg
@@ -11,7 +11,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
     <style>
-        svg .hidden { display: none; } svg .hidden:target { display: inline; }
+        svg .hidden { display: none; }
+        svg .hidden:target { display: inline; }
     </style>
     <circle id="circle" class="hidden" fill="red" cx="60" cy="60" r="50"/>
     <rect id="rect" class="hidden" fill="blue" x="10" y="10" width="100" height="100"/>

--- a/test/plugins/cleanupIDs.10.svg
+++ b/test/plugins/cleanupIDs.10.svg
@@ -17,7 +17,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
     <style>
-        svg .hidden { display: none; } svg .hidden:target { display: inline; }
+        svg .hidden { display: none; }
+        svg .hidden:target { display: inline; }
     </style>
     <defs>
         <circle id="a" fill="red" cx="60" cy="60" r="50"/>

--- a/test/plugins/cleanupIDs.13.svg
+++ b/test/plugins/cleanupIDs.13.svg
@@ -11,7 +11,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
     <style>
-        svg .hidden { display: none; } svg .hidden:target { display: inline; }
+        svg .hidden { display: none; }
+        svg .hidden:target { display: inline; }
     </style>
     <circle id="pre1_circle" class="hidden" fill="red" cx="60" cy="60" r="50"/>
     <rect id="pre2_rect" class="hidden" fill="blue" x="10" y="10" width="100" height="100"/>

--- a/test/plugins/cleanupIDs.14.svg
+++ b/test/plugins/cleanupIDs.14.svg
@@ -17,7 +17,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
     <style>
-        svg .hidden { display: none; } svg .hidden:target { display: inline; }
+        svg .hidden { display: none; }
+        svg .hidden:target { display: inline; }
     </style>
     <defs>
         <circle id="a" fill="red" cx="60" cy="60" r="50"/>

--- a/test/plugins/collapseGroups.13.svg
+++ b/test/plugins/collapseGroups.13.svg
@@ -15,7 +15,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg">
     <style>
-        .n{display:none} .i{display:inline}
+        .n{display:none}
+        .i{display:inline}
     </style>
     <g class="i" id="a"/>
     <g id="b" class="n">

--- a/test/plugins/inlineStyles.13.svg
+++ b/test/plugins/inlineStyles.13.svg
@@ -12,9 +12,7 @@
             /* Atrules with block */
             @font-face {
                 font-family: SomeFont;
-                src: local("Some Font"),
-                local("SomeFont"),
-                url(SomeFont.ttf);
+                src: local("Some Font"), local("SomeFont"), url(SomeFont.ttf);
                 font-weight: bold;
             }
 

--- a/test/plugins/inlineStyles.16.svg
+++ b/test/plugins/inlineStyles.16.svg
@@ -25,9 +25,7 @@
 @@@
 
 <svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 222 57.28">
-    <title>
-        button
-    </title>
+    <title>button</title>
     <rect width="222" height="57.28" rx="28.64" ry="28.64" style="stroke:red;fill:#37d0cd"/>
     <path d="M312.75,168.66A2.15,2.15,0,0,1,311.2,165L316,160l-4.8-5a2.15,2.15,0,1,1,3.1-3l6.21,6.49a2.15,2.15,0,0,1,0,3L314.31,168a2.14,2.14,0,0,1-1.56.67Zm0,0" transform="translate(-119 -131.36)" style="fill:#fff"/>
     <circle cx="33.5" cy="27.25" r="2.94" style="fill:#fff"/>

--- a/test/svg2js/_index.js
+++ b/test/svg2js/_index.js
@@ -177,6 +177,15 @@ describe('svg2js', function() {
 
         });
 
+        describe('text nodes', function() {
+
+            it('should contain preserved whitespace', function() {
+                const textNode = root.content[3].content[1].content[0].content[1];
+                return expect(textNode.content[0].text).to.equal('  test  ');
+            });
+
+        });
+
         describe('API', function() {
 
             describe('clone()', function() {

--- a/test/svg2js/test.svg
+++ b/test/svg2js/test.svg
@@ -12,7 +12,7 @@
     <g>
         <g>
             <circle fill="#ff0000" cx="60px" cy="60px" r="50px"/>
-            <text>test</text>
+            <text>  test  </text>
         </g>
     </g>
     <g style="color: black" class="unknown-class"></g>


### PR DESCRIPTION
### Problem

SVGO configures its SAX parser to normalize whitespace, [collapsing multiple space characters into one](https://github.com/isaacs/sax-js/blob/5aee2163d55cff24b817bbf550bac44841f9df45/lib/sax.js#L640). 

This can change the semantic meaning of SVG content:

- In `<text>` and `<tspan>` nodes when whitespace is being preserved (e.g. `xml:space="preserve"` or `style="white-space: pre"`).
- In `<text>` and `<tspan>` nodes where [glyphs are spaced explicitly using multiple `x` values](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x#tspan). Changing the number of characters in the node changes the indexes of characters (see https://github.com/svg/svgo/issues/1044).

### Solution

This patch disables space normalization in `sax`. It removes trimming for node names classified as "textContent" in `_collections.js`. In addition, it changes the pretty printing logic to not add indents or whitespace when outputting such nodes.

I needed to update a few text fixtures which captured the previous space normalizing behavior. Existing plugin tests have a mixture of text nodes containing and not containing extra whitespace, so they cover the change in functionality. I've also added a test to `svg2js` to verify that the whitespace is preserved when parsing SVGs.

### Related issues
- https://github.com/svg/svgo/issues/634
- https://github.com/svg/svgo/issues/1044
- https://github.com/svg/svgo/issues/1067