### PR TITLE
fix(plugin): removeAttrs: warn without attrs

### DIFF
--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -6,6 +6,19 @@ exports.active = false;
 exports.description = 'removes specified attributes';
 
 const DEFAULT_SEPARATOR = ':';
+const ENOATTRS = `Warning: The plugin "removeAttrs" requires the "attrs" parameter.
+It should have a pattern to remove, otherwise the plugin is a noop.
+Config example:
+
+plugins: [
+  {
+    name: "removeAttrs",
+    params: {
+      attrs: "(fill|stroke)"
+    }
+  }
+]
+`;
 
 /**
  * Remove attributes
@@ -77,7 +90,11 @@ const DEFAULT_SEPARATOR = ':';
  * }>}
  */
 exports.fn = (root, params) => {
-  // wrap into an array if params is not
+  if (typeof params.attrs == 'undefined') {
+    console.warn(ENOATTRS);
+    return null;
+  }
+
   const elemSeparator =
     typeof params.elemSeparator == 'string'
       ? params.elemSeparator

--- a/test/plugins/removeAttrs.06.svg
+++ b/test/plugins/removeAttrs.06.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle fill="red" stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path fill="red" stroke="red" d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke-width="6" stroke-dashoffset="5" cx="60" cy="60" r="50"/>
+    <circle fill="red" stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#000" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="50"/>
+    <circle stroke="#FFF" stroke-width="6" stroke-dashoffset="5" stroke-opacity="0" cx="60" cy="60" r="25"/>
+    <path fill="red" stroke="red" d="M100,200 300,400 H100 V300 C100,100 250,100 250,200 S400,300 400,200 Q400,50 600,300 T1000,300 z"/>
+</svg>
+
+@@@
+
+{}


### PR DESCRIPTION
This is a follow-up of #1560 and should fix #1581. The PR attempt to fix an issue when the plugin is called without the `attrs` option. The code expects that the `attrs` option is present and throw an error when it's not because we end up having `attrs = [undefined]` (see below). 

Technically this should be an error but it would be a breaking change. We can start by introducing a warning (what this PR does) and in a future major version throw an error. I added a test where input = output when `attrs` is not provided i.e. noop.

```
TypeError: Cannot read properties of undefined (reading 'includes')

      94 |         for (let pattern of attrs) {
      95 |           // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
    > 96 |           if (pattern.includes(elemSeparator) === false) {
         |                       ^
      97 |             pattern = ['.*', elemSeparator, pattern, elemSeparator, '.*'].join(
      98 |               ''
      99 |             );

      at Object.enter (plugins/removeAttrs.js:96:23)
      at visit (lib/xast.js:68:30)
      at visit (lib/xast.js:77:7)
      at invokePlugins (lib/svgo/plugins.js:38:11)
      at optimize (lib/svgo.js:55:13)
      at test/plugins/_index.test.js:38:28
```