### PR TITLE
Add currentColor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ const config = await loadConfig(configFile, cwd);
 | [removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js)                         | remove `<style>` elements                                                                                                                                | `disabled` |
 | [removeScriptElement](https://github.com/svg/svgo/blob/master/plugins/removeScriptElement.js)                       | remove `<script>` elements                                                                                                                               | `disabled` |
 | [reusePaths](https://github.com/svg/svgo/blob/master/plugins/reusePaths.js)                                         | Find duplicated <path> elements and replace them with <use> links                                                                                        | `disabled` |
+| [currentColor](https://github.com/svg/svgo/blob/master/plugins/currentColor.js)                                     | set `currentColor` for `color`, `fill` and `stroke` attributes for redefine ability from CSS                                                             | `disabled` |
 
 ## Other Ways to Use SVGO
 

--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -53,6 +53,7 @@ const pluginsOrder = [
   'addAttributesToSVGElement',
   'removeOffCanvasPaths',
   'reusePaths',
+  'currentColor',
 ];
 const defaultPlugins = pluginsOrder.filter((name) => pluginsMap[name].active);
 exports.defaultPlugins = defaultPlugins;

--- a/plugins/currentColor.js
+++ b/plugins/currentColor.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports.type = 'perItem'
+
+exports.active = false
+
+exports.description = 'change fill and stroke attributes to "currentColor"'
+
+/**
+ * Replace values in fill and stroke attributes to "currentColor"
+ * for redefine ability from CSS
+ * Replacing works in cases, when attribute value is not equal to
+ * "none"
+ *
+ * @param {Object} item current iteration item
+ *
+ * @author Konstantin Epishev
+ */
+exports.fn = function (item) {
+    if (!item.isElem()) return
+    if (!item.hasAttr('stroke') && !item.hasAttr('fill') && !item.hasAttr('color')) return
+
+    item.eachAttr(function(attr) {
+        var name = attr.name
+        var value = attr.value
+        var isColorAttr = name === 'stroke' || name === 'fill' || name === 'color'
+
+        if (!isColorAttr || value === 'none') return
+
+        item.attr(name).value = 'currentColor'
+    })
+};

--- a/plugins/plugins.js
+++ b/plugins/plugins.js
@@ -18,6 +18,7 @@ exports.convertPathData = require('./convertPathData.js');
 exports.convertShapeToPath = require('./convertShapeToPath.js');
 exports.convertStyleToAttrs = require('./convertStyleToAttrs.js');
 exports.convertTransform = require('./convertTransform.js');
+exports.currentColor = require('./currentColor')
 exports.mergeStyles = require('./mergeStyles.js');
 exports.inlineStyles = require('./inlineStyles.js');
 exports.mergePaths = require('./mergePaths.js');

--- a/test/plugins/currentColor.01.svg
+++ b/test/plugins/currentColor.01.svg
@@ -1,0 +1,19 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path stroke="#1F273B"/>
+    <path fill="rgb(255, 255, 255)"/>
+    <g>
+        <path stroke="red"/>
+        <path fill="none"/>
+    </g>
+</svg>
+
+@@@
+
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path stroke="currentColor"/>
+    <path fill="currentColor"/>
+    <g>
+        <path stroke="currentColor"/>
+        <path fill="none"/>
+    </g>
+</svg>


### PR DESCRIPTION
Hello! 
I'm always working with monochrome icons, but in some cases I have really a lot of icons and want to change their `stroke` and `fill` from css. For that, I need to replace all values with `currentColor`  value. This do it pretty simple and fast. Except case - when attribute has value `none`, plugin will skip this attribute.