### PR TITLE
Add skip parameter to convert colors plugin

### DIFF
--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -11,7 +11,8 @@ exports.params = {
     names2hex: true,
     rgb2hex: true,
     shorthex: true,
-    shortname: true
+    shortname: true,
+    skip: []
 };
 
 var collections = require('./_collections'),
@@ -54,6 +55,10 @@ exports.fn = function(item, params) {
         item.eachAttr(function(attr) {
 
             if (collections.colorsProps.indexOf(attr.name) > -1) {
+
+                if (params.skip && params.skip.includes(attr.value)) {
+                    return;
+                }
 
                 var val = attr.value,
                     match;

--- a/test/config/_index.js
+++ b/test/config/_index.js
@@ -84,6 +84,9 @@ describe('config', function() {
                 return convertColors.params.should.have.property('rgb2hex', true);
             });
 
+            it('"params" should have property "skip" with value of []', function() {
+                return convertColors.params.should.have.property('skip', []);
+            });
         });
 
     });


### PR DESCRIPTION
Add skip parameter to convert colours plugin to skip attribute values you do not want to convert or optimise.