### PR TITLE
Fix npm vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@trysound/sax": "0.1.1",
     "chalk": "^4.1.0",
     "commander": "^7.1.0",
-    "css-select": "^3.1.2",
+    "css-select": "^4.1.3",
     "css-tree": "^1.1.2",
     "csso": "^4.2.0",
     "stable": "^0.1.8"


### PR DESCRIPTION
Update css-select
High vulnerability observed in one of the dependencies of this package (css-select). Users of svgo have inherited the potential denial of service vulnerability 
<img width="586" alt="Screen Shot 2021-06-14 at 2 45 11 PM" src="https://user-images.githubusercontent.com/43827429/121963809-7d039880-cd1f-11eb-8a10-25a71f6edfbf.png">
I have bumped up the version of `css-select` to mitigate the vulnerability of this package. 
<img width="487" alt="Screen Shot 2021-06-14 at 2 44 27 PM" src="https://user-images.githubusercontent.com/43827429/121963815-7e34c580-cd1f-11eb-94c5-29938cb453e6.png">
All tests are passing after the version upgrade. 

