### PR TITLE
FIX: test: usage of `should` & drop extra `return`

### DIFF
--- a/test/config/_index.js
+++ b/test/config/_index.js
@@ -39,29 +39,29 @@ describe('config', function() {
             removeRasterImages = getPlugin('removeRasterImages', config.plugins);
 
         it('should have "multipass"', function() {
-            return config.multipass.should.be.true;
+            config.multipass.should.be.true();
         });
 
         it('removeDoctype plugin should be disabled', function() {
-            return removeDoctype.active.should.be.false;
+            removeDoctype.active.should.be.false();
         });
 
         describe('enable plugin with params object', function() {
 
             it('removeRasterImages plugin should be enabled', function() {
-                return removeRasterImages.active.should.be.true;
+                removeRasterImages.active.should.be.true();
             });
 
             it('removeRasterImages plugin should have property "params"', function() {
-                return removeRasterImages.should.have.property('params');
+                removeRasterImages.should.have.property('params');
             });
 
             it('"params" should be an instance of Object', function() {
-                return removeRasterImages.params.should.be.an.instanceOf(Object);
+                removeRasterImages.params.should.be.an.instanceOf(Object);
             });
 
             it('"params" should have property "param" with value of true', function() {
-                return removeRasterImages.params.should.have.property('param', true);
+                removeRasterImages.params.should.have.property('param', true);
             });
 
         });
@@ -69,19 +69,19 @@ describe('config', function() {
         describe('extend plugin params with object', function() {
 
             it('convertColors plugin should have property "params"', function() {
-                return convertColors.should.have.property('params');
+                convertColors.should.have.property('params');
             });
 
             it('"params" should be an instance of Object', function() {
-                return convertColors.params.should.be.an.instanceOf(Object);
+                convertColors.params.should.be.an.instanceOf(Object);
             });
 
             it('"params" should have property "shorthex" with value of false', function() {
-                return convertColors.params.should.have.property('shorthex', false);
+                convertColors.params.should.have.property('shorthex', false);
             });
 
             it('"params" should have property "rgb2hex" with value of true', function() {
-                return convertColors.params.should.have.property('rgb2hex', true);
+                convertColors.params.should.have.property('rgb2hex', true);
             });
 
         });
@@ -101,19 +101,19 @@ describe('config', function() {
             cleanupNumericValues = getPlugin('cleanupNumericValues', config.plugins);
 
         it('should have "multipass"', function() {
-            return config.multipass.should.be.true;
+            config.multipass.should.be.true();
         });
 
         it('config.plugins should have length 1', function() {
-            return config.plugins.should.have.length(1);
+            config.plugins.should.have.length(1);
         });
 
         it('cleanupNumericValues plugin should be enabled', function() {
-            return cleanupNumericValues.active.should.be.true;
+            cleanupNumericValues.active.should.be.true();
         });
 
         it('cleanupNumericValues plugin should have floatPrecision set from parameters', function() {
-            return cleanupNumericValues.params.floatPrecision.should.be.equal(2);
+            cleanupNumericValues.params.floatPrecision.should.be.equal(2);
         });
 
     });
@@ -135,11 +135,11 @@ describe('config', function() {
                 customPlugin = getPlugin('aCustomPlugin', config.plugins);
 
             it('custom plugin should be enabled', function() {
-                return customPlugin.active.should.be.true;
+                customPlugin.active.should.be.true();
             });
 
             it('custom plugin should have been given a name', function() {
-                return customPlugin.name.should.equal('aCustomPlugin');
+                customPlugin.name.should.equal('aCustomPlugin');
             });
         });
 
@@ -159,15 +159,15 @@ describe('config', function() {
                 customPlugin = getPlugin('aCustomPlugin', config.plugins);
 
             it('config.plugins should have length 1', function() {
-                return config.plugins.should.have.length(1);
+                config.plugins.should.have.length(1);
             });
 
             it('custom plugin should be enabled', function() {
-                return customPlugin.active.should.be.true;
+                customPlugin.active.should.be.true();
             });
 
             it('custom plugin should have been given a name', function() {
-                return customPlugin.name.should.equal('aCustomPlugin');
+                customPlugin.name.should.equal('aCustomPlugin');
             });
 
         });

--- a/test/jsapi/_index.js
+++ b/test/jsapi/_index.js
@@ -12,7 +12,7 @@ describe('svgo object', function() {
 
     it('should has createContentItem method', function() {
         var svgo = new SVGO();
-        svgo.createContentItem.should.be.a.Function;
+        svgo.createContentItem.should.be.a.Function();
     });
 
     it('should be able to create content item', function() {
@@ -34,7 +34,7 @@ describe('svgo object', function() {
         var item = svgo.createContentItem();
 
         item.should.be.instanceof(JSAPI);
-        item.should.be.empty;
+        item.should.be.empty();
     });
 
     it('should have ES module interop default property', function() {

--- a/test/svg2js/_index.js
+++ b/test/svg2js/_index.js
@@ -41,15 +41,15 @@ describe('svg2js', function() {
         describe('root', function() {
 
             it('should exist', function() {
-                return root.should.exist;
+                SHOULD.exist(root);
             });
 
             it('should be an instance of Object', function() {
-                return root.should.be.an.instanceOf(Object);
+                root.should.be.an.instanceOf(Object);
             });
 
             it('should have property "content"', function() {
-                return root.should.have.property('content');
+                root.should.have.property('content');
             });
 
         });
@@ -57,11 +57,11 @@ describe('svg2js', function() {
         describe('root.content', function() {
 
             it('should be an instance of Array', function() {
-                return root.content.should.be.an.instanceOf(Array);
+                root.content.should.be.an.instanceOf(Array);
             });
 
             it('should have length 4', function() {
-                return root.content.should.have.lengthOf(4);
+                root.content.should.have.lengthOf(4);
             });
 
         });
@@ -69,19 +69,19 @@ describe('svg2js', function() {
         describe('root.content[0].processinginstruction', function() {
 
             it('should exist', function() {
-                return root.content[0].processinginstruction.should.exist;
+                SHOULD.exist(root.content[0].processinginstruction);
             });
 
             it('should be an instance of Object', function() {
-                return root.content[0].processinginstruction.should.be.an.instanceOf(Object);
+                root.content[0].processinginstruction.should.be.an.instanceOf(Object);
             });
 
             it('should have property "name" with value "xml"', function() {
-                return root.content[0].processinginstruction.should.have.property('name', 'xml');
+                root.content[0].processinginstruction.should.have.property('name', 'xml');
             });
 
             it('should have property "body" with value "version=\"1.0\" encoding=\"utf-8\""', function() {
-                return root.content[0].processinginstruction.should.have.property('body', 'version=\"1.0\" encoding=\"utf-8\"');
+                root.content[0].processinginstruction.should.have.property('body', 'version=\"1.0\" encoding=\"utf-8\"');
             });
 
         });
@@ -89,11 +89,11 @@ describe('svg2js', function() {
         describe('root.content[1].comment', function() {
 
             it('should exist', function() {
-                return root.content[1].comment.should.exist;
+                SHOULD.exist(root.content[1].comment);
             });
 
             it('should equal "Generator: Adobe Illustrator…"', function() {
-                return root.content[1].comment.should.equal('Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)');
+                root.content[1].comment.should.equal('Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)');
             });
 
         });
@@ -101,11 +101,11 @@ describe('svg2js', function() {
         describe('root.content[2].doctype', function() {
 
             it('should exist', function() {
-                return root.content[2].doctype.should.exist;
+                SHOULD.exist(root.content[2].doctype);
             });
 
             it('should eventually equal " svg PUBLIC…"', function() {
-                return root.content[2].doctype.should.equal(' svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\"');
+                root.content[2].doctype.should.equal(' svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\"');
             });
 
         });
@@ -113,15 +113,15 @@ describe('svg2js', function() {
         describe('elem', function() {
 
             it('should have property elem: "svg"', function() {
-                return root.content[3].should.have.property('elem', 'svg');
+                root.content[3].should.have.property('elem', 'svg');
             });
 
             it('should have property prefix: ""', function() {
-                return root.content[3].should.have.property('prefix', '');
+                root.content[3].should.have.property('prefix', '');
             });
 
             it('should have property local: "svg"', function() {
-                return root.content[3].should.have.property('local', 'svg');
+                root.content[3].should.have.property('local', 'svg');
             });
 
         });
@@ -131,11 +131,11 @@ describe('svg2js', function() {
             describe('root.content[3].attrs', function() {
 
                 it('should exist', function() {
-                    return root.content[3].attrs.should.exist;
+                    SHOULD.exist(root.content[3].attrs);
                 });
 
                 it('should be an instance of Object', function() {
-                    return root.content[3].attrs.should.be.an.instanceOf(Object);
+                    root.content[3].attrs.should.be.an.instanceOf(Object);
                 });
 
             });
@@ -143,27 +143,27 @@ describe('svg2js', function() {
             describe('root.content[3].attrs.version', function() {
 
                 it('should exist', function() {
-                    return root.content[3].attrs.version.should.exist;
+                    SHOULD.exist(root.content[3].attrs.version);
                 });
 
                 it('should be an instance of Object', function() {
-                    return root.content[3].attrs.version.should.be.an.instanceOf(Object);
+                    root.content[3].attrs.version.should.be.an.instanceOf(Object);
                 });
 
                 it('should have property name: "version"', function() {
-                    return root.content[3].attrs.version.should.have.property('name', 'version');
+                    root.content[3].attrs.version.should.have.property('name', 'version');
                 });
 
                 it('should have property value: "1.1"', function() {
-                    return root.content[3].attrs.version.should.have.property('value', '1.1');
+                    root.content[3].attrs.version.should.have.property('value', '1.1');
                 });
 
                 it('should have property prefix: ""', function() {
-                    return root.content[3].attrs.version.should.have.property('prefix', '');
+                    root.content[3].attrs.version.should.have.property('prefix', '');
                 });
 
                 it('should have property local: "version"', function() {
-                    return root.content[3].attrs.version.should.have.property('local', 'version');
+                    root.content[3].attrs.version.should.have.property('local', 'version');
                 });
 
             });
@@ -173,15 +173,15 @@ describe('svg2js', function() {
         describe('content', function() {
 
             it('should exist', function() {
-                return root.content[3].content.should.exist;
+                SHOULD.exist(root.content[3].content);
             });
 
             it('should be an instance of Array', function() {
-                return root.content[3].content.should.be.an.instanceOf(Array);
+                root.content[3].content.should.be.an.instanceOf(Array);
             });
 
             it('should eventually have length 3', function() {
-                return root.content[3].content.should.have.lengthOf(3);
+                root.content[3].content.should.have.lengthOf(3);
             });
 
         });
@@ -191,19 +191,19 @@ describe('svg2js', function() {
             describe('clone()', function() {
 
                 it('svg should have property "clone"', function() {
-                    return root.content[3].should.have.property('clone');
+                    root.content[3].should.have.property('clone');
                 });
 
                 it('svg.clone() should be an instance of JSAPI', function() {
-                    return root.content[3].clone().should.be.instanceOf(JSAPI);
+                    root.content[3].clone().should.be.instanceOf(JSAPI);
                 });
 
                 it('root.content[3].content[0].clone() has a valid style property', function() {
-                    return root.content[3].content[0].clone().style.should.be.instanceof(CSSStyleDeclaration);
+                    root.content[3].content[0].clone().style.should.be.instanceof(CSSStyleDeclaration);
                 });
 
                 it('root.content[3].content[2].clone() has a valid class property', function() {
-                    return root.content[3].content[2].clone().class.should.be.instanceof(CSSClassList);
+                    root.content[3].content[2].clone().class.should.be.instanceof(CSSClassList);
                 });
 
             });
@@ -211,23 +211,23 @@ describe('svg2js', function() {
             describe('isElem()', function() {
 
                 it('svg should have property "isElem"', function() {
-                    return root.content[3].should.have.property('isElem');
+                    root.content[3].should.have.property('isElem');
                 });
 
                 it('svg.isElem() should be true', function() {
-                    return root.content[3].isElem().should.be.true;
+                    root.content[3].isElem().should.be.true();
                 });
 
                 it('svg.isElem("svg") should be true', function() {
-                    return root.content[3].isElem('svg').should.be.true;
+                    root.content[3].isElem('svg').should.be.true();
                 });
 
                 it('svg.isElem("trololo") should be false', function() {
-                    return root.content[3].isElem('trololo').should.be.false;
+                    root.content[3].isElem('trololo').should.be.false();
                 });
 
                 it('svg.isElem(["svg", "trololo"]) should be true', function() {
-                    return root.content[3].isElem(['svg', 'trololo']).should.be.true;
+                    root.content[3].isElem(['svg', 'trololo']).should.be.true();
                 });
 
             });
@@ -235,15 +235,15 @@ describe('svg2js', function() {
             describe('isEmpty()', function() {
 
                 it('svg should have property "isEmpty"', function() {
-                    return root.content[3].should.have.property('isEmpty');
+                    root.content[3].should.have.property('isEmpty');
                 });
 
                 it('svg.isEmpty() should be false', function() {
-                    return root.content[3].isEmpty().should.be.false;
+                    root.content[3].isEmpty().should.be.false();
                 });
 
                 it('svg.content[0].content[0].isEmpty() should be true', function() {
-                    return root.content[3].content[0].content[0].isEmpty().should.be.true;
+                    root.content[3].content[0].content[0].isEmpty().should.be.true();
                 });
 
             });
@@ -251,31 +251,31 @@ describe('svg2js', function() {
             describe('hasAttr()', function() {
 
                 it('svg should have property "hasAttr"', function() {
-                    return root.content[3].should.have.property('hasAttr');
+                    root.content[3].should.have.property('hasAttr');
                 });
 
                 it('svg.hasAttr() should be true', function() {
-                    return root.content[3].hasAttr().should.be.true;
+                    root.content[3].hasAttr().should.be.true();
                 });
 
                 it('svg.hasAttr("xmlns") should be true', function() {
-                    return root.content[3].hasAttr('xmlns').should.be.true;
+                    root.content[3].hasAttr('xmlns').should.be.true();
                 });
 
                 it('svg.hasAttr("xmlns", "http://www.w3.org/2000/svg") should be true', function() {
-                    return root.content[3].hasAttr('xmlns', 'http://www.w3.org/2000/svg').should.be.true;
+                    root.content[3].hasAttr('xmlns', 'http://www.w3.org/2000/svg').should.be.true();
                 });
 
                 it('svg.hasAttr("xmlns", "trololo") should be false', function() {
-                    return root.content[3].hasAttr('xmlns', 'trololo').should.be.false;
+                    root.content[3].hasAttr('xmlns', 'trololo').should.be.false();
                 });
 
                 it('svg.hasAttr("trololo") should be false', function() {
-                    return root.content[3].hasAttr('trololo').should.be.false;
+                    root.content[3].hasAttr('trololo').should.be.false();
                 });
 
                 it('svg.content[1].hasAttr() should be false', function() {
-                    return root.content[3].content[1].hasAttr().should.be.false;
+                    root.content[3].content[1].hasAttr().should.be.false();
                 });
 
             });
@@ -283,27 +283,27 @@ describe('svg2js', function() {
             describe('attr()', function() {
 
                 it('svg should have property "attr"', function() {
-                    return root.content[3].should.have.property('attr');
+                    root.content[3].should.have.property('attr');
                 });
 
                 it('svg.attr("xmlns") should be an instance of Object', function() {
-                    return root.content[3].attr('xmlns').should.be.an.instanceOf(Object);
+                    root.content[3].attr('xmlns').should.be.an.instanceOf(Object);
                 });
 
                 it('svg.attr("xmlns", "http://www.w3.org/2000/svg") should be an instance of Object', function() {
-                    return root.content[3].attr('xmlns', 'http://www.w3.org/2000/svg').should.be.an.instanceOf(Object);
+                    root.content[3].attr('xmlns', 'http://www.w3.org/2000/svg').should.be.an.instanceOf(Object);
                 });
 
                 it('svg.attr("xmlns", "trololo") should be an undefined', function() {
-                    return SHOULD.not.exist(root.content[3].attr('xmlns', 'trololo'));
+                    SHOULD.not.exist(root.content[3].attr('xmlns', 'trololo'));
                 });
 
                 it('svg.attr("trololo") should be an undefined', function() {
-                    return SHOULD.not.exist(root.content[3].attr('trololo'));
+                    SHOULD.not.exist(root.content[3].attr('trololo'));
                 });
 
                 it('svg.attr() should be undefined', function() {
-                    return SHOULD.not.exist(root.content[3].attr());
+                    SHOULD.not.exist(root.content[3].attr());
                 });
 
             });
@@ -311,33 +311,33 @@ describe('svg2js', function() {
             describe('removeAttr()', function() {
 
                 it('svg should have property "removeAttr"', function() {
-                    return root.content[3].should.have.property('removeAttr');
+                    root.content[3].should.have.property('removeAttr');
                 });
 
                 it('svg.removeAttr("width") should be true', function() {
-                    root.content[3].removeAttr('width').should.be.true;
+                    root.content[3].removeAttr('width').should.be.true();
 
-                    return root.content[3].hasAttr('width').should.be.false;
+                    root.content[3].hasAttr('width').should.be.false();
                 });
 
                 it('svg.removeAttr("height", "120px") should be true', function() {
-                    root.content[3].removeAttr('height', '120px').should.be.true;
+                    root.content[3].removeAttr('height', '120px').should.be.true();
 
-                    return root.content[3].hasAttr('height').should.be.false;
+                    root.content[3].hasAttr('height').should.be.false();
                 });
 
                 it('svg.removeAttr("x", "1px") should be false', function() {
-                    root.content[3].removeAttr('x', '1px').should.be.false;
+                    root.content[3].removeAttr('x', '1px').should.be.false();
 
-                    return root.content[3].hasAttr('x').should.be.true;
+                    root.content[3].hasAttr('x').should.be.true();
                 });
 
                 it('svg.removeAttr("z") should be false', function() {
-                    return root.content[3].removeAttr('z').should.be.false;
+                    root.content[3].removeAttr('z').should.be.false();
                 });
 
                 it('svg.removeAttr() should be false', function() {
-                    return root.content[3].removeAttr().should.be.false;
+                    root.content[3].removeAttr().should.be.false();
                 });
 
             });
@@ -352,35 +352,35 @@ describe('svg2js', function() {
                 };
 
                 it('svg should have property "addAttr"', function() {
-                    return root.content[3].should.have.property('addAttr');
+                    root.content[3].should.have.property('addAttr');
                 });
 
                 it('svg.addAttr(attr) should be an instance of Object', function() {
-                    return root.content[3].addAttr(attr).should.be.an.instanceOf(Object);
+                    root.content[3].addAttr(attr).should.be.an.instanceOf(Object);
                 });
 
                 it('svg.content[1].content[0].addAttr(attr) should be an instance of Object', function() {
-                    return root.content[3].content[1].content[0].addAttr(attr).should.be.an.instanceOf(Object);
+                    root.content[3].content[1].content[0].addAttr(attr).should.be.an.instanceOf(Object);
                 });
 
                 it('svg.addAttr({ name: "trololo" }) should be false', function() {
-                    return root.content[3].addAttr({ name: 'trololo' }).should.be.false;
+                    root.content[3].addAttr({ name: 'trololo' }).should.be.false();
                 });
 
                 it('svg.addAttr({ name: "trololo", value: 3 }) should be false', function() {
-                    return root.content[3].addAttr({ name: 'trololo', value: 3 }).should.be.false;
+                    root.content[3].addAttr({ name: 'trololo', value: 3 }).should.be.false();
                 });
 
                 it('svg.addAttr({ name: "trololo", value: 3, prefix: "" }) should be false', function() {
-                    return root.content[3].addAttr({ name: 'trololo', value: 3, prefix: '' }).should.be.false;
+                    root.content[3].addAttr({ name: 'trololo', value: 3, prefix: '' }).should.be.false();
                 });
 
                 it('svg.addAttr({ name: "trololo", value: 3, local: "trololo" }) should be false', function() {
-                    return root.content[3].addAttr({ name: 'trololo', value: 3, local: 'trololo' }).should.be.false;
+                    root.content[3].addAttr({ name: 'trololo', value: 3, local: 'trololo' }).should.be.false();
                 });
 
                 it('svg.addAttr() should be false', function() {
-                    return root.content[3].addAttr().should.be.false;
+                    root.content[3].addAttr().should.be.false();
                 });
 
             });
@@ -388,19 +388,19 @@ describe('svg2js', function() {
             describe('eachAttr()', function() {
 
                 it('svg should have property "eachAttr"', function() {
-                    return root.content[3].should.have.property('eachAttr');
+                    root.content[3].should.have.property('eachAttr');
                 });
 
                 it('svg.content[0].eachAttr(function() {}) should be true', function() {
                     root.content[3].content[0].eachAttr(function(attr) {
                         attr.test = 1;
-                    }).should.be.true;
+                    }).should.be.true();
 
-                    return root.content[3].content[0].attr('type').test.should.equal(1);
+                    root.content[3].content[0].attr('type').test.should.equal(1);
                 });
 
                 it('svg.content[1].eachAttr(function() {}) should be false', function() {
-                    return root.content[3].content[1].eachAttr().should.be.false;
+                    root.content[3].content[1].eachAttr().should.be.false();
                 });
 
             });
@@ -438,7 +438,7 @@ describe('svg2js', function() {
         describe('root', function() {
 
             it('should have property "error"', function() {
-                return root.should.have.property('error');
+                root.should.have.property('error');
             });
 
         });
@@ -446,11 +446,11 @@ describe('svg2js', function() {
         describe('root.error', function() {
 
             it('should be an instance of String', function() {
-                return root.error.should.an.instanceOf(String);
+                root.error.should.an.instanceOf(String);
             });
 
             it('should be "Error in parsing SVG: Unexpected close tag"', function() {
-                return root.error.should.equal('Error in parsing SVG: Unexpected close tag\nLine: 10\nColumn: 15\nChar: >');
+                root.error.should.equal('Error in parsing SVG: Unexpected close tag\nLine: 10\nColumn: 15\nChar: >');
             });
 
         });
@@ -458,7 +458,7 @@ describe('svg2js', function() {
         describe('error', function() {
 
             it('should not be thrown', function() {
-                return SHOULD.not.exist(error);
+                SHOULD.not.exist(error);
             });
 
         });
@@ -482,7 +482,7 @@ describe('svg2js', function() {
 
         describe('root', function() {
             it('should exist', function() {
-                return root.should.exist;
+                SHOULD.exist(root);
             });
 
             it('should have correctly parsed entities', function() {


### PR DESCRIPTION
simple test script:
```js
require('should')

try {
  console.log('\n# TEST "value.should.be.false" vs "value.should.be.false()"')
  const a = true
  console.log('assign')
  a.should.be.false // no effect
  console.log('pass 1')
  a.should.be.false() // check and throw error
  console.log('pass 2')
} catch (error) {
  console.log(`stopped with error: ${error}`)
}

try {
  console.log('\n# TEST "value.should.exist()"')
  const a = 1
  console.log('assign')
  a.should.exist() // result in no method error
  console.log('pass 1')
} catch (error) {
  console.log(`stopped with error: ${error}`)
}

try {
  console.log('\n# TEST "should.exist(value)"')
  should.exist(1) // check and pass
  console.log('pass 1')
  should.exist(undefined) // check and error
  console.log('pass 2')
} catch (error) {
  console.log(`stopped with error: ${error}`)
}
```