### PR TITLE
Clarify how to enable/configure builtin plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ module.exports = {
       name: 'preset-default',
       params: {
         overrides: {
-          // customize options for plugins that are enabled by default
+          // customize options for plugins included in preset
           builtinPluginName: {
             optionName: 'optionValue',
           },
@@ -98,7 +98,7 @@ module.exports = {
         },
       },
     },
-    // Enable builtin plugin that is not enabled by default
+    // Enable builtin plugin that is not included in preset
     'moreBuiltinPlugin',
     // Enable and configure builtin plugin
     {

--- a/README.md
+++ b/README.md
@@ -89,13 +89,22 @@ module.exports = {
       name: 'preset-default',
       params: {
         overrides: {
-          // customize options
+          // customize options for plugins that are enabled by default
           builtinPluginName: {
             optionName: 'optionValue',
           },
           // or disable plugins
           anotherBuiltinPlugin: false,
         },
+      },
+    },
+    // Enable builtin plugin that is not enabled by default
+    'moreBuiltinPlugin',
+    // Enable and configure builtin plugin
+    {
+      name: 'manyBuiltInPlugin',
+      params: {
+        optionName: 'value',
       },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ module.exports = {
         },
       },
     },
-    // Enable builtin plugin that is not included in preset
+    // Enable builtin plugin not included in preset
     'moreBuiltinPlugin',
-    // Enable and configure builtin plugin
+    // Enable and configure builtin plugin not included in preset
     {
       name: 'manyBuiltInPlugin',
       params: {


### PR DESCRIPTION
I just spent quite a while trying to upgrade to svgo 2.4 because I was thinking that all the configuration I was passing to `extendDefaultPlugins()` previously should now be in `preset-default` overrides. 

Just adding some examples of enabling other builtin plugins could clarify it? 

Maybe I was just being stupid, but a thought :)