### PR TITLE
Migrate ast traversing into xast module

### DIFF
--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const { computeStyle } = require('./style.js');
+const { querySelector } = require('./xast.js');
 const svg2js = require('./svgo/svg2js.js');
 
 describe('computeStyle', () => {
@@ -30,24 +31,24 @@ describe('computeStyle', () => {
         </style>
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#class'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#class'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'red' },
     });
-    expect(computeStyle(root.querySelector('#two-classes'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#two-classes'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'green' },
       stroke: { type: 'static', inherited: false, value: 'black' },
     });
-    expect(computeStyle(root.querySelector('#attribute'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#attribute'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'purple' },
     });
-    expect(computeStyle(root.querySelector('#inline-style'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#inline-style'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'grey' },
     });
-    expect(computeStyle(root.querySelector('#inheritance'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#inheritance'))).to.deep.equal({
       fill: { type: 'static', inherited: true, value: 'yellow' },
     });
     expect(
-      computeStyle(root.querySelector('#nested-inheritance'))
+      computeStyle(querySelector(root, '#nested-inheritance'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: true, value: 'blue' },
     });
@@ -69,23 +70,23 @@ describe('computeStyle', () => {
         </g>
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#complex-selector'))).to.deep.equal(
-      {
-        fill: { type: 'static', inherited: false, value: 'red' },
-      }
-    );
     expect(
-      computeStyle(root.querySelector('#attribute-over-inheritance'))
+      computeStyle(querySelector(root, '#complex-selector'))
+    ).to.deep.equal({
+      fill: { type: 'static', inherited: false, value: 'red' },
+    });
+    expect(
+      computeStyle(querySelector(root, '#attribute-over-inheritance'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'orange' },
     });
     expect(
-      computeStyle(root.querySelector('#style-rule-over-attribute'))
+      computeStyle(querySelector(root, '#style-rule-over-attribute'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'blue' },
     });
     expect(
-      computeStyle(root.querySelector('#inline-style-over-style-rule'))
+      computeStyle(querySelector(root, '#inline-style-over-style-rule'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'purple' },
     });
@@ -103,18 +104,18 @@ describe('computeStyle', () => {
         <rect id="inline-style-over-style-rule" style="fill: purple !important;" class="b" />
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#complex-selector'))).to.deep.equal(
-      {
-        fill: { type: 'static', inherited: false, value: 'green' },
-      }
-    );
     expect(
-      computeStyle(root.querySelector('#style-rule-over-inline-style'))
+      computeStyle(querySelector(root, '#complex-selector'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'green' },
     });
     expect(
-      computeStyle(root.querySelector('#inline-style-over-style-rule'))
+      computeStyle(querySelector(root, '#style-rule-over-inline-style'))
+    ).to.deep.equal({
+      fill: { type: 'static', inherited: false, value: 'green' },
+    });
+    expect(
+      computeStyle(querySelector(root, '#inline-style-over-style-rule'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'purple' },
     });
@@ -140,21 +141,21 @@ describe('computeStyle', () => {
         <rect id="static" class="c" style="fill: black" />
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#media-query'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#media-query'))).to.deep.equal({
       fill: { type: 'dynamic', inherited: false },
     });
-    expect(computeStyle(root.querySelector('#hover'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#hover'))).to.deep.equal({
       fill: { type: 'dynamic', inherited: false },
     });
-    expect(computeStyle(root.querySelector('#inherited'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#inherited'))).to.deep.equal({
       fill: { type: 'dynamic', inherited: true },
     });
     expect(
-      computeStyle(root.querySelector('#inherited-overriden'))
+      computeStyle(querySelector(root, '#inherited-overriden'))
     ).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'blue' },
     });
-    expect(computeStyle(root.querySelector('#static'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#static'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'black' },
     });
   });
@@ -176,13 +177,13 @@ describe('computeStyle', () => {
         <rect id="static" class="c" />
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#media-query'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#media-query'))).to.deep.equal({
       fill: { type: 'dynamic', inherited: false },
     });
-    expect(computeStyle(root.querySelector('#kinda-static'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#kinda-static'))).to.deep.equal({
       fill: { type: 'dynamic', inherited: false },
     });
-    expect(computeStyle(root.querySelector('#static'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#static'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'blue' },
     });
   });
@@ -204,13 +205,15 @@ describe('computeStyle', () => {
         <rect id="invalid-type" class="c" />
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#valid-type'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#valid-type'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'red' },
     });
-    expect(computeStyle(root.querySelector('#empty-type'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#empty-type'))).to.deep.equal({
       fill: { type: 'static', inherited: false, value: 'green' },
     });
-    expect(computeStyle(root.querySelector('#invalid-type'))).to.deep.equal({});
+    expect(computeStyle(querySelector(root, '#invalid-type'))).to.deep.equal(
+      {}
+    );
   });
 
   it('ignores keyframes atrule', () => {
@@ -235,7 +238,7 @@ describe('computeStyle', () => {
         <rect id="element" class="a" />
       </svg>
     `);
-    expect(computeStyle(root.querySelector('#element'))).to.deep.equal({
+    expect(computeStyle(querySelector(root, '#element'))).to.deep.equal({
       animation: {
         type: 'static',
         inherited: false,

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { selectAll, selectOne, is } = require('css-select');
+const xastAdaptor = require('./svgo/css-select-adapter.js');
+
+const cssSelectOptions = {
+  xmlMode: true,
+  adapter: xastAdaptor,
+};
+
+const querySelectorAll = (node, selector) => {
+  return selectAll(selector, node, cssSelectOptions);
+};
+exports.querySelectorAll = querySelectorAll;
+
+const querySelector = (node, selector) => {
+  return selectOne(selector, node, cssSelectOptions);
+};
+exports.querySelector = querySelector;
+
+const matches = (node, selector) => {
+  return is(node, selector, cssSelectOptions);
+};
+exports.matches = matches;
+
+const closestByName = (node, name) => {
+  let currentNode = node;
+  while (currentNode) {
+    if (currentNode.type === 'element' && currentNode.name === name) {
+      return currentNode;
+    }
+    currentNode = currentNode.parentNode;
+  }
+  return null;
+};
+exports.closestByName = closestByName;
+
+const traverseBreak = Symbol();
+exports.traverseBreak = traverseBreak;
+
+const traverse = (node, fn) => {
+  if (fn(node) === traverseBreak) {
+    return traverseBreak;
+  }
+  if (node.type === 'root' || node.type === 'element') {
+    for (const child of node.children) {
+      if (traverse(child, fn) === traverseBreak) {
+        return traverseBreak;
+      }
+    }
+  }
+};
+exports.traverse = traverse;

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const csstree = require('css-tree');
+const { querySelectorAll, closestByName } = require('../lib/xast.js');
+const cssTools = require('../lib/css-tools');
+
 exports.type = 'full';
 
 exports.active = true;
@@ -12,9 +16,6 @@ exports.params = {
 };
 
 exports.description = 'inline styles (additional options)';
-
-var csstree = require('css-tree'),
-  cssTools = require('../lib/css-tools');
 
 /**
  * Moves + merges styles from style elements to element styles
@@ -35,18 +36,18 @@ var csstree = require('css-tree'),
  *     what pseudo-classes/-elements to be used
  *     empty string element for all non-pseudo-classes and/or -elements
  *
- * @param {Object} document document element
+ * @param {Object} root document element
  * @param {Object} opts plugin params
  *
  * @author strarsis <strarsis@gmail.com>
  */
-exports.fn = function (document, opts) {
+exports.fn = function (root, opts) {
   // collect <style/>s
-  var styleEls = document.querySelectorAll('style');
+  var styleEls = querySelectorAll(root, 'style');
 
   //no <styles/>s, nothing to do
-  if (styleEls === null) {
-    return document;
+  if (styleEls.length === 0) {
+    return root;
   }
 
   var styles = [],
@@ -62,7 +63,10 @@ exports.fn = function (document, opts) {
       continue;
     }
     // skip empty <style/>s or <foreignObject> content.
-    if (styleEl.children.length === 0 || styleEl.closestElem('foreignObject')) {
+    if (
+      styleEl.children.length === 0 ||
+      closestByName(styleEl, 'foreignObject')
+    ) {
       continue;
     }
 
@@ -108,13 +112,13 @@ exports.fn = function (document, opts) {
       selectedEls = null;
 
     try {
-      selectedEls = document.querySelectorAll(selectorStr);
+      selectedEls = querySelectorAll(root, selectorStr);
     } catch (selectError) {
       // console.warn('Warning: Syntax error when trying to select \n\n' + selectorStr + '\n\n, skipped. Error details: ' + selectError);
       continue;
     }
 
-    if (selectedEls === null) {
+    if (selectedEls.length === 0) {
       // nothing selected
       continue;
     }
@@ -181,7 +185,7 @@ exports.fn = function (document, opts) {
   }
 
   if (!opts.removeMatchedSelectors) {
-    return document; // no further processing required
+    return root; // no further processing required
   }
 
   // clean up matched class + ID attribute values
@@ -269,5 +273,5 @@ exports.fn = function (document, opts) {
     cssTools.setCssStr(style.styleEl, csstree.generate(style.cssAst));
   }
 
-  return document;
+  return root;
 };

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { querySelector, closestByName } = require('../lib/xast.js');
 const { computeStyle } = require('../lib/style.js');
 const { parsePathData } = require('../lib/path.js');
 
@@ -58,7 +59,7 @@ exports.fn = function (item, params) {
       computedStyle.visibility.type === 'static' &&
       computedStyle.visibility.value === 'hidden' &&
       // keep if any descendant enables visibility
-      item.querySelector('[visibility=visible]') == null
+      querySelector(item, '[visibility=visible]') == null
     ) {
       return false;
     }
@@ -88,7 +89,7 @@ exports.fn = function (item, params) {
       computedStyle.opacity.type === 'static' &&
       computedStyle.opacity.value === '0' &&
       // transparent element inside clipPath still affect clipped elements
-      item.closestElem('clipPath') == null
+      closestByName(item, 'clipPath') == null
     ) {
       return false;
     }

--- a/plugins/removeUnusedNS.js
+++ b/plugins/removeUnusedNS.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { traverse, traverseBreak } = require('../lib/xast.js');
+const { traverse } = require('../lib/xast.js');
 const { parseName } = require('../lib/svgo/tools.js');
 
 exports.type = 'full';

--- a/plugins/removeViewBox.js
+++ b/plugins/removeViewBox.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { closestByName } = require('../lib/xast.js');
+
 exports.type = 'perItem';
 
 exports.active = true;
@@ -32,7 +34,7 @@ exports.fn = function (item) {
     item.attributes.height != null
   ) {
     // TODO remove width/height for such case instead
-    if (item.name === 'svg' && item.closestElem('svg')) {
+    if (item.name === 'svg' && closestByName(item.parentNode, 'svg')) {
       return;
     }
 


### PR DESCRIPTION
Replaced JSAPI methods with new utilities

- querySelectorAll(node, selector)
- querySelector(node, selector)
- matches(node, selector)
- closestByName(node, elementName)
- traverse(node, fn)

New traverse replaced many in-place implementations (bananas).

Note: review with hidden whitespaces