### PR TITLE
Add 'preserve' parameter to 'removeEditorsNSData' plugin

### DIFF
--- a/plugins/removeEditorsNSData.js
+++ b/plugins/removeEditorsNSData.js
@@ -7,10 +7,12 @@ exports.active = true;
 exports.description = 'removes editors namespaces, elements and attributes';
 
 var editorNamespaces = require('./_collections').editorNamespaces,
-    prefixes = [];
+    prefixes = [],
+    preserve = [];
 
 exports.params = {
-    additionalNamespaces: []
+    additionalNamespaces: [],
+    preserve: [],  // preserves elements and attributes
 };
 
 /**
@@ -32,6 +34,9 @@ exports.fn = function(item, params) {
     if (Array.isArray(params.additionalNamespaces)) {
         editorNamespaces = editorNamespaces.concat(params.additionalNamespaces);
     }
+    if (Array.isArray(params.preserve)) {
+        preserve = preserve.concat(params.preserve);
+    }
 
     if (item.elem) {
 
@@ -42,7 +47,9 @@ exports.fn = function(item, params) {
                     prefixes.push(attr.local);
 
                     // <svg xmlns:sodipodi="">
-                    item.removeAttr(attr.name);
+                    if (preserve.indexOf(attr.name) === -1) {
+                      item.removeAttr(attr.name);
+                    }
                 }
             });
 
@@ -50,13 +57,13 @@ exports.fn = function(item, params) {
 
         // <* sodipodi:*="">
         item.eachAttr(function(attr) {
-            if (prefixes.indexOf(attr.prefix) > -1) {
+            if (prefixes.indexOf(attr.prefix) > -1 && preserve.indexOf(attr.name) === -1) {
                 item.removeAttr(attr.name);
             }
         });
 
         // <sodipodi:*>
-        if (prefixes.indexOf(item.prefix) > -1) {
+        if (prefixes.indexOf(item.prefix) > -1 && preserve.indexOf(item.elem) === -1) {
             return false;
         }
 

--- a/test/plugins/removeEditorsNSData.03.svg
+++ b/test/plugins/removeEditorsNSData.03.svg
@@ -8,6 +8,7 @@
         ...
     </sodipodi:fakeelem>
     <path d="..." sodipodi:nodetypes="cccc"/>
+    <path d="..." sodipodi:fakeattr="fakevalue"/>
 </svg>
 
 @@@
@@ -18,8 +19,9 @@
         ...
     </sodipodi:namedview>
     <path d="..."/>
+    <path d="..." sodipodi:fakeattr="fakevalue"/>
 </svg>
 
 @@@
 
-{"preserve":["xmlns:sodipodi","sodipodi:namedview"]}
+{"preserve":["xmlns:sodipodi","sodipodi:fakeattr","sodipodi:namedview"]}

--- a/test/plugins/removeEditorsNSData.03.svg
+++ b/test/plugins/removeEditorsNSData.03.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <sodipodi:namedview/>
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+    <sodipodi:fakeelem/>
+    <sodipodi:fakeelem>
+        ...
+    </sodipodi:fakeelem>
+    <path d="..." sodipodi:nodetypes="cccc"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd">
+    <sodipodi:namedview/>
+    <sodipodi:namedview>
+        ...
+    </sodipodi:namedview>
+    <path d="..."/>
+</svg>
+
+@@@
+
+{"preserve":["xmlns:sodipodi","sodipodi:namedview"]}


### PR DESCRIPTION
Closes #1096

Added `preserve` parameter to `removeEditorNSData` plugin that allows to preserve elements and attributes of elements. Let me know if the desired configuration should split between attributes and elements in two different parameters.