### PR TITLE
Replace attributes iterators with for/of

### DIFF
--- a/lib/svgo/jsAPI.js
+++ b/lib/svgo/jsAPI.js
@@ -202,6 +202,7 @@ JSAPI.prototype.hasAttr = function (name, val) {
   if (name == null) {
     return true;
   }
+  // eslint-disable-next-line no-prototype-builtins
   if (this.attributes.hasOwnProperty(name) === false) {
     return false;
   }

--- a/plugins/_applyTransforms.js
+++ b/plugins/_applyTransforms.js
@@ -25,14 +25,14 @@ const applyTransforms = (elem, pathData, params) => {
   // if there are no 'stroke' attr and references to other objects such as
   // gradiends or clip-path which are also subjects to transform.
   if (
-    !elem.hasAttr('transform') ||
-    !elem.attr('transform').value ||
+    elem.attributes.transform == null ||
+    elem.attributes.transform === '' ||
     // styles are not considered when applying transform
     // can be fixed properly with new style engine
-    elem.hasAttr('style') ||
-    elem.someAttr(
-      (attr) =>
-        referencesProps.includes(attr.name) && attr.value.includes('url(')
+    elem.attributes.style != null ||
+    Object.entries(elem.attributes).some(
+      ([name, value]) =>
+        referencesProps.includes(name) && value.includes('url(')
     )
   ) {
     return;

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -28,27 +28,25 @@ var regNewlinesNeedSpace = /(\S)\r?\n(\S)/g,
  */
 exports.fn = function (item, params) {
   if (item.type === 'element') {
-    item.eachAttr(function (attr) {
+    for (const name of Object.keys(item.attributes)) {
       if (params.newlines) {
         // new line which requires a space instead of themselve
-        attr.value = attr.value.replace(
+        item.attributes[name] = item.attributes[name].replace(
           regNewlinesNeedSpace,
-          function (match, p1, p2) {
-            return p1 + ' ' + p2;
-          }
+          (match, p1, p2) => p1 + ' ' + p2
         );
 
         // simple new line
-        attr.value = attr.value.replace(regNewlines, '');
+        item.attributes[name] = item.attributes[name].replace(regNewlines, '');
       }
 
       if (params.trim) {
-        attr.value = attr.value.trim();
+        item.attributes[name] = item.attributes[name].trim();
       }
 
       if (params.spaces) {
-        attr.value = attr.value.replace(regSpaces, ' ');
+        item.attributes[name] = item.attributes[name].replace(regSpaces, ' ');
       }
-    });
+    }
   }
 };

--- a/plugins/cleanupIDs.js
+++ b/plugins/cleanupIDs.js
@@ -146,11 +146,6 @@ exports.fn = function (data, params) {
       }
       // …and don't remove any ID if yes
       if (item.type === 'element') {
-        const each = (item, fn) => {
-          for (const [name, value] of Object.entries(item.attributes)) {
-            fn([name, value]);
-          }
-        };
         for (const [name, value] of Object.entries(item.attributes)) {
           let key;
           let match;

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -49,13 +49,13 @@ exports.fn = function (item, params) {
         .join(' ');
     }
 
-    item.eachAttr(function (attr) {
+    for (const [name, value] of Object.entries(item.attributes)) {
       // The `version` attribute is a text string and cannot be rounded
-      if (attr.name === 'version') {
-        return;
+      if (name === 'version') {
+        continue;
       }
 
-      var match = attr.value.match(regNumericValues);
+      var match = value.match(regNumericValues);
 
       // if attribute value matches regNumericValues
       if (match) {
@@ -85,8 +85,8 @@ exports.fn = function (item, params) {
           units = '';
         }
 
-        attr.value = num + units;
+        item.attributes[name] = num + units;
       }
-    });
+    }
   }
 };

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -66,25 +66,24 @@ exports.fn = function (item) {
                 !g.hasAttr('transform') &&
                 !inner.hasAttr('transform')))
           ) {
-            g.eachAttr(function (attr) {
-              if (g.children.some(hasAnimatedAttr, attr.name)) return;
+            for (const [name, value] of Object.entries(g.attributes)) {
+              if (g.children.some(hasAnimatedAttr, name)) return;
 
-              if (!inner.hasAttr(attr.name)) {
-                inner.addAttr(attr);
-              } else if (attr.name == 'transform') {
-                inner.attr(attr.name).value =
-                  attr.value + ' ' + inner.attr(attr.name).value;
-              } else if (inner.hasAttr(attr.name, 'inherit')) {
-                inner.attr(attr.name).value = attr.value;
+              if (!inner.hasAttr(name)) {
+                inner.attributes[name] = value;
+              } else if (name == 'transform') {
+                inner.attributes[name] = value + ' ' + inner.attributes[name];
+              } else if (inner.hasAttr(name, 'inherit')) {
+                inner.attributes[name] = value;
               } else if (
-                attrsInheritable.indexOf(attr.name) < 0 &&
-                !inner.hasAttr(attr.name, attr.value)
+                attrsInheritable.includes(name) === false &&
+                !inner.hasAttr(name, value)
               ) {
                 return;
               }
 
-              g.removeAttr(attr.name);
-            });
+              g.removeAttr(name);
+            }
           }
         }
 

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -51,10 +51,10 @@ var collections = require('./_collections'),
  */
 exports.fn = function (item, params) {
   if (item.type === 'element') {
-    item.eachAttr(function (attr) {
-      if (collections.colorsProps.indexOf(attr.name) > -1) {
-        var val = attr.value,
-          match;
+    for (const [name, value] of Object.entries(item.attributes)) {
+      if (collections.colorsProps.includes(name)) {
+        let val = value;
+        let match;
 
         // Convert colors to currentColor
         if (params.currentColor) {
@@ -99,9 +99,9 @@ exports.fn = function (item, params) {
           }
         }
 
-        attr.value = val;
+        item.attributes[name] = val;
       }
-    });
+    }
   }
 };
 

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -34,26 +34,23 @@ exports.fn = function (item) {
   if (
     item.isElem('g') &&
     item.children.length !== 0 &&
-    item.hasAttr('transform') &&
-    !item.someAttr(function (attr) {
-      return ~referencesProps.indexOf(attr.name) && ~attr.value.indexOf('url(');
-    }) &&
-    item.children.every(function (inner) {
-      return inner.isElem(pathElems) && !inner.hasAttr('id');
-    })
+    item.attributes.transform != null &&
+    Object.entries(item.attributes).some(
+      ([name, value]) =>
+        referencesProps.includes(name) && value.includes('url(')
+    ) === false &&
+    item.children.every(
+      (inner) => inner.isElem(pathElems) && !inner.hasAttr('id')
+    )
   ) {
-    item.children.forEach(function (inner) {
-      var attr = item.attr('transform');
-      if (inner.hasAttr('transform')) {
-        inner.attr('transform').value =
-          attr.value + ' ' + inner.attr('transform').value;
+    for (const inner of item.children) {
+      const value = item.attributes.transform;
+      if (inner.attributes.transform != null) {
+        inner.attributes.transform = value + ' ' + inner.attributes.transform;
       } else {
-        inner.addAttr({
-          name: attr.name,
-          value: attr.value,
-        });
+        inner.attributes.transform = value;
       }
-    });
+    }
 
     item.removeAttr('transform');
   }

--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -124,9 +124,7 @@ exports.fn = function (item, params) {
       // matches element
       if (pattern[0].test(item.name)) {
         // loop attributes
-        item.eachAttr(function (attr) {
-          var name = attr.name;
-          var value = attr.value;
+        for (const [name, value] of Object.entries(item.attributes)) {
           var isFillCurrentColor =
             preserveCurrentColor && name == 'fill' && value == 'currentColor';
           var isStrokeCurrentColor =
@@ -136,12 +134,12 @@ exports.fn = function (item, params) {
             // matches attribute name
             if (pattern[1].test(name)) {
               // matches attribute value
-              if (pattern[2].test(attr.value)) {
+              if (pattern[2].test(value)) {
                 item.removeAttr(name);
               }
             }
           }
-        });
+        }
       }
     });
   }

--- a/plugins/removeEditorsNSData.js
+++ b/plugins/removeEditorsNSData.js
@@ -36,24 +36,24 @@ exports.fn = function (item, params) {
 
   if (item.type === 'element') {
     if (item.isElem('svg')) {
-      item.eachAttr(function (attr) {
-        const { prefix, local } = parseName(attr.name);
-        if (prefix === 'xmlns' && editorNamespaces.includes(attr.value)) {
+      for (const [name, value] of Object.entries(item.attributes)) {
+        const { prefix, local } = parseName(name);
+        if (prefix === 'xmlns' && editorNamespaces.includes(value)) {
           prefixes.push(local);
 
           // <svg xmlns:sodipodi="">
-          item.removeAttr(attr.name);
+          item.removeAttr(name);
         }
-      });
+      }
     }
 
     // <* sodipodi:*="">
-    item.eachAttr(function (attr) {
-      const { prefix } = parseName(attr.name);
+    for (const name of Object.keys(item.attributes)) {
+      const { prefix } = parseName(name);
       if (prefixes.includes(prefix)) {
-        item.removeAttr(attr.name);
+        item.removeAttr(name);
       }
-    });
+    }
 
     // <sodipodi:*>
     const { prefix } = parseName(item.name);

--- a/plugins/removeEmptyAttrs.js
+++ b/plugins/removeEmptyAttrs.js
@@ -18,14 +18,14 @@ exports.description = 'removes empty attributes';
  */
 exports.fn = function (item) {
   if (item.type === 'element') {
-    item.eachAttr(function (attr) {
+    for (const [name, value] of Object.entries(item.attributes)) {
       if (
-        attr.value === '' &&
+        value === '' &&
         // empty conditional processing attributes prevents elements from rendering
-        attrsGroups.conditionalProcessing.includes(attr.name) === false
+        attrsGroups.conditionalProcessing.includes(name) === false
       ) {
-        item.removeAttr(attr.name);
+        item.removeAttr(name);
       }
-    });
+    }
   }
 };

--- a/plugins/removeNonInheritableGroupAttrs.js
+++ b/plugins/removeNonInheritableGroupAttrs.js
@@ -7,9 +7,11 @@ exports.active = true;
 exports.description =
   'removes non-inheritable group’s presentational attributes';
 
-var inheritableAttrs = require('./_collections').inheritableAttrs,
-  attrsGroups = require('./_collections').attrsGroups,
-  applyGroups = require('./_collections').presentationNonInheritableGroupAttrs;
+const {
+  inheritableAttrs,
+  attrsGroups,
+  presentationNonInheritableGroupAttrs,
+} = require('./_collections');
 
 /**
  * Remove non-inheritable group's "presentation" attributes.
@@ -20,15 +22,15 @@ var inheritableAttrs = require('./_collections').inheritableAttrs,
  * @author Kir Belevich
  */
 exports.fn = function (item) {
-  if (item.isElem('g')) {
-    item.eachAttr(function (attr) {
+  if (item.type === 'element' && item.name === 'g') {
+    for (const name of Object.keys(item.attributes)) {
       if (
-        ~attrsGroups.presentation.indexOf(attr.name) &&
-        !~inheritableAttrs.indexOf(attr.name) &&
-        !~applyGroups.indexOf(attr.name)
+        attrsGroups.presentation.includes(name) === true &&
+        inheritableAttrs.includes(name) === false &&
+        presentationNonInheritableGroupAttrs.includes(name) === false
       ) {
-        item.removeAttr(attr.name);
+        item.removeAttr(name);
       }
-    });
+    }
   }
 };

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -93,37 +93,36 @@ exports.fn = function (item, params) {
 
     // remove element's unknown attrs and attrs with default values
     if (elems[elem] && elems[elem].attrs) {
-      item.eachAttr(function (attr) {
-        const { prefix } = parseName(attr.name);
+      for (const [name, value] of Object.entries(item.attributes)) {
+        const { prefix } = parseName(name);
         if (
-          attr.name !== 'xmlns' &&
+          name !== 'xmlns' &&
           (prefix === 'xml' || !prefix) &&
-          (!params.keepDataAttrs || attr.name.indexOf('data-') != 0) &&
-          (!params.keepAriaAttrs || attr.name.indexOf('aria-') != 0) &&
-          (!params.keepRoleAttr || attr.name != 'role')
+          (!params.keepDataAttrs || name.indexOf('data-') != 0) &&
+          (!params.keepAriaAttrs || name.indexOf('aria-') != 0) &&
+          (!params.keepRoleAttr || name != 'role')
         ) {
           if (
             // unknown attrs
-            (params.unknownAttrs &&
-              elems[elem].attrs.indexOf(attr.name) === -1) ||
+            (params.unknownAttrs && elems[elem].attrs.indexOf(name) === -1) ||
             // attrs with default values
             (params.defaultAttrs &&
               !item.hasAttr('id') &&
               elems[elem].defaults &&
-              elems[elem].defaults[attr.name] === attr.value &&
-              (attrsInheritable.indexOf(attr.name) < 0 ||
-                !item.parentNode.computedAttr(attr.name))) ||
+              elems[elem].defaults[name] === value &&
+              (attrsInheritable.indexOf(name) < 0 ||
+                !item.parentNode.computedAttr(name))) ||
             // useless overrides
             (params.uselessOverrides &&
               !item.hasAttr('id') &&
-              applyGroups.indexOf(attr.name) < 0 &&
-              attrsInheritable.indexOf(attr.name) > -1 &&
-              item.parentNode.computedAttr(attr.name, attr.value))
+              applyGroups.indexOf(name) < 0 &&
+              attrsInheritable.indexOf(name) > -1 &&
+              item.parentNode.computedAttr(name, value))
           ) {
-            item.removeAttr(attr.name);
+            item.removeAttr(name);
           }
         }
-      });
+      }
     }
   }
 };

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -56,11 +56,11 @@ exports.fn = function (item, params) {
         var parentStroke = item.parentNode.computedAttr('stroke'),
           declineStroke = parentStroke && parentStroke != 'none';
 
-        item.eachAttr(function (attr) {
-          if (regStrokeProps.test(attr.name)) {
-            item.removeAttr(attr.name);
+        for (const name of Object.keys(item.attributes)) {
+          if (regStrokeProps.test(name)) {
+            item.removeAttr(name);
           }
-        });
+        }
 
         if (declineStroke)
           item.addAttr({
@@ -72,11 +72,11 @@ exports.fn = function (item, params) {
 
     // remove fill*
     if (params.fill && (!fill || item.computedAttr('fill-opacity', '0'))) {
-      item.eachAttr(function (attr) {
-        if (regFillProps.test(attr.name)) {
-          item.removeAttr(attr.name);
+      for (const name of Object.keys(item.attributes)) {
+        if (regFillProps.test(name)) {
+          item.removeAttr(name);
         }
-      });
+      }
 
       if (fill) {
         if (item.hasAttr('fill')) item.attr('fill').value = 'none';

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -39,15 +39,14 @@ exports.params = {
  * @author Nikolay Frantsev
  */
 exports.fn = function (item, params) {
-  var attrs = [],
-    sorted = {},
-    orderlen = params.order.length + 1,
-    xmlnsOrder = params.xmlnsOrder || 'front';
+  const attrs = [];
+  const orderlen = params.order.length + 1;
+  const xmlnsOrder = params.xmlnsOrder || 'front';
 
   if (item.type === 'element') {
-    item.eachAttr(function (attr) {
-      attrs.push(attr);
-    });
+    for (const [name, value] of Object.entries(item.attributes)) {
+      attrs.push({ name, value });
+    }
 
     attrs.sort(function (a, b) {
       const { prefix: prefixA } = parseName(a.name);
@@ -83,10 +82,11 @@ exports.fn = function (item, params) {
       return a.name < b.name ? -1 : 1;
     });
 
+    const sorted = {};
     attrs.forEach(function (attr) {
-      sorted[attr.name] = attr;
+      sorted[attr.name] = attr.value;
     });
 
-    item.attrs = sorted;
+    item.attributes = sorted;
   }
 };

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -39,39 +39,36 @@ exports.params = {
  * @author Nikolay Frantsev
  */
 exports.fn = function (item, params) {
-  const attrs = [];
   const orderlen = params.order.length + 1;
   const xmlnsOrder = params.xmlnsOrder || 'front';
 
   if (item.type === 'element') {
-    for (const [name, value] of Object.entries(item.attributes)) {
-      attrs.push({ name, value });
-    }
+    const attrs = Object.entries(item.attributes);
 
-    attrs.sort(function (a, b) {
-      const { prefix: prefixA } = parseName(a.name);
-      const { prefix: prefixB } = parseName(b.name);
-      if (prefixA != prefixB) {
+    attrs.sort(([aName], [bName]) => {
+      const { prefix: aPrefix } = parseName(aName);
+      const { prefix: bPrefix } = parseName(bName);
+      if (aPrefix != bPrefix) {
         // xmlns attributes implicitly have the prefix xmlns
         if (xmlnsOrder == 'front') {
-          if (prefixA === 'xmlns') return -1;
-          if (prefixB === 'xmlns') return 1;
+          if (aPrefix === 'xmlns') return -1;
+          if (bPrefix === 'xmlns') return 1;
         }
-        return prefixA < prefixB ? -1 : 1;
+        return aPrefix < bPrefix ? -1 : 1;
       }
 
-      var aindex = orderlen;
-      var bindex = orderlen;
+      let aindex = orderlen;
+      let bindex = orderlen;
 
-      for (var i = 0; i < params.order.length; i++) {
-        if (a.name == params.order[i]) {
+      for (let i = 0; i < params.order.length; i++) {
+        if (aName == params.order[i]) {
           aindex = i;
-        } else if (a.name.indexOf(params.order[i] + '-') === 0) {
+        } else if (aName.indexOf(params.order[i] + '-') === 0) {
           aindex = i + 0.5;
         }
-        if (b.name == params.order[i]) {
+        if (bName == params.order[i]) {
           bindex = i;
-        } else if (b.name.indexOf(params.order[i] + '-') === 0) {
+        } else if (bName.indexOf(params.order[i] + '-') === 0) {
           bindex = i + 0.5;
         }
       }
@@ -79,14 +76,13 @@ exports.fn = function (item, params) {
       if (aindex != bindex) {
         return aindex - bindex;
       }
-      return a.name < b.name ? -1 : 1;
+      return aName < bName ? -1 : 1;
     });
 
     const sorted = {};
-    attrs.forEach(function (attr) {
-      sorted[attr.name] = attr.value;
-    });
-
+    for (const [name, value] of attrs) {
+      sorted[name] = value;
+    }
     item.attributes = sorted;
   }
 };


### PR DESCRIPTION
These iterators allows to directly manipulate passed value
which does not let us to get rid from legacy "attrs" field.

Object.entries makes it easier to get an access to both attribute
name and value.