### PR TITLE
Add SVG Gobbler to "Ways to use SVGO"

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ const config = await loadConfig(configFile, cwd)
 * as a Atom plugin - [atom-svgo](https://github.com/1000ch/atom-svgo)
 * as a Sublime plugin - [Sublime-svgo](https://github.com/1000ch/Sublime-svgo)
 * as a Figma plugin - [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export)
+* as a Browser extension - [SVG Gobbler](https://github.com/rossmoody/svg-gobbler)
 
 ## Donators
 


### PR DESCRIPTION
I have been working on an open source browser extension called [SVG Gobbler](https://github.com/rossmoody/svg-gobbler) for a few years. Lately the project has utilized SVGO much more directly and predominantly. The eventual plan is to assume all the functionality of Jake Archibald's SVGOMG interface within the code view and allow users to upload SVGs (instead of strictly from web page sourcing).

Open to suggestions as well! 

![image](https://user-images.githubusercontent.com/29072694/126225238-5ed7b4f6-3adf-4485-aee2-de25dbf913f4.png)

