### PR TITLE
Refactor reusePaths plugin

### DIFF
--- a/lib/svgo/jsAPI.d.ts
+++ b/lib/svgo/jsAPI.d.ts
@@ -1,0 +1,2 @@
+declare let obj: any;
+export = obj;

--- a/test/plugins/reusePaths.02.svg
+++ b/test/plugins/reusePaths.02.svg
@@ -11,8 +11,8 @@
 
 <svg xmlns="http://www.w3.org/2000/svg">
     <defs>
-        <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
         <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+        <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
     </defs>
     <use xlink:href="#test0"/>
     <path id="test1" stroke="red" d="M 10,50 l 20,30 L 20,30"/>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,6 @@
     "plugins/removeUnusedNS.js",
     "plugins/removeUselessStrokeAndFill.js",
     "plugins/removeXMLNS.js",
-    "plugins/reusePaths.js",
     "plugins/sortAttrs.js",
     "plugins/removeEmptyContainers.js",
     "plugins/minifyStyles.js",


### PR DESCRIPTION
- migrated to visitor plugin api; combination of enter and exit helped
  to fit into single traverse
- got rid from the only node.clone() usage in the project so no need to
  reimplement it
- the logic is a bit simplified