### PR TITLE
FIX: inlineStyles: mute `Error` from `css-what@3`

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -109,7 +109,7 @@ exports.fn = function(document, opts) {
         try {
             selectedEls = document.querySelectorAll(selectorStr);
         } catch (selectError) {
-            if (selectError.constructor === SyntaxError) {
+            if (selectError.message.includes('Unmatched selector:')) {
                 // console.warn('Warning: Syntax error when trying to select \n\n' + selectorStr + '\n\n, skipped. Error details: ' + selectError);
                 continue;
             }


### PR DESCRIPTION
The `Error` constructor changed in `css-what@3` during the conversion to TypeScript
before: https://github.com/fb55/css-what/blob/fd6de7c1e9c296ab2147eef8790ef8d9980115c0/index.js#L85
after: https://github.com/fb55/css-what/blob/89959c8a7f90358c2218d0a704c4898d7066d857/src/parse.ts#L133

with `"css-select": "^2.0.0"` you'll get the lastest `css-what@3` if you delete `package.lock` and `node_module` then do a `npm install`