### PR TITLE
Improve css-tools

### DIFF
--- a/lib/css-tools.js
+++ b/lib/css-tools.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var csstree = require('css-tree'),
-  List = csstree.List,
-  stable = require('stable'),
-  specificity = require('csso/lib/restructure/prepare/specificity');
+const { List, walk, generate } = require('css-tree');
+const stable = require('stable');
+const specificity = require('csso/lib/restructure/prepare/specificity');
 
 /**
  * Flatten a CSS AST to a selectors list.
@@ -12,41 +11,39 @@ var csstree = require('css-tree'),
  * @return {Array} selectors
  */
 function flattenToSelectors(cssAst) {
-  var selectors = [];
+  const selectors = [];
 
-  csstree.walk(cssAst, {
+  walk(cssAst, {
     visit: 'Rule',
-    enter: function (node) {
+    enter(node) {
       if (node.type !== 'Rule') {
         return;
       }
 
-      var atrule = this.atrule;
-      var rule = node;
+      const { atrule } = this;
+      const rule = node;
 
-      node.prelude.children.each(function (selectorNode, selectorItem) {
-        var selector = {
+      node.prelude.children.each((selectorNode, selectorItem) => {
+        const selector = {
           item: selectorItem,
-          atrule: atrule,
-          rule: rule,
+          atrule,
+          rule,
           pseudos: /** @type {{item: any; list: any[]}[]} */ ([]),
         };
 
-        selectorNode.children.each(function (
-          selectorChildNode,
-          selectorChildItem,
-          selectorChildList
-        ) {
-          if (
-            selectorChildNode.type === 'PseudoClassSelector' ||
-            selectorChildNode.type === 'PseudoElementSelector'
-          ) {
-            selector.pseudos.push({
-              item: selectorChildItem,
-              list: selectorChildList,
-            });
+        selectorNode.children.each(
+          (selectorChildNode, selectorChildItem, selectorChildList) => {
+            if (
+              selectorChildNode.type === 'PseudoClassSelector' ||
+              selectorChildNode.type === 'PseudoElementSelector'
+            ) {
+              selector.pseudos.push({
+                item: selectorChildItem,
+                list: selectorChildList,
+              });
+            }
           }
-        });
+        );
 
         selectors.push(selector);
       });
@@ -64,22 +61,22 @@ function flattenToSelectors(cssAst) {
  * @return {Array} Filtered selectors that match the passed media queries
  */
 function filterByMqs(selectors, useMqs) {
-  return selectors.filter(function (selector) {
+  return selectors.filter((selector) => {
     if (selector.atrule === null) {
-      return ~useMqs.indexOf('');
+      return useMqs.includes('');
     }
 
-    var mqName = selector.atrule.name;
-    var mqStr = mqName;
+    const mqName = selector.atrule.name;
+    let mqStr = mqName;
     if (
       selector.atrule.expression &&
       selector.atrule.expression.children.first().type === 'MediaQueryList'
     ) {
-      var mqExpr = csstree.generate(selector.atrule.expression);
+      const mqExpr = generate(selector.atrule.expression);
       mqStr = [mqName, mqExpr].join(' ');
     }
 
-    return ~useMqs.indexOf(mqStr);
+    return useMqs.includes(mqStr);
   });
 }
 
@@ -91,16 +88,14 @@ function filterByMqs(selectors, useMqs) {
  * @return {Array} Filtered selectors that match the passed pseudo-elements and/or -classes
  */
 function filterByPseudos(selectors, usePseudos) {
-  return selectors.filter(function (selector) {
-    var pseudoSelectorsStr = csstree.generate({
+  return selectors.filter((selector) => {
+    const pseudoSelectorsStr = generate({
       type: 'Selector',
       children: new List().fromArray(
-        selector.pseudos.map(function (pseudo) {
-          return pseudo.item.data;
-        })
+        selector.pseudos.map((pseudo) => pseudo.item.data)
       ),
     });
-    return ~usePseudos.indexOf(pseudoSelectorsStr);
+    return usePseudos.includes(pseudoSelectorsStr);
   });
 }
 
@@ -111,11 +106,11 @@ function filterByPseudos(selectors, usePseudos) {
  * @return {void}
  */
 function cleanPseudos(selectors) {
-  selectors.forEach(function (selector) {
-    selector.pseudos.forEach(function (pseudo) {
+  for (const selector of selectors) {
+    for (const pseudo of selector.pseudos) {
       pseudo.list.remove(pseudo.item);
-    });
-  });
+    }
+  }
 }
 
 /**
@@ -127,10 +122,12 @@ function cleanPseudos(selectors) {
  * @return {number} Score of selector specificity A compared to selector specificity B
  */
 function compareSpecificity(aSpecificity, bSpecificity) {
-  for (var i = 0; i < 4; i += 1) {
+  for (let i = 0; i < 4; i++) {
     if (aSpecificity[i] < bSpecificity[i]) {
       return -1;
-    } else if (aSpecificity[i] > bSpecificity[i]) {
+    }
+
+    if (aSpecificity[i] > bSpecificity[i]) {
       return 1;
     }
   }
@@ -146,8 +143,8 @@ function compareSpecificity(aSpecificity, bSpecificity) {
  * @return {number} Score of selector A compared to selector B
  */
 function compareSimpleSelectorNode(aSimpleSelectorNode, bSimpleSelectorNode) {
-  var aSpecificity = specificity(aSimpleSelectorNode),
-    bSpecificity = specificity(bSimpleSelectorNode);
+  const aSpecificity = specificity(aSimpleSelectorNode);
+  const bSpecificity = specificity(bSimpleSelectorNode);
   return compareSpecificity(aSpecificity, bSpecificity);
 }
 
@@ -172,13 +169,14 @@ function sortSelectors(selectors) {
  * @return {Object} CSSStyleDeclaration property
  */
 function csstreeToStyleDeclaration(declaration) {
-  var propertyName = declaration.property,
-    propertyValue = csstree.generate(declaration.value),
-    propertyPriority = declaration.important ? 'important' : '';
+  const name = declaration.property;
+  const value = generate(declaration.value);
+  const priority = declaration.important ? 'important' : '';
+
   return {
-    name: propertyName,
-    value: propertyValue,
-    priority: propertyPriority,
+    name,
+    value,
+    priority,
   };
 }
 
@@ -195,6 +193,7 @@ function getCssStr(elem) {
   ) {
     return elem.children[0].value;
   }
+
   return '';
 }
 
@@ -222,18 +221,15 @@ function setCssStr(elem, css) {
   return css;
 }
 
-module.exports.flattenToSelectors = flattenToSelectors;
-
-module.exports.filterByMqs = filterByMqs;
-module.exports.filterByPseudos = filterByPseudos;
-module.exports.cleanPseudos = cleanPseudos;
-
-module.exports.compareSpecificity = compareSpecificity;
-module.exports.compareSimpleSelectorNode = compareSimpleSelectorNode;
-
-module.exports.sortSelectors = sortSelectors;
-
-module.exports.csstreeToStyleDeclaration = csstreeToStyleDeclaration;
-
-module.exports.getCssStr = getCssStr;
-module.exports.setCssStr = setCssStr;
+module.exports = {
+  flattenToSelectors,
+  filterByMqs,
+  filterByPseudos,
+  cleanPseudos,
+  compareSpecificity,
+  compareSimpleSelectorNode,
+  sortSelectors,
+  csstreeToStyleDeclaration,
+  getCssStr,
+  setCssStr,
+};


### PR DESCRIPTION
* use const
* use arrow functions
* use `for...of`
* stop using bitwise operators
* group exports

The non-whitespace diff is better: https://github.com/svg/svgo/pull/1600/files?diff=unified&w=1