### PR TITLE
Remove xmlns:xlink in removeXMLNS plugin

### DIFF
--- a/plugins/removeXMLNS.js
+++ b/plugins/removeXMLNS.js
@@ -23,5 +23,6 @@ exports.description =
 exports.fn = function (item) {
   if (item.type === 'element' && item.name === 'svg') {
     delete item.attributes.xmlns;
+    delete item.attributes['xmlns:xlink'];
   }
 };


### PR DESCRIPTION
xmlns:xlink is also not required in SVGs embedded in HTML