### PR TITLE
Add fix for cloning a JS Map when cloning a node

### DIFF
--- a/lib/svgo/css-style-declaration.js
+++ b/lib/svgo/css-style-declaration.js
@@ -34,6 +34,10 @@ CSSStyleDeclaration.prototype.clone = function (parentNode) {
 
   var clone = new CSSStyleDeclaration(parentNode);
   Object.assign(clone, nodeData);
+
+  // JS Maps require explict cloning
+  clone.properties = new Map(node.properties);
+
   return clone;
 };
 


### PR DESCRIPTION
This PR fixes deep cloning of CSSStyleDeclaration AST nodes.

JSON.stringify is used as a classic technique for easy deep cloning of the AST nodes.
In this case the CSSStyleDeclaration AST node uses a Map for performance.
The ES MAP is not cloned by the JSON.stringify approach, it has to be cloned separately.