### PR TITLE
Implement loadConfig utility

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  extendDefaultPlugins,
+  optimize,
+  createContentItem,
+} = require('./svgo.js');
+
+const importConfig = async configFile => {
+  try {
+    const config = require(configFile);
+    if (config == null || typeof config !== 'object' || Array.isArray(config)) {
+      throw Error(`Invalid config file "${configFile}"`);
+    }
+    return config;
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const loadConfig = async (configFile, cwd = process.cwd()) => {
+  if (configFile != null) {
+    if (path.isAbsolute(configFile)) {
+      return await importConfig(configFile);
+    } else {
+      return await importConfig(path.join(cwd, configFile));
+    }
+  }
+  let dir = cwd;
+  while (true) {
+    try {
+      const file = path.join(dir, "svgo.config.js");
+      const stats = await fs.promises.stat(file);
+      if (stats.isFile()) {
+        return await importConfig(file);
+      }
+    } catch {}
+    const parent = path.dirname(dir);
+    if (dir === parent) {
+      return null;
+    }
+    dir = parent;
+  }
+};
+
+exports.loadConfig = loadConfig;
+exports.extendDefaultPlugins = extendDefaultPlugins;
+exports.optimize = optimize;
+exports.createContentItem = createContentItem;

--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -23,7 +23,10 @@ const { encodeSVGDatauri } = require('./svgo/tools.js');
 
 exports.extendDefaultPlugins = extendDefaultPlugins;
 
-const optimize = (svgstr, config = {}) => {
+const optimize = (svgstr, config) => {
+  if (config == null) {
+    config = {};
+  }
   if (typeof config !== 'object') {
     throw Error('Config should be an object')
   }

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -4,9 +4,8 @@
 const FS = require('fs');
 const PATH = require('path');
 const chalk = require('chalk');
-const { optimize } = require('../svgo.js');
+const { loadConfig, optimize } = require('../svgo-node.js');
 const pluginsMap = require('../../plugins/plugins.js');
-const YAML = require('js-yaml');
 const PKG = require('../../package.json');
 const { encodeSVGDatauri, decodeSVGDatauri } = require('./tools.js');
 const { checkIsDir } = require('./tools.js');
@@ -39,7 +38,7 @@ module.exports = function makeProgram(program) {
         .action(action);
 }
 
-function action(args, opts) {
+async function action(args, opts) {
     var input = opts.input || args;
     var output = opts.output;
     var config = {}
@@ -94,26 +93,13 @@ function action(args, opts) {
     }
 
     // --config
-    if (opts.config) {
-        var configPath = PATH.resolve(opts.config),
-            configData;
-        try {
-            // require() adds some weird output on YML files
-            configData = FS.readFileSync(configPath, 'utf8');
-            config = JSON.parse(configData);
-        } catch (err) {
-            if (err.code === 'ENOENT') {
-                return printErrorAndExit(`Error: couldn't find config file '${opts.config}'.`);
-            } else if (err.code === 'EISDIR') {
-                return printErrorAndExit(`Error: directory '${opts.config}' is not a config file.`);
-            }
-            config = YAML.safeLoad(configData);
-            config.__DIR = PATH.dirname(configPath); // will use it to resolve custom plugins defined via path
-
-            if (!config || Array.isArray(config)) {
-                return printErrorAndExit(`Error: invalid config file '${opts.config}'.`);
-            }
-        }
+    try {
+      const loadedConfig = await loadConfig(opts.config);
+      if (loadedConfig != null) {
+        config = loadedConfig;
+      }
+    } catch (error) {
+      return printErrorAndExit(error.message);
     }
 
     // --quiet

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,6 +423,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -851,7 +852,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "find-cache-dir": {
       "version": "3.3.1",
@@ -1238,6 +1240,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1978,7 +1981,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "stable": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "type": "git",
     "url": "git://github.com/svg/svgo.git"
   },
-  "main": "./lib/svgo.js",
+  "main": "./lib/svgo-node.js",
   "bin": {
     "svgo": "./bin/svgo"
   },
@@ -57,7 +57,6 @@
     "css-select-base-adapter": "^0.1.1",
     "css-tree": "^1.1.2",
     "csso": "^4.2.0",
-    "js-yaml": "^3.13.1",
     "sax": "~1.2.4",
     "stable": "^0.1.8"
   },

--- a/test/coa/_index.js
+++ b/test/coa/_index.js
@@ -120,7 +120,7 @@ describe('coa', function() {
 
         const stdin = require('mock-stdin').stdin();
 
-        setTimeout(() => { stdin.send(initialFile, 'ascii').end(); }, 0);
+        setTimeout(() => { stdin.send(initialFile, 'ascii').end(); }, 1000);
 
         runProgram(['--input', '-', '--output', 'temp.svg', '--string', fs.readFileSync(svgPath, 'utf8'), '--quiet'])
             .then(onComplete, onComplete);

--- a/test/config/fixtures/invalid-array.js
+++ b/test/config/fixtures/invalid-array.js
@@ -1,0 +1,1 @@
+module.exports = [];

--- a/test/config/fixtures/invalid-null.js
+++ b/test/config/fixtures/invalid-null.js
@@ -1,0 +1,1 @@
+module.exports = null;

--- a/test/config/fixtures/invalid-string.js
+++ b/test/config/fixtures/invalid-string.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/test/config/fixtures/one/two/config.js
+++ b/test/config/fixtures/one/two/config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: [] };

--- a/test/config/fixtures/svgo.config.js
+++ b/test/config/fixtures/svgo.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: [] };


### PR DESCRIPTION
Ref https://github.com/svg/svgo/issues/1327

Config file now can only be js. `svgo.config.js` is searched by default.
Otherwise any js module specified in `--config` cli flag.

Config loader is exposed in entry point as `loadConfig(configFile, cwd)`.