### PR TITLE
Add svgo-browser link readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Arguments:
 
 * as a web app – [SVGOMG](https://jakearchibald.github.io/svgomg/)
 * as a Nodejs module – [examples](https://github.com/svg/svgo/tree/master/examples)
+* as a libary (Nodejs and browser support) – [svgo-browser](https://github.com/rtivital/svgo-browser)
 * as a Grunt task – [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
 * as a Gulp task – [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin)
 * as a Mimosa module – [mimosa-minify-svg](https://github.com/dbashford/mimosa-minify-svg)

--- a/README.ru.md
+++ b/README.ru.md
@@ -186,6 +186,7 @@ $ [sudo] npm install -g svgo
 
 * в виде веб-приложения - [SVGOMG](https://jakearchibald.github.io/svgomg/)
 * как модуль Node.js – [examples](https://github.com/svg/svgo/tree/master/examples)
+* как библиотеку (с поддержкой Nodejs и браузера) – [svgo-browser](https://github.com/rtivital/svgo-browser)
 * как таск для Grunt – [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
 * как таск для Gulp – [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin)
 * как таск для Mimosa – [mimosa-minify-svg](https://github.com/dbashford/mimosa-minify-svg)


### PR DESCRIPTION
Привет! Hello, I've made a version of svgo that works in browsers (with help of build tools like webpack). With this pull request I've added link to it.

Link – https://github.com/rtivital/svgo-browse

Here is an API example:
```js
// Test data will be used in all examples to illustrate output
const testData = `
  <svg version="1.1" width="10" height="20">
      test
  </svg>
`;
```

**Optimize with all default configuration:**

```js
import optimize from 'svgo-browser/lib/optimize ';

optimize(testData).then(console.log); // -> <svg viewBox="0 0 10 20">test</svg>
```

**Get separate instance:**

```js
import getSvgoInstance from 'svgo-browser/lib/get-svgo-instance';

const svgo = getSvgoInstance();
svgo.optimize(testData).then(console.log); // -> { data: "<svg viewBox="0 0 10 20">test</svg>", info: {}}
``` 