### PR TITLE
Load .cjs with require only

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -15,21 +15,28 @@ exports.createContentItem = createContentItem;
 
 const importConfig = async (configFile) => {
   let config;
-  try {
-    // dynamic import expects file url instead of path and may fail
-    // when windows path is provided
-    const { default: imported } = await import(pathToFileURL(configFile));
-    config = imported;
-  } catch (importError) {
-    // TODO remove require in v3
+  // at the moment dynamic import may randomly fail with segfault
+  // to workaround this for some users .cjs extension is loaded
+  // exclusively with require
+  if (configFile.endsWith('.cjs')) {
+    config = require(configFile);
+  } else {
     try {
-      config = require(configFile);
-    } catch (requireError) {
-      // throw original error if es module is detected
-      if (requireError.code === 'ERR_REQUIRE_ESM') {
-        throw importError;
-      } else {
-        throw requireError;
+      // dynamic import expects file url instead of path and may fail
+      // when windows path is provided
+      const { default: imported } = await import(pathToFileURL(configFile));
+      config = imported;
+    } catch (importError) {
+      // TODO remove require in v3
+      try {
+        config = require(configFile);
+      } catch (requireError) {
+        // throw original error if es module is detected
+        if (requireError.code === 'ERR_REQUIRE_ESM') {
+          throw importError;
+        } else {
+          throw requireError;
+        }
       }
     }
   }


### PR DESCRIPTION
Ref https://github.com/svg/svgo/issues/1596

At the moment dynamic import may randomly fail with segfault.
To workaround this for some users .cjs extension is loaded
exclusively with require.