### PR TITLE
Remove mention of deprecated extendDefaultPlugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ module.exports = {
 
 ## API usage
 
-SVGO provides a few low level utilities. `extendDefaultPlugins` is described above.
+SVGO provides a few low level utilities.
 
 ### optimize
 


### PR DESCRIPTION
Looks like this was missed in #1513.