### PR TITLE
Replace deprecated methods in jsAPI

### DIFF
--- a/lib/svgo/jsAPI.js
+++ b/lib/svgo/jsAPI.js
@@ -332,12 +332,12 @@ JSAPI.prototype.addAttr = function (attr) {
 
   if (attr.name === 'class') {
     // newly added class attribute
-    this.class.hasClass();
+    this.class.addClassValueHandler();
   }
 
   if (attr.name === 'style') {
     // newly added style attribute
-    this.style.hasStyle();
+    this.style.addStyleValueHandler();
   }
 
   return this.attrs[attr.name];


### PR DESCRIPTION
Replace deprecated `hasClass` with the new `addClassValueHandler` and deprecated `hasStyle` with `addStyleValueHandler`