### PR TITLE
Replace strip-ansi with --no-color flag

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -493,7 +493,7 @@ function checkOptimizeFileError(config, input, output, error) {
 function checkWriteFileError(input, output, data, error) {
   if (error.code == 'EISDIR' && input) {
     return fs.promises.writeFile(
-      PATH.resolve(output, PATH.basename(input)),
+      path.resolve(output, path.basename(input)),
       data,
       'utf8'
     );

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const FS = require('fs');
-const PATH = require('path');
+const fs = require('fs');
+const path = require('path');
 const { green, red } = require('nanocolors');
 const { loadConfig, optimize } = require('../svgo-node.js');
 const pluginsMap = require('../../plugins/plugins.js');
@@ -16,7 +16,7 @@ const regSVGFile = /\.svg$/i;
  */
 function checkIsDir(path) {
   try {
-    return FS.lstatSync(path).isDirectory();
+    return fs.lstatSync(path).isDirectory();
   } catch (e) {
     return false;
   }
@@ -73,6 +73,7 @@ module.exports = function makeProgram(program) {
       'Only output error messages, not regular status messages'
     )
     .option('--show-plugins', 'Show available plugins and exit')
+    .option('--no-color', 'Output plain text without color')
     .action(action);
 };
 
@@ -218,7 +219,7 @@ async function action(args, opts, command) {
         for (var i = 0; i < input.length; i++) {
           output[i] = checkIsDir(input[i])
             ? input[i]
-            : PATH.resolve(dir, PATH.basename(input[i]));
+            : path.resolve(dir, path.basename(input[i]));
         }
       } else if (output.length < input.length) {
         output = output.concat(input.slice(output.length));
@@ -283,7 +284,7 @@ function optimizeFolder(config, dir, output) {
   if (!config.quiet) {
     console.log(`Processing directory '${dir}':\n`);
   }
-  return FS.promises
+  return fs.promises
     .readdir(dir)
     .then((files) => processDirectory(config, dir, files, output));
 }
@@ -331,19 +332,19 @@ function getFilesDescriptions(config, dir, files, output) {
         !config.exclude.some((regExclude) => regExclude.test(name))
     )
     .map((name) => ({
-      inputPath: PATH.resolve(dir, name),
-      outputPath: PATH.resolve(output, name),
+      inputPath: path.resolve(dir, name),
+      outputPath: path.resolve(output, name),
     }));
 
   return config.recursive
     ? [].concat(
         filesInThisFolder,
         files
-          .filter((name) => checkIsDir(PATH.resolve(dir, name)))
+          .filter((name) => checkIsDir(path.resolve(dir, name)))
           .map((subFolderName) => {
-            const subFolderPath = PATH.resolve(dir, subFolderName);
-            const subFolderFiles = FS.readdirSync(subFolderPath);
-            const subFolderOutput = PATH.resolve(output, subFolderName);
+            const subFolderPath = path.resolve(dir, subFolderName);
+            const subFolderFiles = fs.readdirSync(subFolderPath);
+            const subFolderOutput = path.resolve(output, subFolderName);
             return getFilesDescriptions(
               config,
               subFolderPath,
@@ -364,7 +365,7 @@ function getFilesDescriptions(config, dir, files, output) {
  * @return {Promise}
  */
 function optimizeFile(config, file, output) {
-  return FS.promises.readFile(file, 'utf8').then(
+  return fs.promises.readFile(file, 'utf8').then(
     (data) =>
       processSVGData(config, { input: 'file', path: file }, data, output, file),
     (error) => checkOptimizeFileError(config, file, output, error)
@@ -398,7 +399,7 @@ function processSVGData(config, info, data, output, input) {
     function () {
       if (!config.quiet && output != '-') {
         if (input) {
-          console.log(`\n${PATH.basename(input)}:`);
+          console.log(`\n${path.basename(input)}:`);
         }
         printTimeInfo(processingTime);
         printProfitInfo(prevFileSize, resultFileSize);
@@ -428,9 +429,9 @@ function writeOutput(input, output, data) {
     return Promise.resolve();
   }
 
-  FS.mkdirSync(PATH.dirname(output), { recursive: true });
+  fs.mkdirSync(path.dirname(output), { recursive: true });
 
-  return FS.promises
+  return fs.promises
     .writeFile(output, data, 'utf8')
     .catch((error) => checkWriteFileError(input, output, data, error));
 }
@@ -491,7 +492,7 @@ function checkOptimizeFileError(config, input, output, error) {
  */
 function checkWriteFileError(input, output, data, error) {
   if (error.code == 'EISDIR' && input) {
-    return FS.promises.writeFile(
+    return fs.promises.writeFile(
       PATH.resolve(output, PATH.basename(input)),
       data,
       'utf8'

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -73,6 +73,7 @@ module.exports = function makeProgram(program) {
       'Only output error messages, not regular status messages'
     )
     .option('--show-plugins', 'Show available plugins and exit')
+    // used by nanocolors internally
     .option('--no-color', 'Output plain text without color')
     .action(action);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
-        "nanocolors": "^0.1.12",
+        "nanocolors": "^0.2.1",
         "stable": "^0.1.8"
       },
       "bin": {
@@ -38,7 +38,6 @@
         "prettier": "^2.4.0",
         "rollup": "^2.56.3",
         "rollup-plugin-terser": "^7.0.2",
-        "strip-ansi": "^6.0.0",
         "tar-stream": "^2.2.0",
         "typescript": "^4.4.3"
       },
@@ -1696,6 +1695,12 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/browserslist/node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1786,6 +1791,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
+    },
+    "node_modules/caniuse-lite/node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4327,9 +4338,9 @@
       "dev": true
     },
     "node_modules/nanocolors": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
-      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.1.tgz",
+      "integrity": "sha512-2IoEVGHuRGjhAQFzbLdK38agBum4vWW4ods4b2h1FhU5SY/6B9DSLEMziQ8XzPSaitPDJtMnpXTGcGcOocDTXQ=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7128,6 +7139,14 @@
         "escalade": "^3.1.1",
         "nanocolors": "^0.1.5",
         "node-releases": "^1.1.76"
+      },
+      "dependencies": {
+        "nanocolors": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+          "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+          "dev": true
+        }
       }
     },
     "bser": {
@@ -7186,6 +7205,14 @@
       "dev": true,
       "requires": {
         "nanocolors": "^0.1.0"
+      },
+      "dependencies": {
+        "nanocolors": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+          "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+          "dev": true
+        }
       }
     },
     "chalk": {
@@ -9131,9 +9158,9 @@
       "dev": true
     },
     "nanocolors": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
-      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.1.tgz",
+      "integrity": "sha512-2IoEVGHuRGjhAQFzbLdK38agBum4vWW4ods4b2h1FhU5SY/6B9DSLEMziQ8XzPSaitPDJtMnpXTGcGcOocDTXQ=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "css-select": "^4.1.3",
     "css-tree": "^1.1.3",
     "csso": "^4.2.0",
-    "nanocolors": "^0.1.12",
+    "nanocolors": "^0.2.1",
     "stable": "^0.1.8"
   },
   "devDependencies": {
@@ -123,7 +123,6 @@
     "prettier": "^2.4.0",
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
-    "strip-ansi": "^6.0.0",
     "tar-stream": "^2.2.0",
     "typescript": "^4.4.3"
   },

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const { spawn } = require('child_process');
-const stripAnsi = require('strip-ansi');
 
 test('should exit with 1 code on syntax error', async () => {
-  const proc = spawn('node', ['../../bin/svgo', 'invalid.svg'], {
+  const proc = spawn('node', ['../../bin/svgo', '--no-color', 'invalid.svg'], {
     cwd: __dirname,
   });
   const [code, stderr] = await Promise.all([
@@ -20,7 +19,7 @@ test('should exit with 1 code on syntax error', async () => {
     }),
   ]);
   expect(code).toEqual(1);
-  expect(stripAnsi(stderr))
+  expect(stderr)
     .toEqual(`SvgoParserError: invalid.svg:2:27: Unquoted attribute value
 
   1 | <svg>


### PR DESCRIPTION
nanocolors checks for --color and --no-color flags to force or disable
output coloring. Which can be used instead of strip-ansi package which
btw introduced vulnerability recently.