### PR TITLE
Fork sax

### DIFF
--- a/lib/svgo/svg2js.js
+++ b/lib/svgo/svg2js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SAX = require('sax'),
+var SAX = require('@trysound/sax'),
     JSAPI = require('./jsAPI.js'),
     CSSClassList = require('./css-class-list'),
     CSSStyleDeclaration = require('./css-style-declaration'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,11 @@
         }
       }
     },
+    "@trysound/sax": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.0.tgz",
+      "integrity": "sha512-1yH66Pny121c7ZwLW/zLedcflwPHELEg4pMo6pA+U1PoEKt8hUI6SKD47mfAJhC+4IExoEr0tMTYETlhpjPhmQ=="
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2068,11 +2073,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "serialize-javascript": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -89,13 +89,13 @@
     ]
   },
   "dependencies": {
+    "@trysound/sax": "0.1.0",
     "chalk": "^4.1.0",
     "commander": "^7.1.0",
     "css-select": "^3.1.2",
     "css-select-base-adapter": "^0.1.1",
     "css-tree": "^1.1.2",
     "csso": "^4.2.0",
-    "sax": "~1.2.4",
     "stable": "^0.1.8"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default {
   plugins: [
     {
       resolveId(importee, importer) {
-        if (['os', 'stream', 'string_decoder'].includes(importee)) {
+        if (importee === 'os') {
           return importee;
         }
         // see https://github.com/csstree/csstree/pull/152
@@ -25,12 +25,6 @@ export default {
       load(id) {
         if (id === 'os') {
           return `export var EOL = '\\n'`;
-        }
-        if (id === 'stream') {
-          return `export function Stream(){}`;
-        }
-        if (id === 'string_decoder') {
-          return `export default null`;
         }
       },
     },


### PR DESCRIPTION
There were a lot of PRs with switching to another xml parser because sax
is not maintained for almost 4 years already.

Though switching parser to solve a few problems may introduce many new
bugs. This is why we decided to fork sax and maintain own version.

For initial release I removed node streams support which allows to get
rid from some magic in browser bundle build config and removed
String.fromCodePoint polyfill.

Forked package is here https://github.com/svg/sax