### PR TITLE
Use charAt instead of charCodeAt when possible

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -103,7 +103,7 @@ exports.cleanupOutData = function (data, params, command) {
     if (
       params.negativeExtraSpace &&
       delimiter != '' &&
-      (item < 0 || (itemStr.charCodeAt(0) == 46 && prev % 1 !== 0))
+      (item < 0 || (itemStr.charAt(0) === '.' && prev % 1 !== 0))
     ) {
       delimiter = '';
     }
@@ -130,9 +130,9 @@ exports.cleanupOutData = function (data, params, command) {
 var removeLeadingZero = function (num) {
   var strNum = num.toString();
 
-  if (0 < num && num < 1 && strNum.charCodeAt(0) == 48) {
+  if (0 < num && num < 1 && strNum.charAt(0) === '0') {
     strNum = strNum.slice(1);
-  } else if (-1 < num && num < 0 && strNum.charCodeAt(1) == 48) {
+  } else if (-1 < num && num < 0 && strNum.charAt(1) === '0') {
     strNum = strNum.charAt(0) + strNum.slice(2);
   }
   return strNum;


### PR DESCRIPTION
Make the intention clearer than having to look at the ASCI codes. Performance should be the same.