### PR TITLE
Drop node.style usages

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -78,7 +78,10 @@ const parseStylesheet = (css, dynamic) => {
    * @type {Array<StylesheetRule>}
    */
   const rules = [];
-  const ast = csstree.parse(css);
+  const ast = csstree.parse(css, {
+    parseValue: false,
+    parseAtrulePrelude: false,
+  });
   csstree.walk(ast, (cssNode) => {
     if (cssNode.type === 'Rule') {
       rules.push(parseRule(cssNode, dynamic || false));
@@ -98,6 +101,30 @@ const parseStylesheet = (css, dynamic) => {
     }
   });
   return rules;
+};
+
+/**
+ * @type {(css: string) => Array<StylesheetDeclaration>}
+ */
+const parseStyleDeclarations = (css) => {
+  /**
+   * @type {Array<StylesheetDeclaration>}
+   */
+  const declarations = [];
+  const ast = csstree.parse(css, {
+    context: 'declarationList',
+    parseValue: false,
+  });
+  csstree.walk(ast, (cssNode) => {
+    if (cssNode.type === 'Declaration') {
+      declarations.push({
+        name: cssNode.property,
+        value: csstree.generate(cssNode.value),
+        important: cssNode.important === true,
+      });
+    }
+  });
+  return declarations;
 };
 
 /**
@@ -143,10 +170,12 @@ const computeOwnStyle = (stylesheet, node) => {
   }
 
   // collect inline styles
-  // @ts-ignore node.style is hidden from pubilc usage
-  for (const [name, { value, priority }] of node.style.properties) {
+  const styleDeclarations =
+    node.attributes.style == null
+      ? []
+      : parseStyleDeclarations(node.attributes.style);
+  for (const { name, value, important } of styleDeclarations) {
     const computed = computedStyle[name];
-    const important = priority === 'important';
     if (computed && computed.type === 'dynamic') {
       continue;
     }


### PR DESCRIPTION
Parsing inline styles with csstree in place is easier.
Caching does not add much value here.