### PR TITLE
Add the SVGO Action as an other way to use SVGO

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Arguments:
 ### Other Ways to Use SVGO
 
 * as a web app – [SVGOMG](https://jakearchibald.github.io/svgomg/)
+* as a GitHub Action – [SVGO Action](https://github.com/marketplace/actions/svgo-action)
 * as a Nodejs module – [examples](https://github.com/svg/svgo/tree/master/examples)
 * as a Grunt task – [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
 * as a Gulp task – [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin)


### PR DESCRIPTION
 I added (my) GitHub Action to run SVGO as a [GitHub Action](https://github.com/features/actions) to the README. Thought it might be useful to some.

I suppose the Russian REAMDE should also be updated, but I don't speak Russian so I didn't update it (I allowed edits from maintainters, so feel free to add it :slightly_smiling_face:)

If this is unwanted, feel free to close it. If the position of the item in the list is inappropriate, let me know and I'm happy to update it.