### PR TITLE
Enable sortAttrs plugin by default

### DIFF
--- a/plugins/preset-default.js
+++ b/plugins/preset-default.js
@@ -36,6 +36,7 @@ const removeUnusedNS = require('./removeUnusedNS.js');
 const sortDefsChildren = require('./sortDefsChildren.js');
 const removeTitle = require('./removeTitle.js');
 const removeDesc = require('./removeDesc.js');
+const sortAttrs = require('./sortAttrs.js');
 
 const presetDefault = createPreset({
   name: 'presetDefault',
@@ -74,6 +75,7 @@ const presetDefault = createPreset({
     sortDefsChildren,
     removeTitle,
     removeDesc,
+    sortAttrs,
   ],
 });
 

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -2,7 +2,7 @@
 
 exports.type = 'visitor';
 exports.name = 'sortAttrs';
-exports.active = false;
+exports.active = true;
 exports.description = 'Sort element attributes for better compression';
 
 /**


### PR DESCRIPTION
It was disabled by default in https://github.com/svg/svgo/commit/b9bbe7a61ba4666510226940fce0ec5c0df0dc83 without explanation - perhaps @deepsweet remembers?

Enabling it produces (slightly) smaller outputs when gzipped. You can verify with https://jakearchibald.github.io/svgomg/