### PR TITLE
Replace mkdirp with fs.mkdir with recursive flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
+  - 14
 
 branches:
   only:

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -4,7 +4,6 @@
 var FS = require('fs'),
     PATH = require('path'),
     chalk = require('chalk'),
-    mkdirp = require('mkdirp'),
     promisify = require('util.promisify'),
     readdir = promisify(FS.readdir),
     readFile = promisify(FS.readFile),
@@ -490,7 +489,7 @@ function writeOutput(input, output, data) {
         return Promise.resolve();
     }
 
-    mkdirp.sync(PATH.dirname(output));
+    FS.mkdirSync(PATH.dirname(output), { recursive: true });
 
     return writeFile(output, data, 'utf8').catch(error => checkWriteFileError(input, output, data, error));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,12 +1046,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "should": "~13.2.3"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.12.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "css-tree": "1.0.0-alpha.37",
     "csso": "^4.0.2",
     "js-yaml": "^3.13.1",
-    "mkdirp": "~0.5.1",
     "sax": "~1.2.4",
     "stable": "^0.1.8",
     "unquote": "~1.1.1",
@@ -72,7 +71,7 @@
     "should": "~13.2.3"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Ref https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_mkdir_path_options_callback

Node 10 add "recursive" flag support to fs.mkdir which behaves similar
to mkdirp package.

Though this requires to bump node support.