### PR TITLE
Update devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -569,49 +569,49 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
-      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
+      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-message-util": "^27.1.0",
+        "jest-util": "^27.1.0",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
-      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
+      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/reporters": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/reporters": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.6",
-        "jest-config": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-changed-files": "^27.1.0",
+        "jest-config": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-resolve-dependencies": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
-        "jest-watcher": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-resolve-dependencies": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
+        "jest-watcher": "^27.1.0",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -620,53 +620,53 @@
       }
     },
     "@jest/environment": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
-      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
+      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6"
+        "jest-mock": "^27.1.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
-      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
+      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
       }
     },
     "@jest/globals": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
-      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
+      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "expect": "^27.0.6"
+        "@jest/environment": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "expect": "^27.1.0"
       }
     },
     "@jest/reporters": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
-      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
+      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -677,10 +677,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -700,45 +700,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
-      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
+      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
-      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
+      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-runtime": "^27.0.6"
+        "jest-haste-map": "^27.1.0",
+        "jest-runtime": "^27.1.0"
       }
     },
     "@jest/transform": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
-      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
+      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.1.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -747,9 +747,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
-      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
+      "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -786,9 +786,9 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz",
-      "integrity": "sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
+      "integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -810,9 +810,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
-      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -977,9 +977,9 @@
       }
     },
     "@types/node": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
+      "version": "16.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.5.tgz",
+      "integrity": "sha512-E7SpxDXoHEpmZ9C1gSqwadhE6zPRtf3g0gJy9Y51DsImnR5TcDs3QEiV/3Q7zOM8LWaZp5Gph71NK6ElVMG1IQ==",
       "dev": true
     },
     "@types/prettier": {
@@ -1169,13 +1169,13 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
-      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
+      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
         "babel-preset-jest": "^27.0.6",
@@ -1293,16 +1293,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       }
     },
     "bser": {
@@ -1355,9 +1355,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true
     },
     "chalk": {
@@ -1669,17 +1669,17 @@
       }
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "requires": {
         "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -1687,9 +1687,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==",
+      "version": "1.3.822",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
+      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
       "dev": true
     },
     "emittery": {
@@ -1989,16 +1989,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
-      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
+      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
@@ -2065,9 +2065,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -2389,9 +2389,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -2540,32 +2540,32 @@
       }
     },
     "jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
-      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
+      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.6",
+        "@jest/core": "^27.1.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.6"
+        "jest-cli": "^27.1.0"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
-          "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
+          "version": "27.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
+          "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.0.6",
-            "@jest/test-result": "^27.0.6",
-            "@jest/types": "^27.0.6",
+            "@jest/core": "^27.1.0",
+            "@jest/test-result": "^27.1.0",
+            "@jest/types": "^27.1.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.0.6",
-            "jest-util": "^27.0.6",
-            "jest-validate": "^27.0.6",
+            "jest-config": "^27.1.0",
+            "jest-util": "^27.1.0",
+            "jest-validate": "^27.1.0",
             "prompts": "^2.0.1",
             "yargs": "^16.0.3"
           }
@@ -2573,82 +2573,82 @@
       }
     },
     "jest-changed-files": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
-      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
+      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       }
     },
     "jest-circus": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
-      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
+      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       }
     },
     "jest-config": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
-      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
+      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "babel-jest": "^27.0.6",
+        "@jest/test-sequencer": "^27.1.0",
+        "@jest/types": "^27.1.0",
+        "babel-jest": "^27.1.0",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
+        "jest-circus": "^27.1.0",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.0.6",
+        "jest-jasmine2": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-runner": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-diff": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-      "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
+      "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-docblock": {
@@ -2661,45 +2661,45 @@
       }
     },
     "jest-each": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
-      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
+      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
-      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
+      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
-      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
+      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-mock": "^27.1.0",
+        "jest-util": "^27.1.0"
       }
     },
     "jest-get-type": {
@@ -2709,12 +2709,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
-      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
+      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -2723,73 +2723,73 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
-      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
+      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.6",
+        "@jest/environment": "^27.1.0",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "pretty-format": "^27.1.0",
         "throat": "^6.0.1"
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
-      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
+      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
-      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
+      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       }
     },
     "jest-message-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
-      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
+      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.1.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -2806,12 +2806,12 @@
       }
     },
     "jest-mock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
-      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
+      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*"
       }
     },
@@ -2828,92 +2828,94 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
-      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
+      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.1.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
-      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
+      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.0.6"
+        "jest-snapshot": "^27.1.0"
       }
     },
     "jest-runner": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
-      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
+      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-leak-detector": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-environment-jsdom": "^27.1.0",
+        "jest-environment-node": "^27.1.0",
+        "jest-haste-map": "^27.1.0",
+        "jest-leak-detector": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-runtime": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-worker": "^27.1.0",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       }
     },
     "jest-runtime": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
-      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
+      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/globals": "^27.0.6",
+        "@jest/console": "^27.1.0",
+        "@jest/environment": "^27.1.0",
+        "@jest/fake-timers": "^27.1.0",
+        "@jest/globals": "^27.1.0",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-mock": "^27.1.0",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-resolve": "^27.1.0",
+        "jest-snapshot": "^27.1.0",
+        "jest-util": "^27.1.0",
+        "jest-validate": "^27.1.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
@@ -2930,9 +2932,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
-      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
+      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -2941,33 +2943,33 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.6",
+        "expect": "^27.1.0",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.6",
+        "jest-diff": "^27.1.0",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-haste-map": "^27.1.0",
+        "jest-matcher-utils": "^27.1.0",
+        "jest-message-util": "^27.1.0",
+        "jest-resolve": "^27.1.0",
+        "jest-util": "^27.1.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.1.0",
         "semver": "^7.3.2"
       }
     },
     "jest-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
-      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
+      "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -2976,17 +2978,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
-      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
+      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2998,24 +3000,24 @@
       }
     },
     "jest-watcher": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
-      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
+      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.1.0",
+        "@jest/types": "^27.1.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.1.0",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
+      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3331,9 +3333,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "normalize-path": {
@@ -3529,9 +3531,9 @@
       }
     },
     "playwright": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.14.0.tgz",
-      "integrity": "sha512-aR5oZ1iVsjQkGfYCjgYAmyMAVu0MQ0i8MgdnfdqDu9EVLfbnpuuFmTv/Rb7/Yjno1kOrDUP9+RyNC+zfG3wozA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.14.1.tgz",
+      "integrity": "sha512-JYNjhwWcfsBkg0FMGLbFO9e58FVdmICE4k97/glIQV7cBULL7oxNjRQC7Ffe+Y70XVNnP0HSJLaA0W5SukyftQ==",
       "dev": true,
       "requires": {
         "commander": "^6.1.0",
@@ -3583,12 +3585,12 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-      "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+      "version": "27.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
+      "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.1.0",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -3762,9 +3764,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -4084,9 +4086,9 @@
       }
     },
     "terser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
+      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -4203,9 +4205,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "universalify": {
@@ -4358,9 +4360,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -101,25 +101,25 @@
     "stable": "^0.1.8"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^17.1.0",
+    "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.2.1",
+    "@rollup/plugin-node-resolve": "^13.0.4",
     "@types/css-tree": "^1.0.6",
     "@types/csso": "^4.2.0",
     "@types/jest": "^27.0.1",
     "del": "^6.0.0",
     "eslint": "^7.32.0",
-    "jest": "^27.0.6",
+    "jest": "^27.1.0",
     "mock-stdin": "^1.0.0",
     "node-fetch": "^2.6.1",
     "pixelmatch": "^5.2.1",
-    "playwright": "^1.14.0",
+    "playwright": "^1.14.1",
     "pngjs": "^6.0.0",
     "prettier": "^2.3.2",
-    "rollup": "^2.56.2",
+    "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
     "tar-stream": "^2.2.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.2"
   },
   "engines": {
     "node": ">=10.13.0"


### PR DESCRIPTION
* @rollup/plugin-commonjs      ^17.1.0  →  ^20.0.0
* @rollup/plugin-node-resolve  ^11.2.1  →  ^13.0.4
* jest                         ^27.0.6  →  ^27.1.0
* playwright                   ^1.14.0  →  ^1.14.1
* rollup                       ^2.56.2  →  ^2.56.3
* typescript                    ^4.3.5  →   ^4.4.2

The major version bumps seem to be OK AFAICT.