### PR TITLE
test/coa/_index.js: Fix regex

### DIFF
--- a/test/coa/_index.js
+++ b/test/coa/_index.js
@@ -166,7 +166,7 @@ describe('coa', function() {
         ]);
       } finally {
         restoreConsoleLog();
-        expect(output).to.match(/www.w3.org\/2000\/svg/);
+        expect(output).to.match(/www\.w3\.org\/2000\/svg/);
       }
     });
 


### PR DESCRIPTION
`.` means any character but we want to match the literal `.`
