### PR TITLE
Avoid node.parentNode in style manager

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -3,6 +3,7 @@
 /**
  * @typedef {import('css-tree').Rule} CsstreeRule
  * @typedef {import('./types').Specificity} Specificity
+ * @typedef {import('./types').Stylesheet} Stylesheet
  * @typedef {import('./types').StylesheetRule} StylesheetRule
  * @typedef {import('./types').StylesheetDeclaration} StylesheetDeclaration
  * @typedef {import('./types').ComputedStyles} ComputedStyles
@@ -128,7 +129,7 @@ const parseStyleDeclarations = (css) => {
 };
 
 /**
- * @type {(stylesheet: Array<StylesheetRule>, node: XastElement) => ComputedStyles}
+ * @type {(stylesheet: Stylesheet, node: XastElement) => ComputedStyles}
  */
 const computeOwnStyle = (stylesheet, node) => {
   /**
@@ -146,7 +147,7 @@ const computeOwnStyle = (stylesheet, node) => {
   }
 
   // collect matching rules
-  for (const { selectors, declarations, dynamic } of stylesheet) {
+  for (const { selectors, declarations, dynamic } of stylesheet.rules) {
     if (matches(node, selectors)) {
       for (const { name, value, important } of declarations) {
         const computed = computedStyle[name];
@@ -211,17 +212,23 @@ const compareSpecificity = (a, b) => {
 };
 
 /**
- * @type {(root: XastRoot) => Array<StylesheetRule>}
+ * @type {(root: XastRoot) => Stylesheet}
  */
 const collectStylesheet = (root) => {
   /**
    * @type {Array<StylesheetRule>}
    */
-  const stylesheet = [];
-  // find and parse all styles
+  const rules = [];
+  /**
+   * @type {Map<XastElement, XastParent>}
+   */
+  const parents = new Map();
   visit(root, {
     element: {
-      enter: (node) => {
+      enter: (node, parentNode) => {
+        // store parents
+        parents.set(node, parentNode);
+        // find and parse all styles
         if (node.name === 'style') {
           const dynamic =
             node.attributes.media != null && node.attributes.media !== 'all';
@@ -233,7 +240,7 @@ const collectStylesheet = (root) => {
             const children = node.children;
             for (const child of children) {
               if (child.type === 'text' || child.type === 'cdata') {
-                stylesheet.push(...parseStylesheet(child.value, dynamic));
+                rules.push(...parseStylesheet(child.value, dynamic));
               }
             }
           }
@@ -242,24 +249,23 @@ const collectStylesheet = (root) => {
     },
   });
   // sort by selectors specificity
-  stable.inplace(stylesheet, (a, b) =>
+  stable.inplace(rules, (a, b) =>
     compareSpecificity(a.specificity, b.specificity)
   );
-  return stylesheet;
+  return { rules, parents };
 };
 exports.collectStylesheet = collectStylesheet;
 
 /**
- * @type {(stylesheet: Array<StylesheetRule>, node: XastElement) => ComputedStyles}
+ * @type {(stylesheet: Stylesheet, node: XastElement) => ComputedStyles}
  */
 const computeStyle = (stylesheet, node) => {
+  const { parents } = stylesheet;
   // collect inherited styles
   const computedStyles = computeOwnStyle(stylesheet, node);
-  let parent = node;
-  // @ts-ignore parentNode is forbidden in public usage
-  while (parent.parentNode && parent.parentNode.type !== 'root') {
-    // @ts-ignore parentNode is forbidden in public usage
-    const inheritedStyles = computeOwnStyle(stylesheet, parent.parentNode);
+  let parent = parents.get(node);
+  while (parent != null && parent.type !== 'root') {
+    const inheritedStyles = computeOwnStyle(stylesheet, parent);
     for (const [name, computed] of Object.entries(inheritedStyles)) {
       if (
         computedStyles[name] == null &&
@@ -270,8 +276,7 @@ const computeStyle = (stylesheet, node) => {
         computedStyles[name] = { ...computed, inherited: true };
       }
     }
-    // @ts-ignore parentNode is forbidden in public usage
-    parent = parent.parentNode;
+    parent = parents.get(parent);
   }
   return computedStyles;
 };

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -1,12 +1,39 @@
 'use strict';
 
+/**
+ * @typedef {import('./types').XastParent} XastParent
+ * @typedef {import('./types').XastElement} XastElement
+ */
+
 const { collectStylesheet, computeStyle } = require('./style.js');
-const { querySelector } = require('./xast.js');
+const { visit } = require('./xast.js');
 const svg2js = require('./svgo/svg2js.js');
 
-describe('computeStyle', () => {
-  it('collects styles', () => {
-    const root = svg2js(`
+/**
+ * @type {(node: XastParent, id: string) => XastElement}
+ */
+const getElementById = (node, id) => {
+  /**
+   * @type {null | XastElement}
+   */
+  let matched = null;
+  visit(node, {
+    element: {
+      enter: (node) => {
+        if (node.attributes.id === id) {
+          matched = node;
+        }
+      },
+    },
+  });
+  if (matched == null) {
+    throw Error('Assert node');
+  }
+  return matched;
+};
+
+it('collects styles', () => {
+  const root = svg2js(`
       <svg>
         <rect id="class" class="a" />
         <rect id="two-classes" class="b a" />
@@ -30,40 +57,38 @@ describe('computeStyle', () => {
         </style>
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(computeStyle(stylesheet, querySelector(root, '#class'))).toEqual({
-      fill: { type: 'static', inherited: false, value: 'red' },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#two-classes'))
-    ).toEqual({
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'class'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'red' },
+  });
+  expect(computeStyle(stylesheet, getElementById(root, 'two-classes'))).toEqual(
+    {
       fill: { type: 'static', inherited: false, value: 'green' },
       stroke: { type: 'static', inherited: false, value: 'black' },
-    });
-    expect(computeStyle(stylesheet, querySelector(root, '#attribute'))).toEqual(
-      {
-        fill: { type: 'static', inherited: false, value: 'purple' },
-      }
-    );
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#inline-style'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'grey' },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#inheritance'))
-    ).toEqual({
-      fill: { type: 'static', inherited: true, value: 'yellow' },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#nested-inheritance'))
-    ).toEqual({
-      fill: { type: 'static', inherited: true, value: 'blue' },
-    });
+    }
+  );
+  expect(computeStyle(stylesheet, getElementById(root, 'attribute'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'purple' },
   });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'inline-style'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'grey' },
+  });
+  expect(computeStyle(stylesheet, getElementById(root, 'inheritance'))).toEqual(
+    {
+      fill: { type: 'static', inherited: true, value: 'yellow' },
+    }
+  );
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'nested-inheritance'))
+  ).toEqual({
+    fill: { type: 'static', inherited: true, value: 'blue' },
+  });
+});
 
-  it('prioritizes different kinds of styles', () => {
-    const root = svg2js(`
+it('prioritizes different kinds of styles', () => {
+  const root = svg2js(`
       <svg>
         <style>
           g > .a { fill: red; }
@@ -78,40 +103,34 @@ describe('computeStyle', () => {
         </g>
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#complex-selector'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'red' },
-    });
-    expect(
-      computeStyle(
-        stylesheet,
-        querySelector(root, '#attribute-over-inheritance')
-      )
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'orange' },
-    });
-    expect(
-      computeStyle(
-        stylesheet,
-        querySelector(root, '#style-rule-over-attribute')
-      )
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'blue' },
-    });
-    expect(
-      computeStyle(
-        stylesheet,
-        querySelector(root, '#inline-style-over-style-rule')
-      )
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'purple' },
-    });
+  const stylesheet = collectStylesheet(root);
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'complex-selector'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'red' },
   });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'attribute-over-inheritance'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'orange' },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'style-rule-over-attribute'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'blue' },
+  });
+  expect(
+    computeStyle(
+      stylesheet,
+      getElementById(root, 'inline-style-over-style-rule')
+    )
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'purple' },
+  });
+});
 
-  it('prioritizes important styles', () => {
-    const root = svg2js(`
+it('prioritizes important styles', () => {
+  const root = svg2js(`
       <svg>
         <style>
           g > .a { fill: red; }
@@ -122,32 +141,32 @@ describe('computeStyle', () => {
         <rect id="inline-style-over-style-rule" style="fill: purple !important;" class="b" />
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#complex-selector'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'green' },
-    });
-    expect(
-      computeStyle(
-        stylesheet,
-        querySelector(root, '#style-rule-over-inline-style')
-      )
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'green' },
-    });
-    expect(
-      computeStyle(
-        stylesheet,
-        querySelector(root, '#inline-style-over-style-rule')
-      )
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'purple' },
-    });
+  const stylesheet = collectStylesheet(root);
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'complex-selector'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'green' },
   });
+  expect(
+    computeStyle(
+      stylesheet,
+      getElementById(root, 'style-rule-over-inline-style')
+    )
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'green' },
+  });
+  expect(
+    computeStyle(
+      stylesheet,
+      getElementById(root, 'inline-style-over-style-rule')
+    )
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'purple' },
+  });
+});
 
-  it('treats at-rules and pseudo-classes as dynamic styles', () => {
-    const root = svg2js(`
+it('treats at-rules and pseudo-classes as dynamic styles', () => {
+  const root = svg2js(`
       <svg>
         <style>
           @media screen {
@@ -166,32 +185,30 @@ describe('computeStyle', () => {
         <rect id="static" class="c" style="fill: black" />
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#media-query'))
-    ).toEqual({
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
+    {
       fill: { type: 'dynamic', inherited: false },
-    });
-    expect(computeStyle(stylesheet, querySelector(root, '#hover'))).toEqual({
-      fill: { type: 'dynamic', inherited: false },
-    });
-    expect(computeStyle(stylesheet, querySelector(root, '#inherited'))).toEqual(
-      {
-        fill: { type: 'dynamic', inherited: true },
-      }
-    );
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#inherited-overriden'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'blue' },
-    });
-    expect(computeStyle(stylesheet, querySelector(root, '#static'))).toEqual({
-      fill: { type: 'static', inherited: false, value: 'black' },
-    });
+    }
+  );
+  expect(computeStyle(stylesheet, getElementById(root, 'hover'))).toEqual({
+    fill: { type: 'dynamic', inherited: false },
   });
+  expect(computeStyle(stylesheet, getElementById(root, 'inherited'))).toEqual({
+    fill: { type: 'dynamic', inherited: true },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'inherited-overriden'))
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'blue' },
+  });
+  expect(computeStyle(stylesheet, getElementById(root, 'static'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'black' },
+  });
+});
 
-  it('considers <style> media attribute', () => {
-    const root = svg2js(`
+it('considers <style> media attribute', () => {
+  const root = svg2js(`
       <svg>
         <style media="print">
           @media screen {
@@ -207,24 +224,24 @@ describe('computeStyle', () => {
         <rect id="static" class="c" />
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#media-query'))
-    ).toEqual({
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
+    {
       fill: { type: 'dynamic', inherited: false },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#kinda-static'))
-    ).toEqual({
-      fill: { type: 'dynamic', inherited: false },
-    });
-    expect(computeStyle(stylesheet, querySelector(root, '#static'))).toEqual({
-      fill: { type: 'static', inherited: false, value: 'blue' },
-    });
+    }
+  );
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'kinda-static'))
+  ).toEqual({
+    fill: { type: 'dynamic', inherited: false },
   });
+  expect(computeStyle(stylesheet, getElementById(root, 'static'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'blue' },
+  });
+});
 
-  it('ignores <style> with invalid type', () => {
-    const root = svg2js(`
+it('ignores <style> with invalid type', () => {
+  const root = svg2js(`
       <svg>
         <style type="text/css">
           .a { fill: red; }
@@ -240,24 +257,20 @@ describe('computeStyle', () => {
         <rect id="invalid-type" class="c" />
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#valid-type'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'red' },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#empty-type'))
-    ).toEqual({
-      fill: { type: 'static', inherited: false, value: 'green' },
-    });
-    expect(
-      computeStyle(stylesheet, querySelector(root, '#invalid-type'))
-    ).toEqual({});
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'valid-type'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'red' },
   });
+  expect(computeStyle(stylesheet, getElementById(root, 'empty-type'))).toEqual({
+    fill: { type: 'static', inherited: false, value: 'green' },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'invalid-type'))
+  ).toEqual({});
+});
 
-  it('ignores keyframes atrule', () => {
-    const root = svg2js(`
+it('ignores keyframes atrule', () => {
+  const root = svg2js(`
       <svg>
         <style>
           .a {
@@ -278,13 +291,12 @@ describe('computeStyle', () => {
         <rect id="element" class="a" />
       </svg>
     `);
-    const stylesheet = collectStylesheet(root);
-    expect(computeStyle(stylesheet, querySelector(root, '#element'))).toEqual({
-      animation: {
-        type: 'static',
-        inherited: false,
-        value: 'loading 4s linear infinite',
-      },
-    });
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'element'))).toEqual({
+    animation: {
+      type: 'static',
+      inherited: false,
+      value: 'loading 4s linear infinite',
+    },
   });
 });

--- a/lib/svgo/svg2js.d.ts
+++ b/lib/svgo/svg2js.d.ts
@@ -1,0 +1,2 @@
+declare let obj: any;
+export = obj;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -97,6 +97,11 @@ export type StylesheetRule = {
   declarations: Array<StylesheetDeclaration>;
 };
 
+export type Stylesheet = {
+  rules: Array<StylesheetRule>;
+  parents: Map<XastElement, XastParent>;
+};
+
 type StaticStyle = {
   type: 'static';
   inherited: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "plugins/**/*",
     "lib/xast.test.js",
     "lib/path.test.js",
+    "lib/style.test.js",
     "test/cli/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
node.parentNode will be removed in v3 along with JSAPI class wrapper on
each node.

Style manager uses it to find inherited styles. To workaround this
I collected all parents along with all styles. This constraints style
manager to work only with initial ast which should not be a problem as
each plagin execution is isolated.

Also covered style manager tests with tsdoc.
Better review with hidden whitespaces.