### PR TITLE
Fix 'ReferenceError: indent is not defined'

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -137,7 +137,7 @@ async function action(args, opts) {
         config.js2svg = config.js2svg || {};
         config.js2svg.pretty = true;
         if (opts.indent != null) {
-            config.js2svg.indent = indent;
+            config.js2svg.indent = opts.indent;
         }
     }
 


### PR DESCRIPTION
BTW, `eslint` could prevent this type of mistake.