### PR TITLE
Add cross-env so that npm scripts work on Windows CMD.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/css-tree": "^1.0.6",
         "@types/csso": "^4.2.0",
         "@types/jest": "^27.0.1",
+        "cross-env": "^7.0.3",
         "del": "^6.0.0",
         "eslint": "^7.32.0",
         "jest": "^27.2.1",
@@ -1928,6 +1929,24 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -7320,6 +7339,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "!**/*.test.js"
   ],
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=3 --coverage",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=3 --coverage",
     "lint": "eslint --ignore-path .gitignore . && prettier --check \"**/*.js\" --ignore-path .gitignore",
     "fix": "eslint --ignore-path .gitignore --fix . && prettier --write \"**/*.js\" --ignore-path .gitignore",
     "typecheck": "tsc",
     "test-browser": "rollup -c && node ./test/browser.js",
-    "test-regression": "node ./test/regression-extract.js && NO_DIFF=1 node ./test/regression.js",
+    "test-regression": "node ./test/regression-extract.js && cross-env NO_DIFF=1 node ./test/regression.js",
     "prepublishOnly": "rm -rf dist && rollup -c"
   },
   "prettier": {
@@ -112,6 +112,7 @@
     "@types/css-tree": "^1.0.6",
     "@types/csso": "^4.2.0",
     "@types/jest": "^27.0.1",
+    "cross-env": "^7.0.3",
     "del": "^6.0.0",
     "eslint": "^7.32.0",
     "jest": "^27.2.1",


### PR DESCRIPTION
Without this it's impossible to run the tests on Windows's native cmd:

```
C:\Users\xmr\Desktop\svgo>npm t

> svgo@2.7.0 test
> NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=3 --coverage

'NODE_OPTIONS' is not recognized as an internal or external command,
operable program or batch file.

C:\Users\xmr\Desktop\svgo>
```