### PR TITLE
Replace chalk with colorette

### DIFF
--- a/bin/svgo
+++ b/bin/svgo
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { red } = require('chalk');
+const { red } = require('colorette');
 const { program } = require('commander');
 const makeProgram = require('../lib/svgo/coa');
 makeProgram(program);

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -2,7 +2,7 @@
 
 const FS = require('fs');
 const PATH = require('path');
-const chalk = require('chalk');
+const { green } = require('colorette');
 const { loadConfig, optimize } = require('../svgo-node.js');
 const pluginsMap = require('../../plugins/plugins.js');
 const PKG = require('../../package.json');
@@ -433,7 +433,7 @@ function printProfitInfo(inBytes, outBytes) {
     Math.round((inBytes / 1024) * 1000) / 1000 +
       ' KiB' +
       (profitPercents < 0 ? ' + ' : ' - ') +
-      chalk.green(Math.abs(Math.round(profitPercents * 10) / 10) + '%') +
+      green(Math.abs(Math.round(profitPercents * 10) / 10) + '%') +
       ' = ' +
       Math.round((outBytes / 1024) * 1000) / 1000 +
       ' KiB'
@@ -485,7 +485,7 @@ function checkWriteFileError(input, output, data, error) {
 function showAvailablePlugins() {
   const list = Object.entries(pluginsMap)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, plugin]) => ` [ ${chalk.green(name)} ] ${plugin.description}`)
+    .map(([name, plugin]) => ` [ ${green(name)} ] ${plugin.description}`)
     .join('\n');
   console.log('Currently available plugins:\n' + list);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,6 +330,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -509,6 +510,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -557,6 +559,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -564,7 +567,13 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
     "commander": {
       "version": "7.1.0",
@@ -1223,7 +1232,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "he": {
       "version": "1.2.0",
@@ -2185,6 +2195,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@trysound/sax": "0.1.1",
-    "chalk": "^4.1.0",
+    "colorette": "^1.2.2",
     "commander": "^7.1.0",
     "css-select": "^4.1.3",
     "css-tree": "^1.1.2",


### PR DESCRIPTION
Replace chalk with colorette to remove 5 deps from production installl:
`ansi-styles`, `supports-color`, `color-convert`, `has-flag`, `color-name`.

Also reduce deps when using PostCSS and SVGO together, since PostCSS
uses colorette.

Tested with `yarn install svgo`.