### PR TITLE
fix: remove the <style> tag when the style is empty after CSS minified

### DIFF
--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const csso = require('csso');
-const { traverse } = require('../lib/xast.js');
+const { traverse, detachNodeFromParent } = require('../lib/xast.js');
 
 exports.type = 'full';
 
@@ -45,6 +45,13 @@ exports.fn = function (ast, options) {
       ) {
         const styleCss = elem.children[0].value;
         const minified = csso.minify(styleCss, minifyOptionsForStylesheet).css;
+
+        // If the result of CSS minified is empty, remove it.
+        if (minified.length === 0) {
+          detachNodeFromParent(elem);
+          return;
+        }
+
         // preserve cdata if necessary
         // TODO split cdata -> text optimisation into separate plugin
         if (styleCss.indexOf('>') >= 0 || styleCss.indexOf('<') >= 0) {

--- a/test/plugins/mergeStyles.12.svg
+++ b/test/plugins/mergeStyles.12.svg
@@ -1,23 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style></style>
-        <linearGradient id="file-name_svg__file-name_svg__original-id" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <style />
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0" />
             <stop offset="1" stop-color="#6b5aed" />
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#file-name_svg__file-name_svg__original-id)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>
 
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style/>
-        <linearGradient id="a" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0"/>
             <stop offset="1" stop-color="#6b5aed"/>
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#a)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>

--- a/test/plugins/minifyStyles.11.svg
+++ b/test/plugins/minifyStyles.11.svg
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        /* test */
+        .unused /* test */ {
+            fill: red; /* test */
+        }
+        .used {
+            fill: green; /* test */
+        }
+    </style>
+    <rect class="used" x="10" y="10" width="100" height="100"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .used{fill:green}
+    </style>
+    <rect class="used" x="10" y="10" width="100" height="100"/>
+</svg>

--- a/test/plugins/minifyStyles.11.svg
+++ b/test/plugins/minifyStyles.11.svg
@@ -1,21 +1,21 @@
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <style>
-        /* test */
-        .unused /* test */ {
-            fill: red; /* test */
-        }
-        .used {
-            fill: green; /* test */
-        }
-    </style>
-    <rect class="used" x="10" y="10" width="100" height="100"/>
+    <defs>
+        <style id="foo">
+            /* test */
+            .unused /* test */ {
+                fill: red; /* test */
+            }
+            .unused2 {
+                fill: green;
+            }
+        </style>
+    </defs>
+    <rect x="10" y="10" width="100" height="100"/>
 </svg>
 
 @@@
 
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <style>
-        .used{fill:green}
-    </style>
-    <rect class="used" x="10" y="10" width="100" height="100"/>
+    <defs/>
+    <rect x="10" y="10" width="100" height="100"/>
 </svg>

--- a/test/plugins/minifyStyles.12.svg
+++ b/test/plugins/minifyStyles.12.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .unused {
+            fill: green;
+        }
+    </style>
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>
+
+@@@
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="100" height="100"/>
+</svg>

--- a/test/plugins/minifyStyles.13.svg
+++ b/test/plugins/minifyStyles.13.svg
@@ -1,23 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style></style>
-        <linearGradient id="file-name_svg__file-name_svg__original-id" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <style>/* test */</style>
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0" />
             <stop offset="1" stop-color="#6b5aed" />
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#file-name_svg__file-name_svg__original-id)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>
 
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
     <defs>
-        <style/>
-        <linearGradient id="a" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
+        <linearGradient id="foo" x1="12" y1="-1" x2="33" y2="46" gradientUnits="userSpaceOnUse">
             <stop offset="0" stop-color="#6b5aed" stop-opacity="0"/>
             <stop offset="1" stop-color="#6b5aed"/>
         </linearGradient>
     </defs>
-    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#a)"/>
+    <path d="M5 24a21.9 21.9 10 1 1 8 18" fill="url(#foo)"/>
 </svg>


### PR DESCRIPTION
This mainly includes comments and unused CSS.

## Input: 

```svg
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <style>/* test */</style>
    <rect x="10" y="10" width="100" height="100"/>
</svg>
```

## Output:

```svg
<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <rect x="10" y="10" width="100" height="100"/>
</svg>