### PR TITLE
Replace util.promisify with fs.promises

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -4,10 +4,6 @@
 var FS = require('fs'),
     PATH = require('path'),
     chalk = require('chalk'),
-    promisify = require('util.promisify'),
-    readdir = promisify(FS.readdir),
-    readFile = promisify(FS.readFile),
-    writeFile = promisify(FS.writeFile),
     SVGO = require('../svgo.js'),
     YAML = require('js-yaml'),
     PKG = require('../../package.json'),
@@ -378,7 +374,7 @@ function optimizeFolder(config, dir, output) {
     if (!config.quiet) {
         console.log(`Processing directory '${dir}':\n`);
     }
-    return readdir(dir).then(files => processDirectory(config, dir, files, output));
+    return FS.promises.readdir(dir).then(files => processDirectory(config, dir, files, output));
 }
 
 /**
@@ -438,7 +434,7 @@ function getFilesDescriptions(config, dir, files, output) {
  * @return {Promise}
  */
 function optimizeFile(config, file, output) {
-    return readFile(file, 'utf8').then(
+    return FS.promises.readFile(file, 'utf8').then(
         data => processSVGData(config, {input: 'file', path: file}, data, output, file),
         error => checkOptimizeFileError(config, file, output, error)
     );
@@ -491,7 +487,7 @@ function writeOutput(input, output, data) {
 
     FS.mkdirSync(PATH.dirname(output), { recursive: true });
 
-    return writeFile(output, data, 'utf8').catch(error => checkWriteFileError(input, output, data, error));
+    return FS.promises.writeFile(output, data, 'utf8').catch(error => checkWriteFileError(input, output, data, error));
 }
 
 
@@ -546,7 +542,7 @@ function checkOptimizeFileError(config, input, output, error) {
  */
 function checkWriteFileError(input, output, data, error) {
     if (error.code == 'EISDIR' && input) {
-        return writeFile(PATH.resolve(output, PATH.basename(input)), data, 'utf8');
+        return FS.promises.writeFile(PATH.resolve(output, PATH.basename(input)), data, 'utf8');
     } else {
         return Promise.reject(error);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,6 +1216,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -1639,15 +1640,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,6 +408,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -481,6 +482,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -494,6 +496,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -644,7 +647,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -726,6 +730,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -739,7 +744,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",
@@ -814,12 +820,14 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -831,6 +839,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -839,6 +848,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -1198,7 +1208,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "js-yaml": "^3.13.1",
     "sax": "~1.2.4",
     "stable": "^0.1.8",
-    "unquote": "~1.1.1",
-    "util.promisify": "~1.0.0"
+    "unquote": "~1.1.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.7",


### PR DESCRIPTION
Node 10 add support for promisified fs methods.
https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_promises_api

In this diff I replaced util.promisify package with the new methods.
Though this requires to bump end-of-life node versions.