### PR TITLE
getAttributeValue returns undefined rather than null

### DIFF
--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -43,7 +43,7 @@ var svgoCssSelectAdapterMin = {
     // getAttributeValue: ( elem:ElementNode, name:String ) => value:String
     // returns null when attribute doesn't exist
     getAttributeValue: function(elem, name) {
-        return elem.hasAttr(name) ? elem.attr(name).value : null;
+        return elem.hasAttr(name) ? elem.attr(name).value : void 0;
     }
 };
 


### PR DESCRIPTION
Ref https://github.com/svg/svgo/issues/930

It should return `undefined` rather than `null` according to <https://github.com/nrkn/css-select-base-adapter/blob/master/index.js#L100>.