### PR TITLE
Remove the `removeViewBox` plugin from the default plugins list

### DIFF
--- a/docs/03-plugins/removeViewBox.mdx
+++ b/docs/03-plugins/removeViewBox.mdx
@@ -2,7 +2,6 @@
 title: removeViewBox
 svgo:
   pluginId: removeViewBox
-  defaultPlugin: true
 ---
 
 Removes the [`viewBox`](https://developer.mozilla.org/docs/Web/SVG/Attribute/viewBox) attribute where it matches the documents width and height.

--- a/plugins/preset-default.js
+++ b/plugins/preset-default.js
@@ -16,7 +16,6 @@ import * as convertColors from './convertColors.js';
 import * as removeUnknownsAndDefaults from './removeUnknownsAndDefaults.js';
 import * as removeNonInheritableGroupAttrs from './removeNonInheritableGroupAttrs.js';
 import * as removeUselessStrokeAndFill from './removeUselessStrokeAndFill.js';
-import * as removeViewBox from './removeViewBox.js';
 import * as cleanupEnableBackground from './cleanupEnableBackground.js';
 import * as removeHiddenElems from './removeHiddenElems.js';
 import * as removeEmptyText from './removeEmptyText.js';
@@ -56,7 +55,6 @@ const presetDefault = createPreset({
     removeUnknownsAndDefaults,
     removeNonInheritableGroupAttrs,
     removeUselessStrokeAndFill,
-    removeViewBox,
     cleanupEnableBackground,
     removeHiddenElems,
     removeEmptyText,

--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -1,6 +1,6 @@
 export const name = 'removeDimensions';
 export const description =
-  'removes width and height in presence of viewBox (opposite to removeViewBox, disable it first)';
+  'removes width and height in presence of viewBox (opposite to removeViewBox)';
 
 /**
  * Remove width/height attributes and add the viewBox attribute if it's missing


### PR DESCRIPTION
Given the discussions in #1128, we should remove the `removeViewBox` plugin from the list of default plugins.

The stated goal of **svgo** is to optimize SVGs _while not changing their renderings_. While SVGs can be rendered in many different contexts, one import context is rendering inside HTML documents. When an svg is placed inline with other HTML, removing the `viewBox` attribute (even when it is a duplicate of the data in the `width`/`height` attributes) does change how the svg is rendered.

According to the [SVG 1.1 specification, section 7.7 The ‘viewBox’ attribute](https://www.w3.org/TR/SVG11/coords.html#ViewBoxAttribute):

> It is often desirable to specify that a given set of graphics stretch to fit a particular container element. The `viewBox` attribute provides this capability.

When svgo removes the `viewBox` attribute, it removes that SVG's ability to be scaled to fit its containing HTML element via CSS. In other words, the Scalable Vector Graphic is no longer _scalable_.

Here's a codepen with an extensive example: https://codepen.io/johnalbin/pen/yLggyXv You can see from the screenshot below that the SVG does not scale properly when CSS resizes the SVG without the `viewBox` attribute.

<img width="934" alt="screenshot of codepen URL above showing how viewBox affects rendering" src="https://user-images.githubusercontent.com/33429/197410581-f7dc8c8e-f9be-4c38-b03f-1b4fa3f60245.png">

Almost all responsive web design websites use this (or a slight variant of the following CSS):

```css
img,
svg {
  max-width: 100%;
  height: auto;
}
```

When that CSS is used, the browser treats the `width` and `height` attributes as the intrinsic size of the image as it scales the SVG _canvas_ (what the SVG spec calls the viewport), but the _contents_ of the SVG (what the spec calls the user space coordinates) are not scaled unless the `viewBox` attribute is present.

That means removing the `viewBox` attribute changes the rendering of the SVG. And, from the svgo homepage:

> SVG files, especially those exported from various editors, usually contain a lot of redundant and useless information. This can include editor metadata, comments, hidden elements, default or non-optimal values and other stuff that can be safely removed or converted **without affecting the SVG rendering result.** _(emphasis mine)_

Which means the `removeViewBox` should not be included in the list of default plugins.

Here's the PR that fixes this bug.