### PR TITLE
Implement exclude pattern cli option

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -56,11 +56,11 @@ module.exports = function makeProgram(program) {
     .option('--indent <INTEGER>', 'Indent number when pretty printing SVGs')
     .option(
       '-r, --recursive',
-      "Use with '-f'. Optimizes *.svg files in folders recursively."
+      "Use with '--folder'. Optimizes *.svg files in folders recursively."
     )
     .option(
-      '-e, --exclude <PATTERN...>',
-      "Use with '-f'. Exclude files matching regular expression pattern."
+      '--exclude <PATTERN...>',
+      "Use with '--folder'. Exclude files matching regular expression pattern."
     )
     .option(
       '-q, --quiet',

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -161,9 +161,7 @@ async function action(args, opts, command) {
   }
 
   // --exclude
-  if (opts.exclude) {
-    config.exclude = opts.exclude.map(pattern => RegExp(pattern));
-  }
+  config.exclude = opts.exclude ? opts.exclude.map(pattern => RegExp(pattern)) : [];
 
   // --precision
   if (opts.precision != null) {
@@ -209,11 +207,14 @@ async function action(args, opts, command) {
     config.datauri = opts.datauri;
   }
 
+  console.log(config)
+
   // --folder
   if (opts.folder) {
     var ouputFolder = (output && output[0]) || opts.folder;
     await optimizeFolder(config, opts.folder, ouputFolder);
   }
+
 
   // --input
   if (input.length !== 0) {

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -299,7 +299,11 @@ function processDirectory(config, dir, files, output) {
  */
 function getFilesDescriptions(config, dir, files, output) {
   const filesInThisFolder = files
-    .filter((name) => regSVGFile.test(name) && !config.exclude.some(regExclude => regExclude.test(name)))
+    .filter(
+      (name) =>
+        regSVGFile.test(name) &&
+        !config.exclude.some(regExclude => regExclude.test(name))
+     )
     .map((name) => ({
       inputPath: PATH.resolve(dir, name),
       outputPath: PATH.resolve(output, name),

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -59,6 +59,10 @@ module.exports = function makeProgram(program) {
       "Use with '-f'. Optimizes *.svg files in folders recursively."
     )
     .option(
+      '-e, --exclude <PATTERN...>',
+      "Use with '-f'. Exclude files matching regular expression pattern."
+    )
+    .option(
       '-q, --quiet',
       'Only output error messages, not regular status messages'
     )
@@ -154,6 +158,11 @@ async function action(args, opts, command) {
   // --recursive
   if (opts.recursive) {
     config.recursive = opts.recursive;
+  }
+
+  // --exclude
+  if (opts.exclude) {
+    config.exclude = opts.exclude.map(pattern => RegExp(pattern));
   }
 
   // --precision
@@ -291,7 +300,7 @@ function processDirectory(config, dir, files, output) {
  */
 function getFilesDescriptions(config, dir, files, output) {
   const filesInThisFolder = files
-    .filter((name) => regSVGFile.test(name))
+    .filter((name) => regSVGFile.test(name) && !config.exclude.some(regExclude => regExclude.test(name)))
     .map((name) => ({
       inputPath: PATH.resolve(dir, name),
       outputPath: PATH.resolve(output, name),

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -207,8 +207,6 @@ async function action(args, opts, command) {
     config.datauri = opts.datauri;
   }
 
-  console.log(config)
-
   // --folder
   if (opts.folder) {
     var ouputFolder = (output && output[0]) || opts.folder;

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -161,7 +161,9 @@ async function action(args, opts, command) {
   }
 
   // --exclude
-  config.exclude = opts.exclude ? opts.exclude.map(pattern => RegExp(pattern)) : [];
+  config.exclude = opts.exclude
+    ? opts.exclude.map((pattern) => RegExp(pattern))
+    : [];
 
   // --precision
   if (opts.precision != null) {
@@ -212,7 +214,6 @@ async function action(args, opts, command) {
     var ouputFolder = (output && output[0]) || opts.folder;
     await optimizeFolder(config, opts.folder, ouputFolder);
   }
-
 
   // --input
   if (input.length !== 0) {
@@ -302,8 +303,8 @@ function getFilesDescriptions(config, dir, files, output) {
     .filter(
       (name) =>
         regSVGFile.test(name) &&
-        !config.exclude.some(regExclude => regExclude.test(name))
-     )
+        !config.exclude.some((regExclude) => regExclude.test(name))
+    )
     .map((name) => ({
       inputPath: PATH.resolve(dir, name),
       outputPath: PATH.resolve(output, name),


### PR DESCRIPTION
Hello, 

I ran accross #1392 because we have almost exactly the same issue
We currently have a kinda big custom script allowing us to do filtering on recursive svgo processing and we were trying to migrate to the cli but this feature is missing

So I implementend a tiny option which accept an array of regex pattern that we can use to filter out file descriptors 