### PR TITLE
Prevent infinite applications of prefix

### DIFF
--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -177,9 +177,14 @@ exports.fn = function(node, opts, extra) {
 
     // prefixes a normal value
     addPrefix = function(name) {
-        if(prefix === false){
+        var isAlreadyPrefixed = name.startsWith(
+            escapeIdentifierName(prefix) + opts.delim
+        );
+
+        if (prefix === false || isAlreadyPrefixed) {
             return escapeIdentifierName(name);
         }
+
         return escapeIdentifierName(prefix + opts.delim + name);
     };
 

--- a/test/plugins/prefixIds.11.svg
+++ b/test/plugins/prefixIds.11.svg
@@ -1,0 +1,15 @@
+<g xmlns="http://www.w3.org/2000/svg" transform="translate(130, 112)">
+    <path class="prefixIds_11_svg__st1" d="M27,0h-37v64C-10,64,27,64.2,27,0z" transform="scale(0.811377 1)">
+    <animateTransform id="prefixIds_11_svg__t_1s" attributeName="transform" type="scale" from="1 1" to="-1 1" begin="0s; prefixIds_11_svg__t_2s.end" dur="0.5s" repeatCount="0"/>
+    <animateTransform id="prefixIds_11_svg__t_2s" attributeName="transform" type="scale" from="-1 1" to="1 1" begin="prefixIds_11_svg__t_1s.end" dur="0.5s" repeatCount="0"/>
+    </path>
+</g>
+
+@@@
+
+<g xmlns="http://www.w3.org/2000/svg" transform="translate(130, 112)">
+    <path class="prefixIds_11_svg__st1" d="M27,0h-37v64C-10,64,27,64.2,27,0z" transform="scale(0.811377 1)">
+        <animateTransform id="prefixIds_11_svg__t_1s" attributeName="transform" type="scale" from="1 1" to="-1 1" begin="0s; prefixIds_11_svg__t_2s.end" dur="0.5s" repeatCount="0"/>
+        <animateTransform id="prefixIds_11_svg__t_2s" attributeName="transform" type="scale" from="-1 1" to="1 1" begin="prefixIds_11_svg__t_1s.end" dur="0.5s" repeatCount="0"/>
+    </path>
+</g>


### PR DESCRIPTION
Closes #1133

Right now, if I run SVGO over the same file multiple times, the IDs keeps on being prefixed over and over. 