### PR TITLE
Refactor removeUselessStrokeAndFill

### DIFF
--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -34,7 +34,9 @@ const invokePlugins = (ast, info, plugins, overrides, globalOverrides) => {
     if (plugin.type === 'visitor') {
       if (plugin.active) {
         const visitor = plugin.fn(ast, params, info);
-        visit(ast, visitor);
+        if (visitor != null) {
+          visit(ast, visitor);
+        }
       }
     }
   }

--- a/test/plugins/removeUselessStrokeAndFill.04.svg
+++ b/test/plugins/removeUselessStrokeAndFill.04.svg
@@ -4,7 +4,8 @@
       <rect width="100" height="100" fill="blue" />
     </marker>
   </defs>
-  <line x1="150" y1="150" x2="165" y2="150" stroke-width="25" marker-end="url(#testMarker)" />
+  <line x1="150" y1="150" x2="165" y2="150" stroke="red" stroke-width="25" marker-end="url(#testMarker)" />
+  <line x1="250" y1="250" x2="265" y2="250" stroke="red" stroke-width="0" marker-end="url(#testMarker)" />
 </svg>
 
 @@@
@@ -15,5 +16,6 @@
             <rect width="100" height="100" fill="blue"/>
         </marker>
     </defs>
-    <line x1="150" y1="150" x2="165" y2="150" stroke-width="25" marker-end="url(#testMarker)"/>
+    <line x1="150" y1="150" x2="165" y2="150" stroke="red" stroke-width="25" marker-end="url(#testMarker)"/>
+    <line x1="250" y1="250" x2="265" y2="250" marker-end="url(#testMarker)"/>
 </svg>

--- a/test/plugins/removeUselessStrokeAndFill.05.svg
+++ b/test/plugins/removeUselessStrokeAndFill.05.svg
@@ -16,7 +16,13 @@
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <g id="test">
+            <rect fill-opacity=".5" width="100" height="100"/>
+        </g>
+    </defs>
     <circle fill="red" fill-opacity=".5" cx="60" cy="60" r="50"/>
+    <g fill="none"/>
 </svg>
 
 @@@

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "plugins/removeEmptyAttrs.js",
     "plugins/removeNonInheritableGroupAttrs.js",
     "plugins/removeUnusedNS.js",
-    "plugins/removeUselessStrokeAndFill.js",
     "plugins/removeXMLNS.js",
     "plugins/reusePaths.js",
     "plugins/sortAttrs.js",


### PR DESCRIPTION
The logic is a little messy. Will be better when we drop node 12 support
and use optional chaining.

- migrated to visitor plugin api
- covered with types
- get rid from patching params as plugin state
- replaced many node.computedAttr() with style manager
- enabled and fixed removeNone param test (was merged as muted back in 2017)
- added ability to return null and not run visitor in plugins