### PR TITLE
Simplify plugins configuration

### DIFF
--- a/lib/svgo/config.js
+++ b/lib/svgo/config.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
     defaults = config;
 
     if (Array.isArray(defaults.plugins)) {
-        defaults.plugins = preparePluginsArray(config, defaults.plugins);
+        defaults.plugins = defaults.plugins.map(resolvePluginConfig);
     }
 
     if ('floatPrecision' in config && Array.isArray(defaults.plugins)) {
@@ -47,70 +47,47 @@ module.exports = function(config) {
 
 };
 
-/**
- * Require() all plugins in array.
- *
- * @param {Object} config
- * @param {Array} plugins input plugins array
- * @return {Array} input plugins array of arrays
- */
-function preparePluginsArray(config, plugins) {
-
-    var plugin,
-        key;
-
-    return plugins.map(function(item) {
-
-        // {}
-        if (typeof item === 'object') {
-
-            key = Object.keys(item)[0];
-
-            // custom
-            if (typeof item[key] === 'object' && item[key].fn && typeof item[key].fn === 'function') {
-                plugin = setupCustomPlugin(key, item[key]);
-
-            } else {
-
-                plugin = setPluginActiveState(
-                    { ...pluginsMap[key] },
-                    item,
-                    key
-                );
-                plugin.name = key;
-            }
-
-        // name
-        } else {
-
-            plugin = { ...pluginsMap[item] };
-            plugin.name = item;
-            if (typeof plugin.params === 'object') {
-                plugin.params = Object.assign({}, plugin.params);
-            }
-
-        }
-
-        return plugin;
-
-    });
-
-}
-
-/**
- * Setup and enable a custom plugin
- *
- * @param {String} plugin name
- * @param {Object} custom plugin
- * @return {Array} enabled plugin
- */
-function setupCustomPlugin(name, plugin) {
-    plugin.active = true;
-    plugin.params = Object.assign({}, plugin.params || {});
-    plugin.name = name;
-
-    return plugin;
-}
+const resolvePluginConfig = plugin => {
+  if (typeof plugin === 'string') {
+    // resolve builtin plugin specified as string
+    const pluginConfig = pluginsMap[plugin];
+    if (pluginConfig == null) {
+      throw Error(`Unknown builtin plugin "${plugin}" specified.`);
+    }
+    return {
+      ...pluginConfig,
+      name: plugin,
+      active: true,
+      params: { ...pluginConfig.params }
+    };
+  }
+  if (typeof plugin === 'object' && plugin != null) {
+    if (plugin.name == null) {
+      throw Error(`Plugin name should be specified`);
+    }
+    if (plugin.fn) {
+      // resolve custom plugin with implementation
+      return {
+        active: true,
+        ...plugin,
+        params: { ...plugin.params }
+      };
+    } else {
+      // resolve builtin plugin specified as object without implementation
+      const pluginConfig = pluginsMap[plugin.name];
+      if (pluginConfig == null) {
+        throw Error(`Unknown builtin plugin "${plugin.name}" specified.`);
+      }
+      return {
+        ...pluginConfig,
+        active: true,
+        ...plugin,
+        params: { ...pluginConfig.params, ...plugin.params }
+      };
+    }
+  }
+  return null;
+};
 
 /**
  * Try to group sequential elements of plugins array.
@@ -131,30 +108,4 @@ function optimizePluginsArray(plugins) {
         return plugins;
     }, []);
 
-}
-
-/**
- * Sets plugin to active or inactive state.
- *
- * @param {Object} plugin
- * @param {Object} item
- * @param {Object} key
- * @return {Object} plugin
- */
-function setPluginActiveState(plugin, item, key) {
-    // name: {}
-    if (typeof item[key] === 'object') {
-        plugin.params = Object.assign({}, plugin.params || {}, item[key]);
-        plugin.active = true;
-
-    // name: false
-    } else if (item[key] === false) {
-        plugin.active = false;
-
-    // name: true
-    } else if (item[key] === true) {
-        plugin.active = true;
-    }
-
-    return plugin;
 }

--- a/test/config/_index.js
+++ b/test/config/_index.js
@@ -29,9 +29,9 @@ describe('config', function() {
         var config = CONFIG({
                 multipass: true,
                 plugins: [
-                    { removeDoctype: false },
-                    { convertColors: { shorthex: false } },
-                    { removeRasterImages: { param: true } }
+                    { name: 'removeDoctype', active: false },
+                    { name: 'convertColors', params: { shorthex: false } },
+                    { name: 'removeRasterImages', params: { param: true } }
                 ]
             }),
             removeDoctype = getPlugin('removeDoctype', config.plugins),
@@ -94,7 +94,7 @@ describe('config', function() {
                 multipass: true,
                 floatPrecision: 2,
                 plugins: [
-                    { cleanupNumericValues: true }
+                    { name: 'cleanupNumericValues' }
                 ]
             }),
             cleanupNumericValues = getPlugin('cleanupNumericValues', config.plugins);
@@ -124,10 +124,9 @@ describe('config', function() {
             var config = CONFIG({
                     plugins: [
                         {
-                            aCustomPlugin: {
-                                type: 'perItem',
-                                fn: function() { }
-                            }
+                            name: 'aCustomPlugin',
+                            type: 'perItem',
+                            fn: function() { }
                         }
                     ]
                 }),
@@ -147,10 +146,9 @@ describe('config', function() {
             var config = CONFIG({
                     plugins: [
                         {
-                            aCustomPlugin: {
-                                type: 'perItem',
-                                fn: function() { }
-                            }
+                            name: 'aCustomPlugin',
+                            type: 'perItem',
+                            fn: function() { }
                         }
                     ]
                 }),

--- a/test/plugins/_index.js
+++ b/test/plugins/_index.js
@@ -24,7 +24,7 @@ describe('plugins tests', function() {
 
             file = PATH.resolve(__dirname, file);
 
-            it(name + '.' + index, function() {
+          it(name + '.' + index, function() {
 
                 return readFile(file)
                 .then(function(data) {
@@ -32,14 +32,15 @@ describe('plugins tests', function() {
                         orig     = splitted[0],
                         should   = splitted[1],
                         params   = splitted[2],
-
-                        plugins = {},
                         svgo;
-
-                    plugins[name] = (params) ? JSON.parse(params) : true;
+                  
+                    const plugin = {
+                      name,
+                      params: (params ? JSON.parse(params) : {}),
+                    };
 
                     svgo = new SVGO({
-                        plugins : [ plugins ],
+                        plugins : [ plugin ],
                         js2svg  : { pretty: true }
                     });
 


### PR DESCRIPTION
- replaced named plugin object with "name" field
- dropped support for params in plugin object; use only params to pass plugin options
- dropped support for "boolean plugins"; use active field instead

```diff
-{
-  pluginName: {
-    fn,
-    params: {},
-    ...params
-  }
-}
+{
+  name: 'pluginName',
+  fn,
+  params: {}
+}
```