### PR TITLE
Remove <style> element from the minifyStyles plugin when it is empty

### DIFF
--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -37,13 +37,22 @@ exports.fn = function(ast, options) {
 
     elems.forEach(function(elem) {
         if (elem.isElem('style')) {
-            // <style> element
-            var styleCss = elem.content[0].text || elem.content[0].cdata || [];
-            var DATA = styleCss.indexOf('>') >= 0 || styleCss.indexOf('<') >= 0 ? 'cdata' : 'text';
+            // has <style> element
+            if (elem.isEmpty()) {
+                // removed empty <style> elements
+                var styleParentEl = elem.parentNode; // svg element
+                var styleIndex = styleParentEl.content.indexOf(elem)
 
-            elem.content[0][DATA] = csso.minify(styleCss, minifyOptionsForStylesheet).css;
+                console.log('style index', styleIndex);
+                styleParentEl.spliceContent(styleIndex, 1);
+            } else {
+                var styleCss = elem.content[0].text || elem.content[0].cdata || [];
+                var DATA = styleCss.indexOf('>') >= 0 || styleCss.indexOf('<') >= 0 ? 'cdata' : 'text';
+
+                elem.content[0][DATA] = csso.minify(styleCss, minifyOptionsForStylesheet).css;
+            }
         } else {
-            // style attribute
+            // has style attribute
             var elemStyle = elem.attr('style').value;
 
             elem.attr('style').value = csso.minifyBlock(elemStyle, minifyOptionsForAttribute).css;
@@ -73,8 +82,7 @@ function findStyleElems(ast) {
             if (item.content) {
                 walk(item, styles);
             }
-
-            if (item.isElem('style') && !item.isEmpty()) {
+            if (item.isElem('style')) {
                 styles.push(item);
             } else if (item.isElem() && item.hasAttr('style')) {
                 styles.push(item);

--- a/test/plugins/_index.js
+++ b/test/plugins/_index.js
@@ -8,7 +8,7 @@ const regEOL = new RegExp(EOL, 'g');
 const regFilename = /^(.*)\.(\d+)\.svg$/;
 const { optimize } = require('../../lib/svgo.js');
 
-describe('plugins tests', function() {
+describe.only('plugins tests', function() {
 
     FS.readdirSync(__dirname).forEach(function(file) {
 

--- a/test/plugins/minifyStyles.02.svg
+++ b/test/plugins/minifyStyles.02.svg
@@ -14,6 +14,5 @@
     <style>
         .st0{fill:red;padding:1em}@media screen and (max-width:200px){.st0{display:none}}
     </style>
-    <style/>
     <rect width="100" height="100" class="st0" style="stroke-width:3;margin:1em"/>
 </svg>

--- a/test/plugins/minifyStyles.11.svg
+++ b/test/plugins/minifyStyles.11.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+    </style>
+
+    <style></style>
+
+    <style />
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>

--- a/test/plugins/minifyStyles.12.svg
+++ b/test/plugins/minifyStyles.12.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .undefind {
+            fill: red;
+        }
+    </style>
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>

--- a/test/plugins/minifyStyles.13.svg
+++ b/test/plugins/minifyStyles.13.svg
@@ -1,23 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style></style>
-        <linearGradient id="file-name_svg__file-name_svg__original-id" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <style>/* test */</style>
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0" />
             <stop offset="1" stop-color="#6b5aed" />
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#file-name_svg__file-name_svg__original-id)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>
 
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style/>
-        <linearGradient id="a" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0"/>
             <stop offset="1" stop-color="#6b5aed"/>
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#a)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>


### PR DESCRIPTION
Fixed: https://github.com/svg/svgo/issues/1226

In the minifyStyles plugin, if the <style> is empty or the css rule in it is not applied to the current svg node, we should remove the empty <style> element.

A similar process has been done in the [inlineStyles plugin](https://github.com/svg/svgo/blob/091172a392f6d751855477d51e5c8bd3e44fde97/plugins/inlineStyles.js#L220-L223).

https://github.com/svg/svgo/blob/091172a392f6d751855477d51e5c8bd3e44fde97/plugins/inlineStyles.js#L220-L223

## Origin

```svg
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <style></style>
    <style />
    <rect x="10" y="10" width="100" height="100"/>
</svg>
```

## Before: 

```svg
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <style />
    <style />
    <rect x="10" y="10" width="100" height="100"/>
</svg>
```

## After:

```svg
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <rect x="10" y="10" width="100" height="100"/>
</svg>
```
