### PR TITLE
Test regressions with W3C SVG 1.1 Test Suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,25 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+  regression:
+    name: Test regressions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE }}
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE }}-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+      - run: npm run test-regression
   test:
     name: Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+diffs
 coverage
 bin/svgo-profiling
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,11 +357,36 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -392,6 +417,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -1064,6 +1099,15 @@
             "ms": "2.1.2"
           }
         },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1182,6 +1226,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1230,13 +1280,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -1334,6 +1381,12 @@
           "dev": true
         }
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.8",
@@ -1740,6 +1793,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1854,6 +1913,23 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pixelmatch": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
+      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
+      "dev": true,
+      "requires": {
+        "pngjs": "^4.0.1"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
+          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
+          "dev": true
+        }
+      }
+    },
     "playwright": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.8.1.tgz",
@@ -1894,13 +1970,19 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "pngjs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+          "dev": true
         }
       }
     },
     "pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
       "dev": true
     },
     "prelude-ls": {
@@ -1975,6 +2057,17 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -2186,6 +2279,15 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -2274,6 +2376,19 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -2351,6 +2466,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -110,11 +110,16 @@
     "chai": "^4.3.0",
     "del": "^6.0.0",
     "eslint": "^7.20.0",
+    "get-stream": "^6.0.0",
     "mocha": "^8.3.0",
     "mock-stdin": "^1.0.0",
+    "node-fetch": "^2.6.1",
+    "pixelmatch": "^5.2.1",
     "playwright": "^1.8.1",
+    "pngjs": "^6.0.0",
     "prettier": "^2.2.1",
     "rollup": "^2.39.0",
+    "tar-stream": "^2.2.0",
     "typescript": "^4.2.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint": "eslint .",
     "typecheck": "tsc",
     "test-browser": "rollup -c && node ./test/browser.js",
+    "test-regression": "NO_DIFF=1 node ./test/regression.js",
     "prepublishOnly": "rm -rf dist && rollup -c"
   },
   "prettier": {

--- a/test/regression.js
+++ b/test/regression.js
@@ -146,18 +146,21 @@ const runTests = async () => {
   console.info(`Skipped: ${skipped}`);
   console.info(`Mismatched: ${mismatched}`);
   console.info(`Passed: ${passed}`);
-  if (mismatched !== 0) {
-    throw Error('Regression tests failed');
-  }
+  return mismatched === 0;
 };
 
 (async () => {
   try {
     const start = process.hrtime.bigint();
-    await runTests();
+    const passed = await runTests();
     const end = process.hrtime.bigint();
     const diff = (end - start) / BigInt(1e+6);
-    console.info(`Regression tests successfully completed in ${diff}ms`);
+    if (passed) {
+      console.info(`Regression tests successfully completed in ${diff}ms`);
+    } else {
+      console.error(`Regression tests failed in ${diff}ms`);
+      process.exit(1);
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/test/regression.js
+++ b/test/regression.js
@@ -23,7 +23,16 @@ const readSvgFiles = async () => {
   extract.on('entry', async (header, stream, next) => {
     try {
       // ignore all animated svg
-      if (header.name.startsWith('svg/') && header.name.includes('animate') === false) {
+      if (
+        header.name.startsWith('svg/') &&
+        // hard to detect the end of animation
+        header.name.includes('animate') === false &&
+        // fails because removeEmptyContainers removes <g> used in script
+        header.name !== 'svg/coords-dom-03-f.svg' &&
+        header.name !== 'svg/coords-dom-04-f.svg' &&
+        // fails because <defs><font-face> is removed
+        header.name !== 'coords-viewattr-01-b.svg'
+      ) {
         if (header.name.endsWith('.svg')) {
           // strip folder and extension
           const name = header.name.slice('svg/'.length, -'.svg'.length);

--- a/test/regression.js
+++ b/test/regression.js
@@ -103,7 +103,7 @@ const runTests = async ({ svgFiles }) => {
       name === 'struct-use-11-f' ||
       name === 'styling-css-01-b' ||
       name === 'styling-css-03-b' ||
-      // name === 'styling-css-04-f' ||
+      name === 'styling-css-04-f' ||
       name === 'styling-css-08-f'
     ) {
       console.info(`${name} is skipped`);

--- a/test/regression.js
+++ b/test/regression.js
@@ -55,10 +55,7 @@ const readSvgFiles = async () => {
     stream.resume();
     next();
   });
-  await pipeline(
-    response.body,
-    extract,
-  );
+  await pipeline(response.body, extract);
   return svgFiles;
 };
 
@@ -145,11 +142,14 @@ const runTests = async ({ svgFiles }) => {
       mismatched += 1;
       console.error(`${name} is mismatched`);
       await fs.promises.mkdir('diffs', { recursive: true });
-      await fs.promises.writeFile(`diffs/${name}.diff.png`, PNG.sync.write(diff));
+      await fs.promises.writeFile(
+        `diffs/${name}.diff.png`,
+        PNG.sync.write(diff)
+      );
     }
-  }
+  };
   const browser = await chromium.launch();
-  const context = await browser.newContext();
+  const context = await browser.newContext({ javaScriptEnabled: false });
   const chunks = chunkInto(svgFiles, 8);
   await Promise.all(
     chunks.map(async (chunk) => {
@@ -157,10 +157,10 @@ const runTests = async ({ svgFiles }) => {
       for (const [name, string] of chunk) {
         await processFile(page, name, string);
       }
-      await page.close()
+      await page.close();
     })
   );
-  await browser.close()
+  await browser.close();
   console.info(`Skipped: ${skipped}`);
   console.info(`Mismatched: ${mismatched}`);
   console.info(`Passed: ${passed}`);
@@ -174,7 +174,7 @@ const runTests = async ({ svgFiles }) => {
     const svgFiles = await readSvgFiles();
     const passed = await runTests({ svgFiles });
     const end = process.hrtime.bigint();
-    const diff = (end - start) / BigInt(1e+6);
+    const diff = (end - start) / BigInt(1e6);
     if (passed) {
       console.info(`Regression tests successfully completed in ${diff}ms`);
     } else {

--- a/test/regression.js
+++ b/test/regression.js
@@ -64,7 +64,7 @@ const optimizeSvgFiles = (svgFiles) => {
   let failed = 0;
   for (const [name, string] of svgFiles) {
     try {
-      const result = optimize(string, { path: name });
+      const result = optimize(string, { path: name, floatPrecision: 4 });
       if (result.error) {
         console.error(result.error);
         console.error(`File: ${name}`);

--- a/test/regression.js
+++ b/test/regression.js
@@ -106,7 +106,17 @@ const runTests = async ({ svgFiles }) => {
       name === 'styling-css-04-f' ||
       name === 'styling-css-08-f' ||
       // unstable test
-      name === 'filters-light-04-f'
+      name === 'filters-light-04-f' ||
+      // mismatched draft cases
+      name === 'filters-offset-02-b' ||
+      name === 'imp-path-01-f' ||
+      name === 'interact-pointer-04-f' ||
+      name === 'painting-marker-properties-01-f' ||
+      name === 'pservers-pattern-05-f' ||
+      name === 'struct-cond-overview-03-f' ||
+      name === 'struct-use-07-b' ||
+      name === 'styling-css-10-f' ||
+      name === 'styling-pres-04-f'
     ) {
       console.info(`${name} is skipped`);
       skipped += 1;
@@ -117,12 +127,6 @@ const runTests = async ({ svgFiles }) => {
     const height = 720;
     await page.goto(`data:image/svg+xml,${encodeURIComponent(string)}`);
     await page.setViewportSize({ width, height });
-    const draft = await page.$('#draft-watermark');
-    if (draft != null) {
-      console.info(`${name} is skipped`);
-      skipped += 1;
-      return;
-    }
     const originalBuffer = await page.screenshot({
       omitBackground: true,
       clip: { x: 0, y: 0, width, height },

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const fs = require('fs');
+const util = require('util');
+const zlib = require('zlib');
+const stream = require('stream');
+const fetch = require('node-fetch');
+const tarStream = require('tar-stream');
+const getStream = require('get-stream');
+const { chromium } = require('playwright');
+const { PNG } = require('pngjs');
+const pixelmatch = require('pixelmatch');
+const { optimize } = require('../lib/svgo.js');
+
+const pipeline = util.promisify(stream.pipeline);
+
+const readSvgFiles = async () => {
+  const svgFiles = new Map();
+  const response = await fetch(
+    'https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz'
+  );
+  const extract = tarStream.extract();
+  extract.on('entry', async (header, stream, next) => {
+    try {
+      // ignore all animated svg
+      if (header.name.startsWith('svg/') && header.name.includes('animate') === false) {
+        if (header.name.endsWith('.svg')) {
+          // strip folder and extension
+          const name = header.name.slice('svg/'.length, -'.svg'.length);
+          const string = await getStream(stream);
+          svgFiles.set(name, string);
+        }
+        if (header.name.endsWith('.svgz')) {
+          // strip folder and extension
+          const name = header.name.slice('svg/'.length, -'.svgz'.length);
+          const string = await getStream(stream.pipe(zlib.createGunzip()));
+          svgFiles.set(name, string);
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
+    stream.resume();
+    next();
+  });
+  await pipeline(
+    response.body,
+    extract,
+  );
+  return svgFiles;
+};
+
+const optimizeSvgFiles = (svgFiles) => {
+  const optimizedFiles = new Map();
+  let failed = 0;
+  for (const [name, string] of svgFiles) {
+    try {
+      const result = optimize(string, { path: name });
+      if (result.error) {
+        console.error(result.error);
+        console.error(`File: ${name}`);
+        failed += 1;
+        continue;
+      } else {
+        optimizedFiles.set(name, result.data);
+      }
+    } catch (error) {
+      console.error(error);
+      console.error(`File: ${name}`);
+      failed += 1;
+      continue;
+    }
+  }
+  if (failed !== 0) {
+    throw Error(`Failed to optimize ${failed} cases`);
+  }
+  return optimizedFiles;
+};
+
+const runTests = async () => {
+  console.info('Download W3C SVG 1.1 Test Suite and extract svg files');
+  const svgFiles = await readSvgFiles();
+  const optimizedFiles = optimizeSvgFiles(svgFiles);
+  let skipped = 0;
+  let mismatched = 0;
+  let passed = 0;
+  console.info('Start browser...');
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  for (const [name, string] of svgFiles) {
+    const optimized = optimizedFiles.get(name);
+    const width = 960;
+    const height = 720;
+    await page.goto(`data:image/svg+xml,${encodeURIComponent(string)}`);
+    await page.setViewportSize({ width, height });
+    const draft = await page.$('#draft-watermark');
+    if (draft != null) {
+      console.info(`${name} is skipped`);
+      skipped += 1;
+      continue;
+    }
+    const originalBuffer = await page.screenshot({
+      omitBackground: true,
+      clip: { x: 0, y: 0, width, height },
+    });
+    await page.goto(`data:image/svg+xml,${encodeURIComponent(optimized)}`);
+    const optimizedBuffer = await page.screenshot({
+      omitBackground: true,
+      clip: { x: 0, y: 0, width, height },
+    });
+    const originalPng = PNG.sync.read(originalBuffer);
+    const optimizedPng = PNG.sync.read(optimizedBuffer);
+    const diff = new PNG({ width, height });
+    const matched = pixelmatch(
+      originalPng.data,
+      optimizedPng.data,
+      diff.data,
+      width,
+      height
+    );
+    // ignore small aliasing issues
+    if (matched <= 4) {
+      console.info(`${name} is passed`);
+      passed += 1;
+    } else {
+      mismatched += 1;
+      console.error(`${name} is mismatched`);
+      await fs.promises.mkdir('diffs', { recursive: true });
+      await fs.promises.writeFile(`diffs/${name}.diff.png`, PNG.sync.write(diff));
+    }
+  }
+  await browser.close()
+  console.info(`Skipped: ${skipped}`);
+  console.info(`Mismatched: ${mismatched}`);
+  console.info(`Passed: ${passed}`);
+  if (mismatched !== 0) {
+    throw Error('Regression tests failed');
+  }
+};
+
+(async () => {
+  try {
+    const start = process.hrtime.bigint();
+    await runTests();
+    const end = process.hrtime.bigint();
+    const diff = (end - start) / BigInt(1e+6);
+    console.info(`Regression tests successfully completed in ${diff}ms`);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/test/regression.js
+++ b/test/regression.js
@@ -104,7 +104,9 @@ const runTests = async ({ svgFiles }) => {
       name === 'styling-css-01-b' ||
       name === 'styling-css-03-b' ||
       name === 'styling-css-04-f' ||
-      name === 'styling-css-08-f'
+      name === 'styling-css-08-f' ||
+      // unstable test
+      name === 'filters-light-04-f'
     ) {
       console.info(`${name} is skipped`);
       skipped += 1;

--- a/test/regression.js
+++ b/test/regression.js
@@ -31,7 +31,9 @@ const readSvgFiles = async () => {
         header.name !== 'svg/coords-dom-03-f.svg' &&
         header.name !== 'svg/coords-dom-04-f.svg' &&
         // fails because <defs><font-face> is removed
-        header.name !== 'coords-viewattr-01-b.svg'
+        header.name !== 'svg/coords-viewattr-01-b.svg' &&
+        // fails because script is not run in base64
+        header.name !== 'svg/masking-path-12-f.svg'
       ) {
         if (header.name.endsWith('.svg')) {
           // strip folder and extension


### PR DESCRIPTION
Visual regressions tests will give us more confidence in SVGO stability.
Test cases are downloaded from w3.org, screenshooted with playwright and
compared with pixelmatch.

See test suite https://www.w3.org/Graphics/SVG/Test/20110816/

Bugs detected with these tests:
- https://github.com/svg/svgo/commit/9b97e06ef69b7961f342c9ee8468c552c9b503a3
- https://github.com/svg/svgo/pull/1371
- https://github.com/svg/svgo/commit/c1d5f0f7a93a6f1c947baa5860ddd40f8d1bb701
- https://github.com/svg/svgo/commit/9de471a0f4bea20581034c2d74b0652c27e0fad0
- https://github.com/svg/svgo/commit/091172a392f6d751855477d51e5c8bd3e44fde97
- https://github.com/svg/svgo/commit/36391564f2d0b2c7ad86c746bacdd6de030ebd3d
- https://github.com/svg/svgo/commit/d14315b68fc1fcb43212219a0da5857ad7a23cd0
- https://github.com/svg/svgo/commit/9d67586787ad16799d7a1cfce1eb0bce829470da
- https://github.com/svg/svgo/commit/d06747abca1e9e652a764db9747395d14f7f6f98
- https://github.com/svg/svgo/commit/dd37fcfebbe2f3cea687ad0bf890ff83ab3c9eb7
- https://github.com/svg/svgo/pull/1378