### PR TITLE
Replace colorette with nanocolors

### DIFF
--- a/bin/svgo
+++ b/bin/svgo
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { red } = require('colorette');
+const { red } = require('nanocolors');
 const { program } = require('commander');
 const makeProgram = require('../lib/svgo/coa');
 makeProgram(program);

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -2,11 +2,12 @@
 
 const FS = require('fs');
 const PATH = require('path');
-const { green, red } = require('colorette');
+const { green, red } = require('nanocolors');
 const { loadConfig, optimize } = require('../svgo-node.js');
 const pluginsMap = require('../../plugins/plugins.js');
 const PKG = require('../../package.json');
 const { encodeSVGDatauri, decodeSVGDatauri } = require('./tools.js');
+
 const regSVGFile = /\.svg$/i;
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@trysound/sax": "0.2.0",
-        "colorette": "^1.4.0",
         "commander": "^7.2.0",
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
+        "nanocolors": "^0.1.12",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -29,7 +29,7 @@
         "@types/jest": "^27.0.1",
         "del": "^6.0.0",
         "eslint": "^7.32.0",
-        "jest": "^27.2.0",
+        "jest": "^27.2.1",
         "mock-stdin": "^1.0.0",
         "node-fetch": "^2.6.2",
         "pixelmatch": "^5.2.1",
@@ -237,19 +237,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-replace-supers": "^7.15.4",
         "@babel/helper-simple-access": "^7.15.4",
         "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.15.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -793,15 +793,15 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.0.tgz",
-      "integrity": "sha512-E/2NHhq+VMo18DpKkoty8Sjey8Kps5Cqa88A8NP757s6JjYqPdioMuyUBhDiIOGCdQByEp0ou3jskkTszMS0nw==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.1.tgz",
+      "integrity": "sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==",
       "dev": true,
       "dependencies": {
         "@jest/console": "^27.2.0",
-        "@jest/reporters": "^27.2.0",
+        "@jest/reporters": "^27.2.1",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -810,15 +810,15 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-changed-files": "^27.1.1",
-        "jest-config": "^27.2.0",
+        "jest-config": "^27.2.1",
         "jest-haste-map": "^27.2.0",
         "jest-message-util": "^27.2.0",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-resolve-dependencies": "^27.2.0",
-        "jest-runner": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-resolve-dependencies": "^27.2.1",
+        "jest-runner": "^27.2.1",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "jest-watcher": "^27.2.0",
@@ -873,29 +873,29 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.0.tgz",
-      "integrity": "sha512-raqk9Gf9WC3hlBa57rmRmJfRl9hom2b+qEE/ifheMtwn5USH5VZxzrHHOZg0Zsd/qC2WJ8UtyTwHKQAnNlDMdg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.1.tgz",
+      "integrity": "sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^27.2.0",
         "@jest/types": "^27.1.1",
-        "expect": "^27.2.0"
+        "expect": "^27.2.1"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.0.tgz",
-      "integrity": "sha512-7wfkE3iRTLaT0F51h1mnxH3nQVwDCdbfgXiLuCcNkF1FnxXLH9utHqkSLIiwOTV1AtmiE0YagHbOvx4rnMP/GA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.1.tgz",
+      "integrity": "sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^27.2.0",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -959,24 +959,24 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.0.tgz",
-      "integrity": "sha512-PrqarcpzOU1KSAK7aPwfL8nnpaqTMwPe7JBPnaOYRDSe/C6AoJiL5Kbnonqf1+DregxZIRAoDg69R9/DXMGqXA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.1.tgz",
+      "integrity": "sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==",
       "dev": true,
       "dependencies": {
         "@jest/test-result": "^27.2.0",
         "graceful-fs": "^4.2.4",
         "jest-haste-map": "^27.2.0",
-        "jest-runtime": "^27.2.0"
+        "jest-runtime": "^27.2.1"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.0.tgz",
-      "integrity": "sha512-Q8Q/8xXIZYllk1AF7Ou5sV3egOZsdY/Wlv09CSbcexBRcC1Qt6lVZ7jRFAZtbHsEEzvOCyFEC4PcrwKwyjXtCg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.1.tgz",
+      "integrity": "sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
@@ -1512,12 +1512,12 @@
       "dev": true
     },
     "node_modules/babel-jest": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.0.tgz",
-      "integrity": "sha512-bS2p+KGGVVmWXBa8+i6SO/xzpiz2Q/2LnqLbQknPKefWXVZ67YIjA4iXup/jMOEZplga9PpWn+wrdb3UdDwRaA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.1.tgz",
+      "integrity": "sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
@@ -1674,16 +1674,16 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001254",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.830",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1775,10 +1775,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
       "dev": true,
+      "dependencies": {
+        "nanocolors": "^0.1.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -1874,11 +1877,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2212,9 +2210,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.836",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz",
-      "integrity": "sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==",
+      "version": "1.3.848",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.848.tgz",
+      "integrity": "sha512-wchRyBcdcmibioggdO7CbMT5QQ4lXlN/g7Mkpf1K2zINidnqij6EVu94UIZ+h5nB2S9XD4bykqFv9LonAWLFyw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2614,9 +2612,9 @@
       }
     },
     "node_modules/expect": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.0.tgz",
-      "integrity": "sha512-oOTbawMQv7AK1FZURbPTgGSzmhxkjFzoARSvDjOMnOpeWuYQx1tP6rXu9MIX5mrACmyCAM7fSNP8IJO2f1p0CQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
+      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^27.1.1",
@@ -3276,9 +3274,9 @@
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3350,14 +3348,14 @@
       }
     },
     "node_modules/jest": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.0.tgz",
-      "integrity": "sha512-oUqVXyvh5YwEWl263KWdPUAqEzBFzGHdFLQ05hUnITr1tH+9SscEI9A/GH9eBClA+Nw1ct+KNuuOV6wlnmBPcg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.1.tgz",
+      "integrity": "sha512-0MyvNS7J1HbkeotYaqKNGioN+p1/AAPtI1Z8iwMtCBE+PwBT+M4l25D9Pve8/KdhktYLgZaGyyj9CoDytD+R2Q==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.2.0",
+        "@jest/core": "^27.2.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.2.0"
+        "jest-cli": "^27.2.1"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3389,9 +3387,9 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.0.tgz",
-      "integrity": "sha512-WwENhaZwOARB1nmcboYPSv/PwHBUGRpA4MEgszjr9DLCl97MYw0qZprBwLb7rNzvMwfIvNGG7pefQ5rxyBlzIA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.1.tgz",
+      "integrity": "sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==",
       "dev": true,
       "dependencies": {
         "@jest/environment": "^27.2.0",
@@ -3401,13 +3399,13 @@
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^27.2.0",
         "jest-matcher-utils": "^27.2.0",
         "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "pretty-format": "^27.2.0",
         "slash": "^3.0.0",
@@ -3418,29 +3416,63 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-cli": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.1.tgz",
+      "integrity": "sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^27.2.1",
+        "@jest/test-result": "^27.2.0",
+        "@jest/types": "^27.1.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "jest-config": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
+        "prompts": "^2.0.1",
+        "yargs": "^16.0.3"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-config": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.0.tgz",
-      "integrity": "sha512-Z1romHpxeNwLxQtouQ4xt07bY6HSFGKTo0xJcvOK3u6uJHveA4LB2P+ty9ArBLpTh3AqqPxsyw9l9GMnWBYS9A==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.1.tgz",
+      "integrity": "sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.2.0",
+        "@jest/test-sequencer": "^27.2.1",
         "@jest/types": "^27.1.1",
-        "babel-jest": "^27.2.0",
+        "babel-jest": "^27.2.1",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.2.0",
+        "jest-circus": "^27.2.1",
         "jest-environment-jsdom": "^27.2.0",
         "jest-environment-node": "^27.2.0",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.2.0",
+        "jest-jasmine2": "^27.2.1",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-runner": "^27.2.0",
+        "jest-runner": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "micromatch": "^4.0.4",
@@ -3572,9 +3604,9 @@
       }
     },
     "node_modules/jest-jasmine2": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.0.tgz",
-      "integrity": "sha512-NcPzZBk6IkDW3Z2V8orGueheGJJYfT5P0zI/vTO/Jp+R9KluUdgFrgwfvZ0A34Kw6HKgiWFILZmh3oQ/eS+UxA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.1.tgz",
+      "integrity": "sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==",
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.1.0",
@@ -3585,13 +3617,13 @@
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^27.2.0",
         "jest-matcher-utils": "^27.2.0",
         "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "pretty-format": "^27.2.0",
         "throat": "^6.0.1"
@@ -3721,29 +3753,29 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.0.tgz",
-      "integrity": "sha512-EY5jc/Y0oxn+oVEEldTidmmdVoZaknKPyDORA012JUdqPyqPL+lNdRyI3pGti0RCydds6coaw6xt4JQY54dKsg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.1.tgz",
+      "integrity": "sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.2.0"
+        "jest-snapshot": "^27.2.1"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.0.tgz",
-      "integrity": "sha512-Cl+BHpduIc0cIVTjwoyx0pQk4Br8gn+wkr35PmKCmzEdOUnQ2wN7QVXA8vXnMQXSlFkN/+KWnk20TAVBmhgrww==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.1.tgz",
+      "integrity": "sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==",
       "dev": true,
       "dependencies": {
         "@jest/console": "^27.2.0",
         "@jest/environment": "^27.2.0",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -3757,7 +3789,7 @@
         "jest-leak-detector": "^27.2.0",
         "jest-message-util": "^27.2.0",
         "jest-resolve": "^27.2.0",
-        "jest-runtime": "^27.2.0",
+        "jest-runtime": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-worker": "^27.2.0",
         "source-map-support": "^0.5.6",
@@ -3768,18 +3800,18 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.0.tgz",
-      "integrity": "sha512-6gRE9AVVX49hgBbWQ9PcNDeM4upMUXzTpBs0kmbrjyotyUyIJixLPsYjpeTFwAA07PVLDei1iAm2chmWycdGdQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.1.tgz",
+      "integrity": "sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==",
       "dev": true,
       "dependencies": {
         "@jest/console": "^27.2.0",
         "@jest/environment": "^27.2.0",
         "@jest/fake-timers": "^27.2.0",
-        "@jest/globals": "^27.2.0",
+        "@jest/globals": "^27.2.1",
         "@jest/source-map": "^27.0.6",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
@@ -3794,7 +3826,7 @@
         "jest-mock": "^27.1.1",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "slash": "^3.0.0",
@@ -3819,9 +3851,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.0.tgz",
-      "integrity": "sha512-MukJvy3KEqemCT2FoT3Gum37CQqso/62PKTfIzWmZVTsLsuyxQmJd2PI5KPcBYFqLlA8LgZLHM8ZlazkVt8LsQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.1.tgz",
+      "integrity": "sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.7.2",
@@ -3830,13 +3862,13 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "graceful-fs": "^4.2.4",
         "jest-diff": "^27.2.0",
         "jest-get-type": "^27.0.6",
@@ -3944,40 +3976,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/jest-cli": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.0.tgz",
-      "integrity": "sha512-bq1X/B/b1kT9y1zIFMEW3GFRX1HEhFybiqKdbxM+j11XMMYSbU9WezfyWIhrSOmPT+iODLATVjfsCnbQs7cfIA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/core": "^27.2.0",
-        "@jest/test-result": "^27.2.0",
-        "@jest/types": "^27.1.1",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "import-local": "^3.0.2",
-        "jest-config": "^27.2.0",
-        "jest-util": "^27.2.0",
-        "jest-validate": "^27.2.0",
-        "prompts": "^2.0.1",
-        "yargs": "^16.0.3"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
       }
     },
     "node_modules/jpeg-js": {
@@ -4328,6 +4326,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4359,9 +4362,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -5973,19 +5976,19 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.15.4",
         "@babel/helper-replace-supers": "^7.15.4",
         "@babel/helper-simple-access": "^7.15.4",
         "@babel/helper-split-export-declaration": "^7.15.4",
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "@babel/template": "^7.15.4",
         "@babel/traverse": "^7.15.4",
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.15.6"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -6034,9 +6037,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -6126,9 +6129,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -6404,15 +6407,15 @@
       }
     },
     "@jest/core": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.0.tgz",
-      "integrity": "sha512-E/2NHhq+VMo18DpKkoty8Sjey8Kps5Cqa88A8NP757s6JjYqPdioMuyUBhDiIOGCdQByEp0ou3jskkTszMS0nw==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.1.tgz",
+      "integrity": "sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==",
       "dev": true,
       "requires": {
         "@jest/console": "^27.2.0",
-        "@jest/reporters": "^27.2.0",
+        "@jest/reporters": "^27.2.1",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -6421,15 +6424,15 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-changed-files": "^27.1.1",
-        "jest-config": "^27.2.0",
+        "jest-config": "^27.2.1",
         "jest-haste-map": "^27.2.0",
         "jest-message-util": "^27.2.0",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-resolve-dependencies": "^27.2.0",
-        "jest-runner": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-resolve-dependencies": "^27.2.1",
+        "jest-runner": "^27.2.1",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "jest-watcher": "^27.2.0",
@@ -6467,26 +6470,26 @@
       }
     },
     "@jest/globals": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.0.tgz",
-      "integrity": "sha512-raqk9Gf9WC3hlBa57rmRmJfRl9hom2b+qEE/ifheMtwn5USH5VZxzrHHOZg0Zsd/qC2WJ8UtyTwHKQAnNlDMdg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.1.tgz",
+      "integrity": "sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==",
       "dev": true,
       "requires": {
         "@jest/environment": "^27.2.0",
         "@jest/types": "^27.1.1",
-        "expect": "^27.2.0"
+        "expect": "^27.2.1"
       }
     },
     "@jest/reporters": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.0.tgz",
-      "integrity": "sha512-7wfkE3iRTLaT0F51h1mnxH3nQVwDCdbfgXiLuCcNkF1FnxXLH9utHqkSLIiwOTV1AtmiE0YagHbOvx4rnMP/GA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.1.tgz",
+      "integrity": "sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^27.2.0",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -6533,21 +6536,21 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.0.tgz",
-      "integrity": "sha512-PrqarcpzOU1KSAK7aPwfL8nnpaqTMwPe7JBPnaOYRDSe/C6AoJiL5Kbnonqf1+DregxZIRAoDg69R9/DXMGqXA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.1.tgz",
+      "integrity": "sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==",
       "dev": true,
       "requires": {
         "@jest/test-result": "^27.2.0",
         "graceful-fs": "^4.2.4",
         "jest-haste-map": "^27.2.0",
-        "jest-runtime": "^27.2.0"
+        "jest-runtime": "^27.2.1"
       }
     },
     "@jest/transform": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.0.tgz",
-      "integrity": "sha512-Q8Q/8xXIZYllk1AF7Ou5sV3egOZsdY/Wlv09CSbcexBRcC1Qt6lVZ7jRFAZtbHsEEzvOCyFEC4PcrwKwyjXtCg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.1.tgz",
+      "integrity": "sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
@@ -6991,12 +6994,12 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.0.tgz",
-      "integrity": "sha512-bS2p+KGGVVmWXBa8+i6SO/xzpiz2Q/2LnqLbQknPKefWXVZ67YIjA4iXup/jMOEZplga9PpWn+wrdb3UdDwRaA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.1.tgz",
+      "integrity": "sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
@@ -7115,16 +7118,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001254",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.830",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       }
     },
     "bser": {
@@ -7177,10 +7180,13 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
-      "dev": true
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "dev": true,
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -7253,11 +7259,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -7509,9 +7510,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.836",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz",
-      "integrity": "sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==",
+      "version": "1.3.848",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.848.tgz",
+      "integrity": "sha512-wchRyBcdcmibioggdO7CbMT5QQ4lXlN/g7Mkpf1K2zINidnqij6EVu94UIZ+h5nB2S9XD4bykqFv9LonAWLFyw==",
       "dev": true
     },
     "emittery": {
@@ -7811,9 +7812,9 @@
       "dev": true
     },
     "expect": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.0.tgz",
-      "integrity": "sha512-oOTbawMQv7AK1FZURbPTgGSzmhxkjFzoARSvDjOMnOpeWuYQx1tP6rXu9MIX5mrACmyCAM7fSNP8IJO2f1p0CQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
+      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
@@ -8304,9 +8305,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-instrument": {
@@ -8362,36 +8363,14 @@
       }
     },
     "jest": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.0.tgz",
-      "integrity": "sha512-oUqVXyvh5YwEWl263KWdPUAqEzBFzGHdFLQ05hUnITr1tH+9SscEI9A/GH9eBClA+Nw1ct+KNuuOV6wlnmBPcg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.1.tgz",
+      "integrity": "sha512-0MyvNS7J1HbkeotYaqKNGioN+p1/AAPtI1Z8iwMtCBE+PwBT+M4l25D9Pve8/KdhktYLgZaGyyj9CoDytD+R2Q==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.2.0",
+        "@jest/core": "^27.2.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.2.0"
-      },
-      "dependencies": {
-        "jest-cli": {
-          "version": "27.2.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.0.tgz",
-          "integrity": "sha512-bq1X/B/b1kT9y1zIFMEW3GFRX1HEhFybiqKdbxM+j11XMMYSbU9WezfyWIhrSOmPT+iODLATVjfsCnbQs7cfIA==",
-          "dev": true,
-          "requires": {
-            "@jest/core": "^27.2.0",
-            "@jest/test-result": "^27.2.0",
-            "@jest/types": "^27.1.1",
-            "chalk": "^4.0.0",
-            "exit": "^0.1.2",
-            "graceful-fs": "^4.2.4",
-            "import-local": "^3.0.2",
-            "jest-config": "^27.2.0",
-            "jest-util": "^27.2.0",
-            "jest-validate": "^27.2.0",
-            "prompts": "^2.0.1",
-            "yargs": "^16.0.3"
-          }
-        }
+        "jest-cli": "^27.2.1"
       }
     },
     "jest-changed-files": {
@@ -8406,9 +8385,9 @@
       }
     },
     "jest-circus": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.0.tgz",
-      "integrity": "sha512-WwENhaZwOARB1nmcboYPSv/PwHBUGRpA4MEgszjr9DLCl97MYw0qZprBwLb7rNzvMwfIvNGG7pefQ5rxyBlzIA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.1.tgz",
+      "integrity": "sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==",
       "dev": true,
       "requires": {
         "@jest/environment": "^27.2.0",
@@ -8418,13 +8397,13 @@
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^27.2.0",
         "jest-matcher-utils": "^27.2.0",
         "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "pretty-format": "^27.2.0",
         "slash": "^3.0.0",
@@ -8432,29 +8411,49 @@
         "throat": "^6.0.1"
       }
     },
+    "jest-cli": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.1.tgz",
+      "integrity": "sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^27.2.1",
+        "@jest/test-result": "^27.2.0",
+        "@jest/types": "^27.1.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "jest-config": "^27.2.1",
+        "jest-util": "^27.2.0",
+        "jest-validate": "^27.2.0",
+        "prompts": "^2.0.1",
+        "yargs": "^16.0.3"
+      }
+    },
     "jest-config": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.0.tgz",
-      "integrity": "sha512-Z1romHpxeNwLxQtouQ4xt07bY6HSFGKTo0xJcvOK3u6uJHveA4LB2P+ty9ArBLpTh3AqqPxsyw9l9GMnWBYS9A==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.1.tgz",
+      "integrity": "sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.2.0",
+        "@jest/test-sequencer": "^27.2.1",
         "@jest/types": "^27.1.1",
-        "babel-jest": "^27.2.0",
+        "babel-jest": "^27.2.1",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.2.0",
+        "jest-circus": "^27.2.1",
         "jest-environment-jsdom": "^27.2.0",
         "jest-environment-node": "^27.2.0",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.2.0",
+        "jest-jasmine2": "^27.2.1",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-runner": "^27.2.0",
+        "jest-runner": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "micromatch": "^4.0.4",
@@ -8552,9 +8551,9 @@
       }
     },
     "jest-jasmine2": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.0.tgz",
-      "integrity": "sha512-NcPzZBk6IkDW3Z2V8orGueheGJJYfT5P0zI/vTO/Jp+R9KluUdgFrgwfvZ0A34Kw6HKgiWFILZmh3oQ/eS+UxA==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.1.tgz",
+      "integrity": "sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -8565,13 +8564,13 @@
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^27.2.0",
         "jest-matcher-utils": "^27.2.0",
         "jest-message-util": "^27.2.0",
-        "jest-runtime": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-runtime": "^27.2.1",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "pretty-format": "^27.2.0",
         "throat": "^6.0.1"
@@ -8669,26 +8668,26 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.0.tgz",
-      "integrity": "sha512-EY5jc/Y0oxn+oVEEldTidmmdVoZaknKPyDORA012JUdqPyqPL+lNdRyI3pGti0RCydds6coaw6xt4JQY54dKsg==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.1.tgz",
+      "integrity": "sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==",
       "dev": true,
       "requires": {
         "@jest/types": "^27.1.1",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.2.0"
+        "jest-snapshot": "^27.2.1"
       }
     },
     "jest-runner": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.0.tgz",
-      "integrity": "sha512-Cl+BHpduIc0cIVTjwoyx0pQk4Br8gn+wkr35PmKCmzEdOUnQ2wN7QVXA8vXnMQXSlFkN/+KWnk20TAVBmhgrww==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.1.tgz",
+      "integrity": "sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==",
       "dev": true,
       "requires": {
         "@jest/console": "^27.2.0",
         "@jest/environment": "^27.2.0",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -8702,7 +8701,7 @@
         "jest-leak-detector": "^27.2.0",
         "jest-message-util": "^27.2.0",
         "jest-resolve": "^27.2.0",
-        "jest-runtime": "^27.2.0",
+        "jest-runtime": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-worker": "^27.2.0",
         "source-map-support": "^0.5.6",
@@ -8710,18 +8709,18 @@
       }
     },
     "jest-runtime": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.0.tgz",
-      "integrity": "sha512-6gRE9AVVX49hgBbWQ9PcNDeM4upMUXzTpBs0kmbrjyotyUyIJixLPsYjpeTFwAA07PVLDei1iAm2chmWycdGdQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.1.tgz",
+      "integrity": "sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==",
       "dev": true,
       "requires": {
         "@jest/console": "^27.2.0",
         "@jest/environment": "^27.2.0",
         "@jest/fake-timers": "^27.2.0",
-        "@jest/globals": "^27.2.0",
+        "@jest/globals": "^27.2.1",
         "@jest/source-map": "^27.0.6",
         "@jest/test-result": "^27.2.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
@@ -8736,7 +8735,7 @@
         "jest-mock": "^27.1.1",
         "jest-regex-util": "^27.0.6",
         "jest-resolve": "^27.2.0",
-        "jest-snapshot": "^27.2.0",
+        "jest-snapshot": "^27.2.1",
         "jest-util": "^27.2.0",
         "jest-validate": "^27.2.0",
         "slash": "^3.0.0",
@@ -8755,9 +8754,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.0.tgz",
-      "integrity": "sha512-MukJvy3KEqemCT2FoT3Gum37CQqso/62PKTfIzWmZVTsLsuyxQmJd2PI5KPcBYFqLlA8LgZLHM8ZlazkVt8LsQ==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.1.tgz",
+      "integrity": "sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -8766,13 +8765,13 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.2.0",
+        "@jest/transform": "^27.2.1",
         "@jest/types": "^27.1.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.2.0",
+        "expect": "^27.2.1",
         "graceful-fs": "^4.2.4",
         "jest-diff": "^27.2.0",
         "jest-get-type": "^27.0.6",
@@ -9131,6 +9130,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9156,9 +9160,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
       "dev": true
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -98,11 +98,11 @@
   },
   "dependencies": {
     "@trysound/sax": "0.2.0",
-    "colorette": "^1.4.0",
     "commander": "^7.2.0",
     "css-select": "^4.1.3",
     "css-tree": "^1.1.3",
     "csso": "^4.2.0",
+    "nanocolors": "^0.1.12",
     "stable": "^0.1.8"
   },
   "devDependencies": {
@@ -114,7 +114,7 @@
     "@types/jest": "^27.0.1",
     "del": "^6.0.0",
     "eslint": "^7.32.0",
-    "jest": "^27.2.0",
+    "jest": "^27.2.1",
     "mock-stdin": "^1.0.0",
     "node-fetch": "^2.6.2",
     "pixelmatch": "^5.2.1",


### PR DESCRIPTION
Ref https://github.com/ai/nanocolors

Nanocolors is the new player in color libraries. And it's perfectly
packaged as all @ai packages. Colorette is already replaced even
in transitive dependencies.