### PR TITLE
FIX: convertStyleToAttrs: regexp string escaping for `Important rule`

### DIFF
--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -29,7 +29,7 @@ var stylingProps = require('./_collections').attrsGroups.presentation,
     rDeclEnd = '\\s*(?:;\\s*|$)',
 
     // Important rule
-    rImportant = '(\\s*!important(?![-(\w]))?',
+    rImportant = '(\\s*!important(?![-(\\w]))?',
 
     // Final RegExp to parse CSS declarations.
     regDeclarationBlock = new RegExp(rAttr + ':' + rValue + rImportant + rDeclEnd, 'ig'),


### PR DESCRIPTION
so the resulting regexp will change from:
`/(\s*!important(?![-(w]))?/`
to:
`/(\s*!important(?![-(\w]))?/`