### PR TITLE
Add dereferenceUses plugin

### DIFF
--- a/plugins/dereferenceUses.js
+++ b/plugins/dereferenceUses.js
@@ -1,0 +1,71 @@
+'use strict';
+
+
+exports.type = 'full';
+
+exports.active = true;
+
+exports.description = 'dereferences <use/> elements';
+
+exports.params = {
+    keepHref: false, // keep (xlink:)href attributes
+};
+
+
+const overridingUseAttributes = [ 'x', 'y', 'width', 'height', 'href', 'xlink:href' ];
+
+
+/**
+ * Dereferences <use> elements
+ *
+ *
+ * @param {Object} document document element
+ * @param {Object} options plugin params
+ *
+ * @author strarsis <strarsis@gmail.com>
+ */
+exports.fn = function(document, options) {
+    options = options || {};
+
+    // collect <use/>s
+    var useEls = document.querySelectorAll('use');
+
+    // no <use/>s, nothing to do
+    if (useEls === null) {
+        return document;
+    }
+
+    // replace <use/> with referenced node
+    for (var useEl of useEls) {
+        var hrefAttr = useEl.attr('href') ? useEl.attr('href') : useEl.attr('xlink:href');
+        if(!hrefAttr || hrefAttr.value.length === 0) continue;
+        var href = hrefAttr.value;
+
+
+        var targetEl = document.querySelector(href);
+        if(!targetEl) continue;
+
+
+        var insertEl = targetEl.clone();
+
+
+        // Attribute inheritance
+        // @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use
+        //   "Only the attributes x, y, width, height and href on the use element will override those set on the referenced element.
+        //    However, any other attributes not set on the referenced element will be applied to the use element."
+        useEl.eachAttr(function(attr) {
+            if(insertEl.hasAttr(attr.name) && !overridingUseAttributes.includes(attr.name)) return;
+            if(!options.keepHref && attr.name === ('href' || 'xlink:href')) return;
+
+            insertEl.addAttr(attr);
+        });
+        insertEl.removeAttr('id'); // only the original node is allowed to have this ID
+
+
+        var useParentEl = useEl.parentNode;
+        var useElPosition = useParentEl.content.indexOf(useEl); // position of <use/> in parent
+        useParentEl.spliceContent(useElPosition, 1, insertEl); // replace <use/> with node
+    }
+
+    return document;
+};

--- a/test/plugins/dereferenceUses.01.svg
+++ b/test/plugins/dereferenceUses.01.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle id="myCircle" cx="5" cy="5" r="4" />
+    <use xlink:href="#myCircle" />
+    <use       href="#myCircle" />
+</svg>
+
+@@@
+
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle id="myCircle" cx="5" cy="5" r="4"/>
+    <circle cx="5" cy="5" r="4" xlink:href="#myCircle"/>
+    <circle cx="5" cy="5" r="4" href="#myCircle"/>
+</svg>
+
+@@@
+
+{"keepHref":true}

--- a/test/plugins/dereferenceUses.02.svg
+++ b/test/plugins/dereferenceUses.02.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4" />
+    <use href="#nonExisting" />
+</svg>
+
+@@@
+
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4"/>
+    <use href="#nonExisting"/>
+</svg>
+
+@@@
+
+{"keepHref":true}

--- a/test/plugins/dereferenceUses.03.svg
+++ b/test/plugins/dereferenceUses.03.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle id="myCircle" cx="5" cy="5" r="4" x="5" />
+    <use href="#myCircle" x="10" />
+    <use href="#myCircle" x="20" />
+</svg>
+
+@@@
+
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle id="myCircle" cx="5" cy="5" r="4" x="5"/>
+    <circle cx="5" cy="5" r="4" x="10" href="#myCircle"/>
+    <circle cx="5" cy="5" r="4" x="20" href="#myCircle"/>
+</svg>
+
+@@@
+
+{"keepHref":true}

--- a/test/plugins/dereferenceUses.04.svg
+++ b/test/plugins/dereferenceUses.04.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue"/>
+    <use href="#myCircle" x="10" fill="blue"/>
+    <use href="#myCircle" x="20" fill="white" stroke="red"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue"/>
+    <circle cx="5" cy="5" r="4" stroke="blue" href="#myCircle" x="10" fill="blue"/>
+    <circle cx="5" cy="5" r="4" stroke="blue" href="#myCircle" x="20" fill="white"/>
+</svg>
+
+@@@
+
+{"keepHref":true}

--- a/test/plugins/dereferenceUses.05.svg
+++ b/test/plugins/dereferenceUses.05.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue"/>
+    <use href="#myCircle" x="10" fill="blue"/>
+    <use href="#myCircle" x="20" fill="white" stroke="red"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue"/>
+    <circle cx="5" cy="5" r="4" stroke="blue" x="10" fill="blue"/>
+    <circle cx="5" cy="5" r="4" stroke="blue" x="20" fill="white"/>
+</svg>


### PR DESCRIPTION
This PR adds the dereferenceUses plugin, which dereferences `<use/>` elements, replacing it with the targetted node.
It also takes the [special attribute inheritance rules](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) into account.