### PR TITLE
Implement hex truncation.

### DIFF
--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -11,7 +11,8 @@ exports.params = {
     names2hex: true,
     rgb2hex: true,
     shorthex: true,
-    shortname: true
+    shortname: true,
+    truncatehex: false
 };
 
 var collections = require('./_collections'),
@@ -19,6 +20,7 @@ var collections = require('./_collections'),
     rComma = '\\s*,\\s*',
     regRGB = new RegExp('^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$'),
     regHEX = /^\#(([a-fA-F0-9])\2){3}$/,
+    truncatableRegHEX = /^\#(?:([a-fA-F0-9])[a-fA-F0-9]){3}$/,
     none = /\bnone\b/i;
 
 /**
@@ -90,7 +92,7 @@ exports.fn = function(item, params) {
                 }
 
                 // Convert long hex to short hex
-                if (params.shorthex && (match = val.match(regHEX))) {
+                if (params.shorthex && (match = val.match(params.truncatehex ? truncatableRegHEX : regHEX))) {
                     val = '#' + match[0][1] + match[0][3] + match[0][5];
                 }
 

--- a/test/plugins/convertColors.05.svg
+++ b/test/plugins/convertColors.05.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="black"/>
+    <g color="BLACK"/>
+    <path fill="rgb(64, 64, 64)"/>
+    <path fill="rgb(86.27451%,86.666667%,87.058824%)"/>
+    <path fill="rgb(-255,100,500)"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g color="#000"/>
+    <g color="#000"/>
+    <path fill="#444"/>
+    <path fill="#DDD"/>
+    <path fill="#06F"/>
+</svg>
+
+@@@
+
+{ "truncatehex": true }


### PR DESCRIPTION
This adds a flag to the convertColors plugin which is off by default which drops every second character in a 6-character hex color.  In a lot of cases 12bpp is enough and this can make a dent in file size.

Should help with #1247 and #763.