### PR TITLE
Allow choosing EOL and appending final newline

### DIFF
--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -1,9 +1,5 @@
 'use strict';
 
-jest.mock('os', () => ({
-  EOL: '\r\n',
-}));
-
 const { optimize } = require('./svgo.js');
 
 test('allow to setup default preset', () => {
@@ -69,31 +65,6 @@ test('allow to disable and customize plugins in preset', () => {
 });
 
 describe('allow to configure EOL', () => {
-  // See mock at top of test file
-  afterAll(() => {
-    jest.unmock('os');
-  });
-
-  test('should default to platform EOL', () => {
-    const svg = `
-      <?xml version="1.0" encoding="utf-8"?>
-      <svg viewBox="0 0 120 120">
-        <desc>
-          Not standard description
-        </desc>
-        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
-      </svg>
-    `;
-    // using toEqual because line endings matter in these tests
-    expect(
-      optimize(svg, {
-        js2svg: { pretty: true, indent: 2 },
-      }).data
-    ).toEqual(
-      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
-    );
-  });
-
   test('should respect EOL set to LF', () => {
     const svg = `
       <?xml version="1.0" encoding="utf-8"?>
@@ -128,6 +99,26 @@ describe('allow to configure EOL', () => {
     expect(
       optimize(svg, {
         js2svg: { eol: 'crlf', pretty: true, indent: 2 },
+      }).data
+    ).toEqual(
+      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
+    );
+  });
+
+  test('should respect EOL set to line break', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    // using toEqual because line endings matter in these tests
+    expect(
+      optimize(svg, {
+        js2svg: { eol: '\r\n', pretty: true, indent: 2 },
       }).data
     ).toEqual(
       `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+jest.mock('os', () => ({
+  EOL: '\r\n',
+}));
+
 const { optimize } = require('./svgo.js');
 
 test('allow to setup default preset', () => {
@@ -62,6 +66,132 @@ test('allow to disable and customize plugins in preset', () => {
     </svg>
     "
   `);
+});
+
+describe('allow to configure EOL', () => {
+  // See mock at top of test file
+  afterAll(() => {
+    jest.unmock('os');
+  });
+
+  test('should default to platform EOL', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    // using toEqual because line endings matter in these tests
+    expect(
+      optimize(svg, {
+        js2svg: { pretty: true, indent: 2 },
+      }).data
+    ).toEqual(
+      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
+    );
+  });
+
+  test('should respect EOL set to LF', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    // using toEqual because line endings matter in these tests
+    expect(
+      optimize(svg, {
+        js2svg: { eol: 'lf', pretty: true, indent: 2 },
+      }).data
+    ).toEqual(
+      `<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n`
+    );
+  });
+
+  test('should respect EOL set to CRLF', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    // using toEqual because line endings matter in these tests
+    expect(
+      optimize(svg, {
+        js2svg: { eol: 'crlf', pretty: true, indent: 2 },
+      }).data
+    ).toEqual(
+      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
+    );
+  });
+});
+
+describe('allow to configure final newline', () => {
+  test('should not add final newline when unset', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    expect(optimize(svg).data).toMatchInlineSnapshot(
+      `"<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>"`
+    );
+  });
+
+  test('should add final newline when set', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    expect(
+      optimize(svg, {
+        js2svg: { finalNewline: true },
+      }).data
+    ).toMatchInlineSnapshot(`
+      "<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>
+      "
+    `);
+  });
+
+  test('should not add extra newlines when using pretty: true', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    expect(
+      optimize(svg, {
+        js2svg: { finalNewline: true, pretty: true, indent: 2 },
+      }).data
+    ).toMatchInlineSnapshot(`
+      "<svg viewBox=\\"0 0 120 120\\">
+        <circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/>
+      </svg>
+      "
+    `);
+  });
 });
 
 test('allow to customize precision for preset', () => {

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -75,12 +75,11 @@ describe('allow to configure EOL', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
+    const { data } = optimize(svg, {
+      js2svg: { eol: 'lf', pretty: true, indent: 2 },
+    });
     // using toEqual because line endings matter in these tests
-    expect(
-      optimize(svg, {
-        js2svg: { eol: 'lf', pretty: true, indent: 2 },
-      }).data
-    ).toEqual(
+    expect(data).toEqual(
       `<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n`
     );
   });
@@ -95,12 +94,11 @@ describe('allow to configure EOL', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
+    const { data } = optimize(svg, {
+      js2svg: { eol: 'crlf', pretty: true, indent: 2 },
+    });
     // using toEqual because line endings matter in these tests
-    expect(
-      optimize(svg, {
-        js2svg: { eol: 'crlf', pretty: true, indent: 2 },
-      }).data
-    ).toEqual(
+    expect(data).toEqual(
       `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
     );
   });
@@ -115,12 +113,11 @@ describe('allow to configure EOL', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
+    const { data } = optimize(svg, {
+      js2svg: { eol: '\r\n', pretty: true, indent: 2 },
+    });
     // using toEqual because line endings matter in these tests
-    expect(
-      optimize(svg, {
-        js2svg: { eol: '\r\n', pretty: true, indent: 2 },
-      }).data
-    ).toEqual(
+    expect(data).toEqual(
       `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
     );
   });
@@ -137,7 +134,8 @@ describe('allow to configure final newline', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
-    expect(optimize(svg).data).toMatchInlineSnapshot(
+    const { data } = optimize(svg);
+    expect(data).toMatchInlineSnapshot(
       `"<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>"`
     );
   });
@@ -152,11 +150,10 @@ describe('allow to configure final newline', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
-    expect(
-      optimize(svg, {
-        js2svg: { finalNewline: true },
-      }).data
-    ).toMatchInlineSnapshot(`
+    const { data } = optimize(svg, {
+      js2svg: { finalNewline: true },
+    });
+    expect(data).toMatchInlineSnapshot(`
       "<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>
       "
     `);
@@ -172,11 +169,10 @@ describe('allow to configure final newline', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
-    expect(
-      optimize(svg, {
-        js2svg: { finalNewline: true, pretty: true, indent: 2 },
-      }).data
-    ).toMatchInlineSnapshot(`
+    const { data } = optimize(svg, {
+      js2svg: { finalNewline: true, pretty: true, indent: 2 },
+    });
+    expect(data).toMatchInlineSnapshot(`
       "<svg viewBox=\\"0 0 120 120\\">
         <circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/>
       </svg>

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -80,7 +80,7 @@ describe('allow to configure EOL', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      `<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n`
+      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
     );
   });
 
@@ -99,11 +99,11 @@ describe('allow to configure EOL', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
+      '<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n'
     );
   });
 
-  test('should respect EOL set to line break', () => {
+  test('should default to LF line break for any other EOL values', () => {
     const svg = `
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
@@ -114,11 +114,11 @@ describe('allow to configure EOL', () => {
       </svg>
     `;
     const { data } = optimize(svg, {
-      js2svg: { eol: '\r\n', pretty: true, indent: 2 },
+      js2svg: { eol: 'invalid', pretty: true, indent: 2 },
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      `<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n`
+      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
     );
   });
 });
@@ -134,9 +134,10 @@ describe('allow to configure final newline', () => {
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
     `;
-    const { data } = optimize(svg);
-    expect(data).toMatchInlineSnapshot(
-      `"<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>"`
+    const { data } = optimize(svg, { js2svg: { eol: 'lf' } });
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120"><circle fill="red" cx="60" cy="60" r="50"/></svg>'
     );
   });
 
@@ -151,12 +152,12 @@ describe('allow to configure final newline', () => {
       </svg>
     `;
     const { data } = optimize(svg, {
-      js2svg: { finalNewline: true },
+      js2svg: { finalNewline: true, eol: 'lf' },
     });
-    expect(data).toMatchInlineSnapshot(`
-      "<svg viewBox=\\"0 0 120 120\\"><circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/></svg>
-      "
-    `);
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120"><circle fill="red" cx="60" cy="60" r="50"/></svg>\n'
+    );
   });
 
   test('should not add extra newlines when using pretty: true', () => {
@@ -170,14 +171,12 @@ describe('allow to configure final newline', () => {
       </svg>
     `;
     const { data } = optimize(svg, {
-      js2svg: { finalNewline: true, pretty: true, indent: 2 },
+      js2svg: { finalNewline: true, pretty: true, indent: 2, eol: 'lf' },
     });
-    expect(data).toMatchInlineSnapshot(`
-      "<svg viewBox=\\"0 0 120 120\\">
-        <circle fill=\\"red\\" cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/>
-      </svg>
-      "
-    `);
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
+    );
   });
 });
 

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -118,8 +118,7 @@ async function action(args, opts, command) {
   }
 
   if (opts.eol != null) {
-    const eol = opts.eol.toLowerCase();
-    if (eol !== 'lf' && eol !== 'crlf') {
+    if (opts.eol !== 'lf' && opts.eol !== 'crlf') {
       console.error(
         "error: option '--eol' must have one of the following values: 'lf' or 'crlf'"
       );

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -117,13 +117,11 @@ async function action(args, opts, command) {
     }
   }
 
-  if (opts.eol != null) {
-    if (opts.eol !== 'lf' && opts.eol !== 'crlf') {
-      console.error(
-        "error: option '--eol' must have one of the following values: 'lf' or 'crlf'"
-      );
-      process.exit(1);
-    }
+  if (opts.eol != null && opts.eol !== 'lf' && opts.eol !== 'crlf') {
+    console.error(
+      "error: option '--eol' must have one of the following values: 'lf' or 'crlf'"
+    );
+    process.exit(1);
   }
 
   // --show-plugins

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -55,6 +55,11 @@ module.exports = function makeProgram(program) {
     .option('--pretty', 'Make SVG pretty printed')
     .option('--indent <INTEGER>', 'Indent number when pretty printing SVGs')
     .option(
+      '--eol <EOL>',
+      'Line break to use when outputting SVG: lf, crlf. If unspecified, uses platform default.'
+    )
+    .option('--final-newline', 'Ensure SVG ends with a line break')
+    .option(
       '-r, --recursive',
       "Use with '--folder'. Optimizes *.svg files in folders recursively."
     )
@@ -109,6 +114,16 @@ async function action(args, opts, command) {
       process.exit(1);
     } else {
       opts.indent = number;
+    }
+  }
+
+  if (opts.eol != null) {
+    const eol = opts.eol.toLowerCase();
+    if (eol !== 'lf' && eol !== 'crlf') {
+      console.error(
+        "error: option '--eol' must have one of the following values: 'lf' or 'crlf'"
+      );
+      process.exit(1);
     }
   }
 
@@ -183,6 +198,18 @@ async function action(args, opts, command) {
     if (opts.indent != null) {
       config.js2svg.indent = opts.indent;
     }
+  }
+
+  // --eol
+  if (opts.eol) {
+    config.js2svg = config.js2svg || {};
+    config.js2svg.eol = opts.eol;
+  }
+
+  // --final-newline
+  if (opts.finalNewline) {
+    config.js2svg = config.js2svg || {};
+    config.js2svg.finalNewline = true;
   }
 
   // --output

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -28,7 +28,7 @@ var defaults = {
   encodeEntity: encodeEntity,
   pretty: false,
   useShortTags: true,
-  eol: platformEOL,
+  eol: platformEOL === '\r\n' ? 'crlf' : 'lf',
   finalNewline: false,
 };
 
@@ -66,15 +66,10 @@ function JS2SVG(config) {
     this.config.indent = '    ';
   }
 
-  if (typeof this.config.eol === 'string' && this.config.eol) {
-    const configuredEOL = this.config.eol.toLowerCase();
-    if (configuredEOL === 'lf') {
-      this.eol = '\n';
-    } else if (configuredEOL === 'crlf') {
-      this.eol = '\r\n';
-    } else {
-      this.eol = this.config.eol;
-    }
+  if (this.config.eol === 'crlf') {
+    this.eol = '\r\n';
+  } else {
+    this.eol = '\n';
   }
 
   if (this.config.pretty) {

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -28,7 +28,7 @@ var defaults = {
   encodeEntity: encodeEntity,
   pretty: false,
   useShortTags: true,
-  eol: undefined,
+  eol: platformEOL,
   finalNewline: false,
 };
 
@@ -66,14 +66,14 @@ function JS2SVG(config) {
     this.config.indent = '    ';
   }
 
-  this.eol = platformEOL;
-
   if (typeof this.config.eol === 'string' && this.config.eol) {
     const configuredEOL = this.config.eol.toLowerCase();
     if (configuredEOL === 'lf') {
       this.eol = '\n';
     } else if (configuredEOL === 'crlf') {
       this.eol = '\r\n';
+    } else {
+      this.eol = this.config.eol;
     }
   }
 

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var EOL = require('os').EOL,
+var platformEOL = require('os').EOL,
   textElems = require('../../plugins/_collections.js').textElems;
 
 var defaults = {
@@ -28,6 +28,8 @@ var defaults = {
   encodeEntity: encodeEntity,
   pretty: false,
   useShortTags: true,
+  eol: undefined,
+  finalNewline: false,
 };
 
 var entities = {
@@ -64,15 +66,26 @@ function JS2SVG(config) {
     this.config.indent = '    ';
   }
 
+  this.eol = platformEOL;
+
+  if (typeof this.config.eol === 'string' && this.config.eol) {
+    const configuredEOL = this.config.eol.toLowerCase();
+    if (configuredEOL === 'lf') {
+      this.eol = '\n';
+    } else if (configuredEOL === 'crlf') {
+      this.eol = '\r\n';
+    }
+  }
+
   if (this.config.pretty) {
-    this.config.doctypeEnd += EOL;
-    this.config.procInstEnd += EOL;
-    this.config.commentEnd += EOL;
-    this.config.cdataEnd += EOL;
-    this.config.tagShortEnd += EOL;
-    this.config.tagOpenEnd += EOL;
-    this.config.tagCloseEnd += EOL;
-    this.config.textEnd += EOL;
+    this.config.doctypeEnd += this.eol;
+    this.config.procInstEnd += this.eol;
+    this.config.commentEnd += this.eol;
+    this.config.cdataEnd += this.eol;
+    this.config.tagShortEnd += this.eol;
+    this.config.tagOpenEnd += this.eol;
+    this.config.tagCloseEnd += this.eol;
+    this.config.textEnd += this.eol;
   }
 
   this.indentLevel = 0;
@@ -117,6 +130,15 @@ JS2SVG.prototype.convert = function (data) {
   }
 
   this.indentLevel--;
+
+  if (
+    this.config.finalNewline &&
+    this.indentLevel === 0 &&
+    svg.length > 0 &&
+    svg[svg.length - 1] !== '\n'
+  ) {
+    svg += this.eol;
+  }
 
   return {
     data: svg,


### PR DESCRIPTION
Addresses #951

Adds the following options to js2svg and CLI:

- eol — can be set to `lf` or `crlf`. If unspecified, js2svg uses the platform EOL.
- finalNewline — defaults to false. If true, js2svg ensures any SVG output has a final newline.

Tests added to cover both options.