### PR TITLE
Move platform specific eol to svgo-node entry point

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -1,12 +1,16 @@
 'use strict';
 
+const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const {
   extendDefaultPlugins,
-  optimize,
+  optimize: optimizeAgnostic,
   createContentItem,
 } = require('./svgo.js');
+
+exports.extendDefaultPlugins = extendDefaultPlugins;
+exports.createContentItem = createContentItem;
 
 const importConfig = async (configFile) => {
   const config = require(configFile);
@@ -47,8 +51,19 @@ const loadConfig = async (configFile, cwd = process.cwd()) => {
     dir = parent;
   }
 };
-
 exports.loadConfig = loadConfig;
-exports.extendDefaultPlugins = extendDefaultPlugins;
+
+const optimize = (input, config) => {
+  if (typeof config !== 'object') {
+    throw Error('Config should be an object');
+  }
+  return optimizeAgnostic(input, {
+    ...config,
+    js2svg: {
+      // platform specific default for end of line
+      eol: os.EOL === '\r\n' ? 'crlf' : 'lf',
+      ...(config == null ? null : config.js2svg),
+    },
+  });
+};
 exports.optimize = optimize;
-exports.createContentItem = createContentItem;

--- a/lib/svgo/js2svg.js
+++ b/lib/svgo/js2svg.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var platformEOL = require('os').EOL,
-  textElems = require('../../plugins/_collections.js').textElems;
+const { textElems } = require('../../plugins/_collections.js');
 
 var defaults = {
   doctypeStart: '<!DOCTYPE',
@@ -28,7 +27,7 @@ var defaults = {
   encodeEntity: encodeEntity,
   pretty: false,
   useShortTags: true,
-  eol: platformEOL === '\r\n' ? 'crlf' : 'lf',
+  eol: 'lf',
   finalNewline: false,
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,17 +15,9 @@ export default {
   plugins: [
     {
       resolveId(importee, importer) {
-        if (importee === 'os') {
-          return importee;
-        }
         // see https://github.com/csstree/csstree/pull/152
         if (importee === 'css-tree') {
           return this.resolve('css-tree/dist/csstree.min.js', importer);
-        }
-      },
-      load(id) {
-        if (id === 'os') {
-          return `export var EOL = '\\n'`;
         }
       },
     },


### PR DESCRIPTION
`os` package in js2svg module bothered me for a long time.
We had to hack rollup to mock it for browser.

Thanks to https://github.com/svg/svgo/pull/1546 we now can pass eol from
svgo-node entry point and simplify build.

cc @adalinesimonian 