### PR TITLE
Remove node 16 version fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          # restrict the version to fix the bug introduced in 16.9 (https://github.com/nodejs/node/issues/40030)
-          - 16.8
+          - 16
           - 14
           - 12
           - 10


### PR DESCRIPTION
Looks like the bug with v8 internals was fixed.