### PR TITLE
Add plugin multiCollapseGroups

### DIFF
--- a/plugins/multiCollapseGroups.js
+++ b/plugins/multiCollapseGroups.js
@@ -1,0 +1,96 @@
+'use strict';
+
+exports.type = 'perItemReverse';
+
+exports.active = true;
+
+exports.description = 'collapses useless groups';
+
+var collections = require('./_collections'),
+    attrsInheritable = collections.inheritableAttrs,
+    animationElems = collections.elemsGroups.animation;
+
+function hasAnimatedAttr(item) {
+    /* jshint validthis:true */
+    return item.isElem(animationElems) && item.hasAttr('attributeName', this) ||
+        !item.isEmpty() && item.content.some(hasAnimatedAttr, this);
+}
+
+/*
+ * Collapse useless groups.
+ *
+ * @example
+ * <g>
+ *     <g attr1="val1">
+ *         <path d="..."/>
+ *         <path d="..."/>
+ *     </g>
+ * </g>
+ *         ⬇
+ * <path attr1="val1" d="..."/>
+ * <path attr1="val1" d="..."/>
+ *
+ * @param {Object} item current iteration item
+ * @return {Boolean} if false, item will be filtered out
+ *
+ * @author Gil Goncalves
+ */
+exports.fn = function(item) {
+
+    // non-empty elements
+    if (item.isElem() && !item.isElem('switch') && !item.isEmpty()) {
+        item.content.forEach(function(g, i) {
+            // non-empty groups
+            if (g.isElem('g') && !g.isEmpty()) {
+
+                var transferred_attributes = [];
+
+                // move group attibutes to the single content element
+                if (g.hasAttr() && g.content.length > 0) {
+
+                    // transfer attributes into children
+                    g.content.forEach(function(inner) {
+                        if (inner.isElem() && !inner.hasAttr('id') && !g.hasAttr('filter') &&
+                            !(g.hasAttr('class') && inner.hasAttr('class')) && (
+                                !g.hasAttr('clip-path') && !g.hasAttr('mask') ||
+                                    inner.isElem('g') && !g.hasAttr('transform') && !inner.hasAttr('transform')
+                            )
+                           ) {
+
+                            g.eachAttr(function(attr) {
+                                if (g.content.some(hasAnimatedAttr, attr.name)) return;
+
+                                if (!inner.hasAttr(attr.name)) {
+                                    inner.addAttr(attr);
+                                    transferred_attributes.push(attr);
+                                } else if (attr.name == 'transform') {
+                                    inner.attr(attr.name).value = attr.value + ' ' + inner.attr(attr.name).value;
+                                    transferred_attributes.push(attr);
+                                } else if (inner.hasAttr(attr.name, 'inherit')) {
+                                    inner.attr(attr.name).value = attr.value;
+                                    transferred_attributes.push(attr);
+                                } else if (
+                                    attrsInheritable.indexOf(attr.name) < 0 &&
+                                        !inner.hasAttr(attr.name, attr.value)
+                                ) {
+                                    return;
+                                }
+                            });
+
+                        }
+                    });
+
+                    // remove attributes from group
+                    transferred_attributes.forEach(function(attr) {
+                        g.removeAttr(attr.name);
+                    });
+                }
+
+                // collapse groups without attributes
+                if (!g.hasAttr() && !g.content.some(function(item) { return item.isElem(animationElems) })) {
+                    item.spliceContent(i, 1, g.content);
+                }
+            }
+        });
+    }
+};

--- a/test/plugins/multiCollapseGroups.01.svg
+++ b/test/plugins/multiCollapseGroups.01.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g>
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..."/>
+</svg>

--- a/test/plugins/multiCollapseGroups.02.svg
+++ b/test/plugins/multiCollapseGroups.02.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g attr1="val1">
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..." attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.03.svg
+++ b/test/plugins/multiCollapseGroups.03.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g attr2="val2">
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..." attr2="val2" attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.04.svg
+++ b/test/plugins/multiCollapseGroups.04.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g>
+            <path d="..."/>
+        </g>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..." attr1="val1"/>
+    <path d="..." attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.05.svg
+++ b/test/plugins/multiCollapseGroups.05.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g attr2="val2">
+            <path d="..."/>
+        </g>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..." attr2="val2" attr1="val1"/>
+    <path d="..." attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.06.svg
+++ b/test/plugins/multiCollapseGroups.06.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g fill="red">
+            <path fill="green" d="..."/>
+        </g>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g fill="red" attr1="val1">
+        <path fill="green" d="..."/>
+    </g>
+    <path d="..." attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.07.svg
+++ b/test/plugins/multiCollapseGroups.07.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g attr2="val2">
+            <path attr2="val2" d="..."/>
+        </g>
+        <g attr2="val2">
+            <path attr2="val3" d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr2="val2" attr1="val1">
+        <path attr2="val2" d="..."/>
+    </g>
+    <g attr2="val2" attr1="val1">
+        <path attr2="val3" d="..."/>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.08.svg
+++ b/test/plugins/multiCollapseGroups.08.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <g transform="rotate(45)">
+            <path transform="scale(2)" d="..."/>
+        </g>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path transform="rotate(45) scale(2)" d="..." attr1="val1"/>
+    <path d="..." attr1="val1"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.09.svg
+++ b/test/plugins/multiCollapseGroups.09.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+       <path d="..."/>
+    </clipPath>
+    <g transform="matrix(0 -1.25 -1.25 0 100 100)" clip-path="url(#a)">
+        <g transform="scale(.2)">
+            <path d="..."/>
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+        <path d="..."/>
+    </clipPath>
+    <g transform="matrix(0 -1.25 -1.25 0 100 100)" clip-path="url(#a)">
+        <path d="..." transform="scale(.2)"/>
+        <path d="..." transform="scale(.2)"/>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.10.svg
+++ b/test/plugins/multiCollapseGroups.10.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+       <path d="..."/>
+    </clipPath>
+    <clipPath id="b">
+       <path d="..."/>
+    </clipPath>
+    <g transform="matrix(0 -1.25 -1.25 0 100 100)" clip-path="url(#a)">
+        <g transform="scale(.2)">
+            <g>
+                <g clip-path="url(#b)">
+                    <path d="..."/>
+                    <path d="..."/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+        <path d="..."/>
+    </clipPath>
+    <clipPath id="b">
+        <path d="..."/>
+    </clipPath>
+    <g transform="matrix(0 -1.25 -1.25 0 100 100)" clip-path="url(#a)">
+        <g clip-path="url(#b)" transform="scale(.2)">
+            <path d="..."/>
+            <path d="..."/>
+        </g>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.11.svg
+++ b/test/plugins/multiCollapseGroups.11.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+       <path d="..."/>
+    </clipPath>
+    <path d="..."/>
+    <g clip-path="url(#a)">
+        <path d="..." transform="scale(.2)"/>
+    </g>
+    <g mask="url(#a)">
+        <path d="..." transform="scale(.2)"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <clipPath id="a">
+        <path d="..."/>
+    </clipPath>
+    <path d="..."/>
+    <g clip-path="url(#a)">
+        <path d="..." transform="scale(.2)"/>
+    </g>
+    <g mask="url(#a)">
+        <path d="..." transform="scale(.2)"/>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.12.svg
+++ b/test/plugins/multiCollapseGroups.12.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g stroke="#000">
+        <g id="star">
+            <path id="bar" d="..."/>
+        </g>
+    </g>
+    <g>
+        <animate id="frame0" attributeName="visibility" values="visible" dur="33ms" begin="0s;frame27.end"/>
+        <path d="..." fill="#272727"/>
+        <path d="..." fill="#404040"/>
+        <path d="..." fill="#2d2d2d"/>
+    </g>
+    <g transform="rotate(-90 25 0)">
+        <circle stroke-dasharray="110" r="20" stroke="#10cfbd" fill="none" stroke-width="3" stroke-linecap="round">
+            <animate attributeName="stroke-dashoffset" values="360;140" dur="2.2s" keyTimes="0;1" calcMode="spline" fill="freeze" keySplines="0.41,0.314,0.8,0.54" repeatCount="indefinite" begin="0"/>
+            <animateTransform attributeName="transform" type="rotate" values="0;274;360" keyTimes="0;0.74;1" calcMode="linear" dur="2.2s" repeatCount="indefinite" begin="0"/>
+        </circle>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g stroke="#000">
+        <g id="star">
+            <path id="bar" d="..."/>
+        </g>
+    </g>
+    <g>
+        <animate id="frame0" attributeName="visibility" values="visible" dur="33ms" begin="0s;frame27.end"/>
+        <path d="..." fill="#272727"/>
+        <path d="..." fill="#404040"/>
+        <path d="..." fill="#2d2d2d"/>
+    </g>
+    <g transform="rotate(-90 25 0)">
+        <circle stroke-dasharray="110" r="20" stroke="#10cfbd" fill="none" stroke-width="3" stroke-linecap="round">
+            <animate attributeName="stroke-dashoffset" values="360;140" dur="2.2s" keyTimes="0;1" calcMode="spline" fill="freeze" keySplines="0.41,0.314,0.8,0.54" repeatCount="indefinite" begin="0"/>
+            <animateTransform attributeName="transform" type="rotate" values="0;274;360" keyTimes="0;0.74;1" calcMode="linear" dur="2.2s" repeatCount="indefinite" begin="0"/>
+        </circle>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.13.svg
+++ b/test/plugins/multiCollapseGroups.13.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .n{display:none}
+        .i{display:inline}
+    </style>
+    <g id="a">
+        <g class="i"/>
+    </g>
+    <g id="b" class="n">
+        <g class="i"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .n{display:none} .i{display:inline}
+    </style>
+    <g class="i" id="a"/>
+    <g id="b" class="n">
+        <g class="i"/>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.14.svg
+++ b/test/plugins/multiCollapseGroups.14.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <switch>
+        <g id="a">
+            <g class="i"/>
+        </g>
+        <g id="b" class="n">
+            <g class="i"/>
+        </g>
+        <g>
+            <g/>
+        </g>
+    </switch>
+
+</svg>
+
+@@@
+
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <switch>
+        <g id="a">
+            <g class="i"/>
+        </g>
+        <g id="b" class="n">
+            <g class="i"/>
+        </g>
+        <g>
+            <g/>
+        </g>
+    </switch>
+</svg>

--- a/test/plugins/multiCollapseGroups.15.svg
+++ b/test/plugins/multiCollapseGroups.15.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+	<g color="red">
+		<g color="inherit" fill="none" stroke="none">
+			<circle cx="130" cy="80" r="60" fill="currentColor"/>
+			<circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4"/>
+		</g>
+	</g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle cx="130" cy="80" r="60" fill="currentColor" color="red" stroke="none"/>
+    <circle cx="350" cy="80" r="60" stroke="currentColor" stroke-width="4" color="red" fill="none"/>
+</svg>

--- a/test/plugins/multiCollapseGroups.16.svg
+++ b/test/plugins/multiCollapseGroups.16.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#...)">
+        <g>
+            <path d="..."/>
+        </g>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g filter="url(#...)">
+        <path d="..."/>
+    </g>
+</svg>

--- a/test/plugins/multiCollapseGroups.17.svg
+++ b/test/plugins/multiCollapseGroups.17.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g attr1="val1">
+        <path d="..."/>
+        <path d="..."/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="..." attr1="val1"/>
+    <path d="..." attr1="val1"/>
+</svg>


### PR DESCRIPTION
collapseGroups is a great plugin, but unfortunately, it only deals with
single elements inside a <g>, which is why I made this plugin.

This will behave in the same way as `collapseGroups` but will also
transfer the attributes from the group into all child nodes.