### PR TITLE
Update example for removeAttrs

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -39,7 +39,7 @@ const config = {
     'convertShapeToPath',
     'sortAttrs',
     'removeDimensions',
-    { name: 'removeAttrs', attrs: '(stroke|fill)' },
+    { name: 'removeAttrs', params: { attrs: '(stroke|fill)' } },
   ],
 };
 


### PR DESCRIPTION
Old example didn't work with `removeAttrs` plugin. This worked for me and also validated here:
https://github.com/svg/svgo/issues/1344