### PR TITLE
Improve path merging for non-filled paths

### DIFF
--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -58,7 +58,8 @@ exports.fn = function(item, params) {
                 prevPathJS = path2js(prevContentItem),
                 curPathJS = path2js(contentItem);
 
-            if (equalData && (params.force || !intersects(prevPathJS, curPathJS))) {
+            var noFill = contentItem.hasAttr('fill') && contentItem.attr('fill').value === 'none';
+            if (equalData && (params.force || (noFill || !intersects(prevPathJS, curPathJS)))) {
                 js2path(prevContentItem, prevPathJS.concat(curPathJS), params);
                 return false;
             }


### PR DESCRIPTION
If two paths are not filled, it does not matter whether they intersect or not and they can be merged. This helps with the common case of many different "lines" (which have no fill) that will fail to be merged if they intersect, which is common in many graphics. 

With this change many of my files I got another 10% size reduction, because path merging almost always failed for my non-filled paths in "crowded" svgs..