### PR TITLE
Fix config type

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -54,6 +54,9 @@ const loadConfig = async (configFile, cwd = process.cwd()) => {
 exports.loadConfig = loadConfig;
 
 const optimize = (input, config) => {
+  if (config == null) {
+    config = {};
+  }
   if (typeof config !== 'object') {
     throw Error('Config should be an object');
   }
@@ -62,7 +65,7 @@ const optimize = (input, config) => {
     js2svg: {
       // platform specific default for end of line
       eol: os.EOL === '\r\n' ? 'crlf' : 'lf',
-      ...(config == null ? null : config.js2svg),
+      ...config.js2svg,
     },
   });
 };

--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * @typedef {import('../lib/types').Plugin} Plugin
+ */
+
+const os = require('os');
+const { optimize } = require('./svgo-node.js');
+
+const describeLF = os.EOL === '\r\n' ? describe.skip : describe;
+const describeCRLF = os.EOL === '\r\n' ? describe : describe.skip;
+
+describeLF('with LF line-endings', () => {
+  test('should work', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg);
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120"><circle fill="red" cx="60" cy="60" r="50"/></svg>'
+    );
+  });
+
+  test('should respect config', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg, {
+      js2svg: { pretty: true, indent: 2 },
+    });
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
+    );
+  });
+
+  test('should respect line-ending config', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg, {
+      js2svg: { eol: 'crlf', pretty: true, indent: 2 },
+    });
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n'
+    );
+  });
+});
+
+describeCRLF('with CRLF line-endings', () => {
+  test('should work', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg);
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120"><circle fill="red" cx="60" cy="60" r="50"/></svg>'
+    );
+  });
+
+  test('should respect config', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg, {
+      js2svg: { pretty: true, indent: 2 },
+    });
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120">\r\n  <circle fill="red" cx="60" cy="60" r="50"/>\r\n</svg>\r\n'
+    );
+  });
+
+  test('should respect line-ending config', () => {
+    const svg = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <svg viewBox="0 0 120 120">
+        <desc>
+          Not standard description
+        </desc>
+        <circle fill="#ff0000" cx="60" cy="60" r="50"/>
+      </svg>
+    `;
+    const { data } = optimize(svg, {
+      js2svg: { eol: 'lf', pretty: true, indent: 2 },
+    });
+    // using toEqual because line endings matter in these tests
+    expect(data).toEqual(
+      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
+    );
+  });
+});


### PR DESCRIPTION
https://github.com/svg/svgo/pull/1565 changed the signature when using SVGO programmatically so that the config argument is required. This breaks Parcel's usage where it might be `undefined` (https://github.com/parcel-bundler/parcel/blob/6f6759e5c2140aa8d7c3be70d56432258439ff19/packages/optimizers/svgo/src/SVGOOptimizer.js#L26-L32).

I've matched the original `optimize` function, and add some basic tests to cover it.

Refs https://github.com/parcel-bundler/parcel/pull/6481#discussion_r707864127