### PR TITLE
Fix `new Buffer` usage

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -12,11 +12,7 @@ exports.encodeSVGDatauri = function(str, type) {
     if (!type || type === 'base64') {
         // base64
         prefix += ';base64,';
-        if (Buffer.from) {
-            str = prefix + Buffer.from(str).toString('base64');
-        } else {
-            str = prefix + new Buffer(str).toString('base64');
-        }
+        str = prefix + Buffer.from(str).toString('base64');
     } else if (type === 'enc') {
         // URI encoded
         str = prefix + ',' + encodeURIComponent(str);
@@ -44,7 +40,7 @@ exports.decodeSVGDatauri = function(str) {
 
     if (match[2]) {
         // base64
-        str = new Buffer(data, 'base64').toString('utf8');
+        str = Buffer.from(data, 'base64').toString('utf8');
     } else if (data.charAt(0) === '%') {
         // URI encoded
         str = decodeURIComponent(data);


### PR DESCRIPTION
Node.js 10.x which is the minimum supported version supports `Buffer.from`