### PR TITLE
skip prefixing in prefixIds plugin when prefix already detected

### DIFF
--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -177,8 +177,12 @@ exports.fn = function(node, opts, extra) {
 
     // prefixes a normal value
     addPrefix = function(name) {
-        if(prefix === false){
+        if (prefix === false){
             return escapeIdentifierName(name);
+        }
+        // prefix has already been added, perhaps on a previous run
+        if (name.startsWith(escapeIdentifierName(prefix + opts.delim))) {
+            return name;
         }
         return escapeIdentifierName(prefix + opts.delim + name);
     };

--- a/test/plugins/prefixIds.11.svg
+++ b/test/plugins/prefixIds.11.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .prefixIds_11_svg__test{color:blue}#prefixIds_11_svg__test{color:red}
+    </style>
+    <rect class="prefixIds_11_svg__test" x="10" y="10" width="100" height="100"/>
+    <rect class="" id="prefixIds_11_svg__test" x="10" y="10" width="100" height="100"/>
+</svg>
+
+@@@
+
+<svg width="120" height="120" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .prefixIds_11_svg__test{color:blue}#prefixIds_11_svg__test{color:red}
+    </style>
+    <rect class="prefixIds_11_svg__test" x="10" y="10" width="100" height="100"/>
+    <rect class="" id="prefixIds_11_svg__test" x="10" y="10" width="100" height="100"/>
+</svg>


### PR DESCRIPTION
Hi all,

Thanks for this wonderful library.

We are currently having the following issue, which I've resolved by modifying the `prefixIds` plugin:
1. We run `yarn svgo --pretty --indent=2 ./src/components/Icon/*/` each time we add a new SVG to our project
2. It processes and overwrites each SVG file in-place
3. Each ID has the filename prefix added to it each time. Resulting in ever-growing prefixes (example: if the original ID is `origID` and the file is AvatarGroup.svg, then after two runs, we get: `AvatarGroup_svg__AvatarGroup_svg__origID`)

This change attempts to detect if the prefix is already applied and avoids applying it again.

cc @strarsis based [on this comment](https://github.com/svg/svgo/issues/674#issuecomment-495928417)