### PR TITLE
Refactor inlineStyles

### DIFF
--- a/test/plugins/inlineStyles.14.svg
+++ b/test/plugins/inlineStyles.14.svg
@@ -19,10 +19,10 @@
 <svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.285 81.285">
     <defs>
         <style>
-            @media only screen and (min-device-width:320px) and (max-device-width:480px) and (-webkit-min-device-pixel-ratio:2){.blue{fill:blue}}
+            @media only screen and (min-device-width:320px) and (max-device-width:480px) and (-webkit-min-device-pixel-ratio:2){}
         </style>
     </defs>
-    <rect width="100" height="100" class="blue"/>
+    <rect width="100" height="100" style="fill:blue"/>
 </svg>
 
 @@@

--- a/test/plugins/inlineStyles.16.svg
+++ b/test/plugins/inlineStyles.16.svg
@@ -25,6 +25,7 @@
 @@@
 
 <svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 222 57.28">
+    <defs/>
     <title>button</title>
     <rect width="222" height="57.28" rx="28.64" ry="28.64" style="stroke:red;fill:#37d0cd"/>
     <path d="M312.75,168.66A2.15,2.15,0,0,1,311.2,165L316,160l-4.8-5a2.15,2.15,0,1,1,3.1-3l6.21,6.49a2.15,2.15,0,0,1,0,3L314.31,168a2.14,2.14,0,0,1-1.56.67Zm0,0" transform="translate(-119 -131.36)" style="fill:#fff"/>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "plugins/removeEmptyAttrs.js",
     "plugins/removeNonInheritableGroupAttrs.js",
     "plugins/removeXMLNS.js",
-    "plugins/inlineStyles.js",
     "plugins/preset-default.js"
   ]
 }


### PR DESCRIPTION
This is a big one

- got rid from another closestByName usage
- delegated removing empty defs elements to removeEmptyContainers plugin
- got rid from all css-tools usages (most inlineStyles code was there
  for some reason)
- combined a few loops
- fixed useMqs option (I would remove it in v3 for simplicity as it
  seems nobody use it)

cc @strarsis 