### PR TITLE
Null checkin strongRound

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -772,7 +772,7 @@ function getIntersection(coords) {
  */
 function strongRound(data) {
     for (var i = data.length; i-- > 0;) {
-        if (data[i].toFixed(precision) != data[i]) {
+        if (data[i] && data[i].toFixed(precision) != data[i]) {
             var rounded = +data[i].toFixed(precision - 1);
             data[i] = +Math.abs(rounded - data[i]).toFixed(precision + 1) >= error ?
                 +data[i].toFixed(precision) :


### PR DESCRIPTION
Build process failed when we updated `svgo` package, and on inspection we found that a null check was missing before parsing the floating number