### PR TITLE
Disable convertStyleToAttrs plugin by default

### DIFF
--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -2,7 +2,7 @@
 
 exports.type = 'perItem';
 
-exports.active = true;
+exports.active = false;
 
 exports.description = 'converts style to attributes';
 

--- a/test/svgo/_index.js
+++ b/test/svgo/_index.js
@@ -61,4 +61,9 @@ describe('svgo', () => {
     const result = optimize('<svg />', { input: 'file', path: 'input.svg' });
     expect(result.data).to.equal('<svg/>');
   });
+  it('should preserve style specifity over attributes', async () => {
+    const [original, expected] = await parseFixture('style-specifity.svg');
+    const result = optimize(original, { input: 'file', path: 'input.svg', js2svg: { pretty: true } });
+    expect(normalize(result.data)).to.equal(expected);
+  });
 });

--- a/test/svgo/style-specifity.svg
+++ b/test/svgo/style-specifity.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <style>
+    .fill-red { fill: red; }
+  </style>
+  <rect x="20" y="20" width="10" height="10" class="fill-red" style="fill:green;" />
+  <rect x="70" y="20" width="10" height="10" class="fill-red" style="fill:blue;" />
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <style>
+        .fill-red{fill:red}
+    </style>
+    <path class="fill-red" style="fill:green" d="M20 20h10v10H20z"/>
+    <path class="fill-red" style="fill:#00f" d="M70 20h10v10H70z"/>
+</svg>


### PR DESCRIPTION
Ref https://github.com/svg/svgo/issues/1362 https://github.com/svg/svgo/issues/1360

From the [spec](https://www.w3.org/TR/SVG11/styling.html#UsingPresentationAttributes):

> Presentation attributes have lower priority than other CSS style rules specified in author style sheets or ‘style’ attributes.

Though we replace inline styles with attributes without checking if
thare is any `<style>` element. This makes the plugin unsafe and it
should not be enabled by default.

cc @sk- @strarsis 