### PR TITLE
Migrate to picocolors

### DIFF
--- a/bin/svgo
+++ b/bin/svgo
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { red } = require('nanocolors');
+const colors = require('picocolors');
 const { program } = require('commander');
 const makeProgram = require('../lib/svgo/coa');
 makeProgram(program);
 program.parseAsync(process.argv).catch(error => {
-  console.error(red(error.stack));
+  console.error(colors.red(error.stack));
   process.exit(1);
 });

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { green, red } = require('nanocolors');
+const colors = require('picocolors');
 const { loadConfig, optimize } = require('../svgo-node.js');
 const pluginsMap = require('../../plugins/plugins.js');
 const PKG = require('../../package.json');
@@ -73,7 +73,7 @@ module.exports = function makeProgram(program) {
       'Only output error messages, not regular status messages'
     )
     .option('--show-plugins', 'Show available plugins and exit')
-    // used by nanocolors internally
+    // used by picocolors internally
     .option('--no-color', 'Output plain text without color')
     .action(action);
 };
@@ -387,7 +387,7 @@ function processSVGData(config, info, data, output, input) {
 
   const result = optimize(data, { ...config, ...info });
   if (result.modernError) {
-    console.error(red(result.modernError.toString()));
+    console.error(colors.red(result.modernError.toString()));
     process.exit(1);
   }
   if (config.datauri) {
@@ -457,7 +457,7 @@ function printProfitInfo(inBytes, outBytes) {
     Math.round((inBytes / 1024) * 1000) / 1000 +
       ' KiB' +
       (profitPercents < 0 ? ' + ' : ' - ') +
-      green(Math.abs(Math.round(profitPercents * 10) / 10) + '%') +
+      colors.green(Math.abs(Math.round(profitPercents * 10) / 10) + '%') +
       ' = ' +
       Math.round((outBytes / 1024) * 1000) / 1000 +
       ' KiB'
@@ -509,7 +509,7 @@ function checkWriteFileError(input, output, data, error) {
 function showAvailablePlugins() {
   const list = Object.entries(pluginsMap)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, plugin]) => ` [ ${green(name)} ] ${plugin.description}`)
+    .map(([name, plugin]) => ` [ ${colors.green(name)} ] ${plugin.description}`)
     .join('\n');
   console.log('Currently available plugins:\n' + list);
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "css-select": "^4.1.3",
     "css-tree": "^1.1.3",
     "csso": "^4.2.0",
-    "nanocolors": "^0.2.1",
+    "picocolors": "^0.2.1",
     "stable": "^0.1.8"
   },
   "devDependencies": {
@@ -117,7 +117,7 @@
     "@types/jest": "^27.0.1",
     "del": "^6.0.0",
     "eslint": "^7.32.0",
-    "jest": "^27.2.1",
+    "jest": "^27.2.4",
     "mock-stdin": "^1.0.0",
     "node-fetch": "^2.6.2",
     "pixelmatch": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"@babel/code-frame@npm:7.12.11, @babel/code-frame@npm:^7.10.4":
+"@babel/code-frame@npm:7.12.11":
   version: 7.12.11
   resolution: "@babel/code-frame@npm:7.12.11"
   dependencies:
@@ -14,7 +14,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.14.5":
+"@babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/code-frame@npm:7.14.5"
   dependencies:
@@ -482,50 +482,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/console@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/console@npm:27.2.0"
+"@jest/console@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/console@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     chalk: ^4.0.0
-    jest-message-util: ^27.2.0
-    jest-util: ^27.2.0
+    jest-message-util: ^27.2.4
+    jest-util: ^27.2.4
     slash: ^3.0.0
-  checksum: 82a64185f6062e3525a5e74340e2a30b8a7e9e29579aec95a35b438b997b8c18dc7274111007e7cb61cc0a6035ff5ff6706e7cafc66b185b9839eefb2ec7d806
+  checksum: 8dc8197b2422dead41b588a3f6bd01e4256d5b30b0a9dd6e9dedb623ba08773bf8d1518104419e13fe057351f30df42ea36d544fb9a231f9bfb6bc3fbcc0669e
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "@jest/core@npm:27.2.1"
+"@jest/core@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/core@npm:27.2.4"
   dependencies:
-    "@jest/console": ^27.2.0
-    "@jest/reporters": ^27.2.1
-    "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/console": ^27.2.4
+    "@jest/reporters": ^27.2.4
+    "@jest/test-result": ^27.2.4
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     ansi-escapes: ^4.2.1
     chalk: ^4.0.0
     emittery: ^0.8.1
     exit: ^0.1.2
     graceful-fs: ^4.2.4
-    jest-changed-files: ^27.1.1
-    jest-config: ^27.2.1
-    jest-haste-map: ^27.2.0
-    jest-message-util: ^27.2.0
+    jest-changed-files: ^27.2.4
+    jest-config: ^27.2.4
+    jest-haste-map: ^27.2.4
+    jest-message-util: ^27.2.4
     jest-regex-util: ^27.0.6
-    jest-resolve: ^27.2.0
-    jest-resolve-dependencies: ^27.2.1
-    jest-runner: ^27.2.1
-    jest-runtime: ^27.2.1
-    jest-snapshot: ^27.2.1
-    jest-util: ^27.2.0
-    jest-validate: ^27.2.0
-    jest-watcher: ^27.2.0
+    jest-resolve: ^27.2.4
+    jest-resolve-dependencies: ^27.2.4
+    jest-runner: ^27.2.4
+    jest-runtime: ^27.2.4
+    jest-snapshot: ^27.2.4
+    jest-util: ^27.2.4
+    jest-validate: ^27.2.4
+    jest-watcher: ^27.2.4
     micromatch: ^4.0.4
-    p-each-series: ^2.1.0
     rimraf: ^3.0.0
     slash: ^3.0.0
     strip-ansi: ^6.0.0
@@ -534,56 +533,56 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: a2b52c3a111775161b58e5fd7e71767a9085bcb6125c814e87abae198ef5c3600a1e6d76555b507609caca40291e9b98014ab1db35abd0c584a2db97ab86a0d2
+  checksum: 64703000e109bbfc464bacf187fe599ec774f176da75a29d6ae50cbfdc130b94971023aeeb6e7ee0891070f18bbf092baf4bdaa35fcbd4d1fcad334f50cbb84d
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/environment@npm:27.2.0"
+"@jest/environment@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/environment@npm:27.2.4"
   dependencies:
-    "@jest/fake-timers": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/fake-timers": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
-    jest-mock: ^27.1.1
-  checksum: c3ac3311238b0b5fa36f53d506d4ae7046307db91b1448476aa7a11587a1ac7de517522ac2949f75524aca4d4d9cff0ccd52bb09daea85c418d7eab0f79822c5
+    jest-mock: ^27.2.4
+  checksum: 61ce9414197720b528225059463c28941d1cd0815b33526688acd469f8622af89d3c1c1c4b06d1c12bd68ff4d45a28a8a137a39191b10d23cd68888601078296
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/fake-timers@npm:27.2.0"
+"@jest/fake-timers@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/fake-timers@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
-    "@sinonjs/fake-timers": ^7.0.2
+    "@jest/types": ^27.2.4
+    "@sinonjs/fake-timers": ^8.0.1
     "@types/node": "*"
-    jest-message-util: ^27.2.0
-    jest-mock: ^27.1.1
-    jest-util: ^27.2.0
-  checksum: d062d2da31aee81f788a9aef3f4bae295e029c1272611765d17dd450c9b9ca07859c50f4cb1ebf47fbb08eec970381e23b8d04479f1ee37618d8df5a0599288c
+    jest-message-util: ^27.2.4
+    jest-mock: ^27.2.4
+    jest-util: ^27.2.4
+  checksum: 99e8e9a0b4911fd099099cfab5b1790bba788aa1021bc7e17a6c98fd96c64ba48ce14cf3cc3206e8d91a13bb90ac7f76ade4f12ef6ef94257c80e6ffc3524ed7
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "@jest/globals@npm:27.2.1"
+"@jest/globals@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/globals@npm:27.2.4"
   dependencies:
-    "@jest/environment": ^27.2.0
-    "@jest/types": ^27.1.1
-    expect: ^27.2.1
-  checksum: 839478dd3cc75e4ab68ae006785a0c8de21ec1b0104b18050c1267e9685bf049cc3500ecf29384df747e5d5b6619c56f4ac56dc6e5bda5d96b3fe1f42b7e385e
+    "@jest/environment": ^27.2.4
+    "@jest/types": ^27.2.4
+    expect: ^27.2.4
+  checksum: ee3a6832eeb11db307893702786157e9ba41650f9e57f555ed910f8b20ae3d479afc936276731ece1e42c1c9063e487fdd36a9b05d29f28f44d839e357d0c38a
   languageName: node
   linkType: hard
 
-"@jest/reporters@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "@jest/reporters@npm:27.2.1"
+"@jest/reporters@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/reporters@npm:27.2.4"
   dependencies:
     "@bcoe/v8-coverage": ^0.2.3
-    "@jest/console": ^27.2.0
-    "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/console": ^27.2.4
+    "@jest/test-result": ^27.2.4
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     chalk: ^4.0.0
     collect-v8-coverage: ^1.0.0
     exit: ^0.1.2
@@ -594,21 +593,21 @@ __metadata:
     istanbul-lib-report: ^3.0.0
     istanbul-lib-source-maps: ^4.0.0
     istanbul-reports: ^3.0.2
-    jest-haste-map: ^27.2.0
-    jest-resolve: ^27.2.0
-    jest-util: ^27.2.0
-    jest-worker: ^27.2.0
+    jest-haste-map: ^27.2.4
+    jest-resolve: ^27.2.4
+    jest-util: ^27.2.4
+    jest-worker: ^27.2.4
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
     terminal-link: ^2.0.0
-    v8-to-istanbul: ^8.0.0
+    v8-to-istanbul: ^8.1.0
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 41065ed7b44a72c05b429960922d32356a6dd35571d58803eb3c811bbbb62278b607b697631bdcd8fe509c8d592f8b852b7105faa779b55902b0d90b3b274055
+  checksum: 965a234b3eba554cdc03068fcba28ccce0e06377bb2bc49db9cc584dfe0dc0cb02e38ccb84857d9dc492e9e66794a5f5af03ec2dfa8b504c3224e4641cf97d02
   languageName: node
   linkType: hard
 
@@ -623,63 +622,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/test-result@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "@jest/test-result@npm:27.2.0"
+"@jest/test-result@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/test-result@npm:27.2.4"
   dependencies:
-    "@jest/console": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/console": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/istanbul-lib-coverage": ^2.0.0
     collect-v8-coverage: ^1.0.0
-  checksum: 0aa4c6c40135f68e9f10d67acb76b9b3e19d1b0fcddcd1132a2cce4fa7e2a40b54489c370bdeaa74c46bb587930f970a9572e6cc3227b459f2f9c5670107381d
+  checksum: 1ec3c1cecf68e35efddda0308b7cbd39689bf0dde79fb1461b9bcfd8ca5774d7018c5542f1e1d5a6d7508dffecdb5ad7bbde000e9dc2c7efee0792abab4052f8
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "@jest/test-sequencer@npm:27.2.1"
+"@jest/test-sequencer@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/test-sequencer@npm:27.2.4"
   dependencies:
-    "@jest/test-result": ^27.2.0
+    "@jest/test-result": ^27.2.4
     graceful-fs: ^4.2.4
-    jest-haste-map: ^27.2.0
-    jest-runtime: ^27.2.1
-  checksum: a6445ab84b9747c68cd77fb1f18c68dc10f6dbd1912fa7c0e436a8f294095da3d342ecd56d6c81812efadc84fe26a4cfa60d6b9e180b2a3550e5ecd428d1d3b8
+    jest-haste-map: ^27.2.4
+    jest-runtime: ^27.2.4
+  checksum: 3383e9e94f16d2299386172cfe456e38a806f689bbf3c9657d1c7a6adeefd50d71fa9eae00bde9f230f700b5d10f90dbd8a0a429e188f532038de8342bd0d81d
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "@jest/transform@npm:27.2.1"
+"@jest/transform@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/transform@npm:27.2.4"
   dependencies:
     "@babel/core": ^7.1.0
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     babel-plugin-istanbul: ^6.0.0
     chalk: ^4.0.0
     convert-source-map: ^1.4.0
     fast-json-stable-stringify: ^2.0.0
     graceful-fs: ^4.2.4
-    jest-haste-map: ^27.2.0
+    jest-haste-map: ^27.2.4
     jest-regex-util: ^27.0.6
-    jest-util: ^27.2.0
+    jest-util: ^27.2.4
     micromatch: ^4.0.4
     pirates: ^4.0.1
     slash: ^3.0.0
     source-map: ^0.6.1
     write-file-atomic: ^3.0.0
-  checksum: c6ebfb4481cf5dae9fcfda05bd4f5b4e79fcc2030c516d6a20a67e128d6391248a1641846b57262de34cf9371101f4657f883fffdb52295c18103c08a2ea2f1f
+  checksum: 8732959e09df1dde798eb7fa6ac6b5ad67b59f800d95151e8f96125d65e940c74d81ffb5a16d5c79c44f188ad61ec612ba55739883b844513c9ed088cf7214e6
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^27.1.1":
-  version: 27.1.1
-  resolution: "@jest/types@npm:27.1.1"
+"@jest/types@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "@jest/types@npm:27.2.4"
   dependencies:
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
-  checksum: c310ebf3ec0724a6e933ccd9eb3ee46d4da0bcc87b4572b9a2734d4e534ac130a724be9f8eedbd6aa9cff5df0d5844cb16550f3d10d467d71838cf38ccb534f9
+  checksum: 1e753c4fef7fed4bb9f3a9c2c2cd7d97317851a065c95aa8461dacdf7bdb5c6fa7a319d011869086dc5a45226280a844a4a6696dbe4a14b2e2449250db10fd46
   languageName: node
   linkType: hard
 
@@ -796,12 +795,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^7.0.2":
-  version: 7.1.2
-  resolution: "@sinonjs/fake-timers@npm:7.1.2"
+"@sinonjs/fake-timers@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@sinonjs/fake-timers@npm:8.0.1"
   dependencies:
     "@sinonjs/commons": ^1.7.0
-  checksum: 5ce48e40db14d7e1419bae287b84559133d580cb56130b51d7479dff318bfafed87531f8b48f618f07e3c9a6113c9e3f00286805d55de64986b9cccb8eb6d5cf
+  checksum: f9f73504278c94ab9337d36e9f594082451f55fa7824e8fcd650354aaa0427c3bfb4ea26ff9afdb10e0d3c48da46452d0754bc0248aeb987584d47af63115e3d
   languageName: node
   linkType: hard
 
@@ -935,9 +934,9 @@ __metadata:
   linkType: hard
 
 "@types/prettier@npm:^2.1.5":
-  version: 2.3.2
-  resolution: "@types/prettier@npm:2.3.2"
-  checksum: 7b425386aaf3b03fa63382ed1aceff367477ef9a52a2705978bfb1495fa1d8795316e1ab84671f6c8c5920de59a33d1567d837b9eb033996983efdfdbce84cb3
+  version: 2.4.1
+  resolution: "@types/prettier@npm:2.4.1"
+  checksum: c191cf299ff2fe7c1b9e68920c7d0f700d23c9407d29792dc26f6faa26b4b7d056c6e915f35c0f6cdf497789c58d3074e428d1b99242cbfa3013b63576b3b270
   languageName: node
   linkType: hard
 
@@ -1124,10 +1123,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ansi-regex@npm:5.0.0"
-  checksum: cbd9b5c9dbbb4a949c2a6e93f1c6cc19f0683d8a4724d08d2158627be6d373f0f3ba1f4ada01dce7ee141f2ba2628fbbd29932c7d49926e3b630c7f329f3178b
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: c944e1229f022a2071f7477ea425964328c577d2c752083fe564ea0513b6d733c9ec65102f6d4d2b54cba0cb2dc969648b60d567abeff13dc95ecc0b9b97737d
   languageName: node
   linkType: hard
 
@@ -1213,12 +1212,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "babel-jest@npm:27.2.1"
+"babel-jest@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "babel-jest@npm:27.2.4"
   dependencies:
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/babel__core": ^7.1.14
     babel-plugin-istanbul: ^6.0.0
     babel-preset-jest: ^27.2.0
@@ -1227,7 +1226,7 @@ __metadata:
     slash: ^3.0.0
   peerDependencies:
     "@babel/core": ^7.8.0
-  checksum: 44c79b9c3d307b6140c928945d4889b7290d72edc2a4a94384a7f0da19d3d682318c58afc206a62d02b9e31d8eb7d7dbf6a0568c978f60bd17a1cdd5cc8af0c8
+  checksum: c22b1edf2db94279026efa75f7b38dfac47b81746d8a09c80de351e5ac9679056503801c3878956202cd0f4e812cf3d0346be1ec7807d1c5b3af97cc6467ce34
   languageName: node
   linkType: hard
 
@@ -1349,17 +1348,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.16.6":
-  version: 4.17.1
-  resolution: "browserslist@npm:4.17.1"
+  version: 4.17.3
+  resolution: "browserslist@npm:4.17.3"
   dependencies:
-    caniuse-lite: ^1.0.30001259
-    electron-to-chromium: ^1.3.846
+    caniuse-lite: ^1.0.30001264
+    electron-to-chromium: ^1.3.857
     escalade: ^3.1.1
-    nanocolors: ^0.1.5
-    node-releases: ^1.1.76
+    node-releases: ^1.1.77
+    picocolors: ^0.2.1
   bin:
     browserslist: cli.js
-  checksum: 735d4f007dc74f5281d80c7f1677e22d750b78cf9e3c934e8ff4308674fcd4b561c9ec4a8aca7fecd34366077489b29004ca472a480140ccd7674d739c21b7f6
+  checksum: a68e1d1d5802cdcc4403ffc11df2d7b029ac5e36a8de245b8ab234e9b9cb83923b8f4f69b312b5f7fa2183c43a7091436b22949afddda796cc1ffcfd573effb9
   languageName: node
   linkType: hard
 
@@ -1450,12 +1449,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001259":
-  version: 1.0.30001260
-  resolution: "caniuse-lite@npm:1.0.30001260"
-  dependencies:
-    nanocolors: ^0.1.0
-  checksum: 8626bce717bfd29775cab2b90351a4a92e21ba1e59ef82cf24498228d39ec1e9e354fbcff23918ae9cbc848d3a278e75de35edca4eb739317fddbffe0479eaf5
+"caniuse-lite@npm:^1.0.30001264":
+  version: 1.0.30001264
+  resolution: "caniuse-lite@npm:1.0.30001264"
+  checksum: 98c7297f333e2a637315c33aaa8e15e98b42829d483d7ffb41a0eecd6216375f8a40670ec1e7239985fd7b495f5cdcc5e415ce61cc0a7d9748a19b8450d5b211
   languageName: node
   linkType: hard
 
@@ -1886,10 +1883,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.846":
-  version: 1.3.848
-  resolution: "electron-to-chromium@npm:1.3.848"
-  checksum: 0eedeb75a04adfa5febb13edf5b07340b9e8a6f4674ac2a2f620168e43896b000e87ff22687fe85859661311e559f399e6b67678cb9b85f090f77f0f79d7ab2d
+"electron-to-chromium@npm:^1.3.857":
+  version: 1.3.859
+  resolution: "electron-to-chromium@npm:1.3.859"
+  checksum: 3a838b14612ab02cf57d1dcc5afc07b579aec6619f3cd2d8d7b7adcbb132ffe0facc6f4ddccc12cabbe2416f647c3240151e19ef7c82337965b47342f49f536f
   languageName: node
   linkType: hard
 
@@ -2183,17 +2180,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "expect@npm:27.2.1"
+"expect@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "expect@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     ansi-styles: ^5.0.0
     jest-get-type: ^27.0.6
-    jest-matcher-utils: ^27.2.0
-    jest-message-util: ^27.2.0
+    jest-matcher-utils: ^27.2.4
+    jest-message-util: ^27.2.4
     jest-regex-util: ^27.0.6
-  checksum: 9367c5b5ffbb474b3bc382186aabbcdf37c8c9e5abff38517bcc1e756debb645a1ab36e17179f9eab71cc80311d7ba4fe0491c85f51c1ba223032c09779e4a65
+  checksum: 4e123e99bab8717d820dabf2a172db42ae9bfdcdbebdf8020958fbe6a2f1d9561ea7797558fca06fc11668ac7462c39e18413286ad6e43a52331e68d1511aea8
   languageName: node
   linkType: hard
 
@@ -2449,8 +2446,8 @@ __metadata:
   linkType: hard
 
 "glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
-  version: 7.1.7
-  resolution: "glob@npm:7.1.7"
+  version: 7.2.0
+  resolution: "glob@npm:7.2.0"
   dependencies:
     fs.realpath: ^1.0.0
     inflight: ^1.0.4
@@ -2458,7 +2455,7 @@ __metadata:
     minimatch: ^3.0.4
     once: ^1.3.0
     path-is-absolute: ^1.0.0
-  checksum: 352f74f08247db5420161a2f68f2bd84b53228b5fcfc9dcc37cd54d3f19ec0232495d84aeff1286d0727059e9fdc1031400e00b971bdc59e30f8f82b199c9d02
+  checksum: 1171c3d7b1f5a367499e498826cddafc642aa55ef21e810031a287d3199612a889059d7d2c276a04c636c3ac2fd5943896bfc309110b21fafaeb8a1e0a199d6e
   languageName: node
   linkType: hard
 
@@ -2639,14 +2636,14 @@ __metadata:
   linkType: hard
 
 "import-local@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "import-local@npm:3.0.2"
+  version: 3.0.3
+  resolution: "import-local@npm:3.0.3"
   dependencies:
     pkg-dir: ^4.2.0
     resolve-cwd: ^3.0.0
   bin:
     import-local-fixture: fixtures/cli.js
-  checksum: 9ba5f1697b8b11aae8dab7964bf1c2409ed5dc51dd03fe8698fb32df04a3a683adbe9d95e6bb963a384373ec8d055c508f0c534b45aac1de4a3b4b653e6cfe82
+  checksum: 7acddfb42dadf69d83456100ba2106cd89d4ec5d432e65773026bbbc9e27c1e1444f57ec14bb428a35dd4bf018030a35f180bf382e8a89b8cb8810b7701ac520
   languageName: node
   linkType: hard
 
@@ -2891,60 +2888,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:^27.1.1":
-  version: 27.1.1
-  resolution: "jest-changed-files@npm:27.1.1"
+"jest-changed-files@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-changed-files@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     execa: ^5.0.0
     throat: ^6.0.1
-  checksum: 7a050b2190bd1855bbc22877ef1cff21161ff5ad076bb5de3937cd85925a9d18eb3912f4b08dbbecbc382a79dd5942e2bf295f07ff5e2d18bcb4fd44a1337dc9
+  checksum: b5e6157805295b77d2247d834097f5623e5bad32af9246c5b140dcf88cb046fb81f7c3342c3c8dfd1f7880941a8496e633348fec7f7c724134f8743145ac1b03
   languageName: node
   linkType: hard
 
-"jest-circus@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-circus@npm:27.2.1"
+"jest-circus@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-circus@npm:27.2.4"
   dependencies:
-    "@jest/environment": ^27.2.0
-    "@jest/test-result": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/environment": ^27.2.4
+    "@jest/test-result": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     chalk: ^4.0.0
     co: ^4.6.0
     dedent: ^0.7.0
-    expect: ^27.2.1
+    expect: ^27.2.4
     is-generator-fn: ^2.0.0
-    jest-each: ^27.2.0
-    jest-matcher-utils: ^27.2.0
-    jest-message-util: ^27.2.0
-    jest-runtime: ^27.2.1
-    jest-snapshot: ^27.2.1
-    jest-util: ^27.2.0
-    pretty-format: ^27.2.0
+    jest-each: ^27.2.4
+    jest-matcher-utils: ^27.2.4
+    jest-message-util: ^27.2.4
+    jest-runtime: ^27.2.4
+    jest-snapshot: ^27.2.4
+    jest-util: ^27.2.4
+    pretty-format: ^27.2.4
     slash: ^3.0.0
     stack-utils: ^2.0.3
     throat: ^6.0.1
-  checksum: 53054aad5f43ae49210246cfa7406b458d2805e30d3db24c75e45aba0090ffcb43693fb3500cb2514940af775558198a9952d92a8943473028b3a80e96039826
+  checksum: 151269cd8f1e2cb51700b4e36355e22d663a54b8db969be03c39ce8fbaac11fa89f87633199dbfef0cb6f6d11eeacc7ef67dba10131edbe74d5fb120ee67a6b6
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-cli@npm:27.2.1"
+"jest-cli@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-cli@npm:27.2.4"
   dependencies:
-    "@jest/core": ^27.2.1
-    "@jest/test-result": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/core": ^27.2.4
+    "@jest/test-result": ^27.2.4
+    "@jest/types": ^27.2.4
     chalk: ^4.0.0
     exit: ^0.1.2
     graceful-fs: ^4.2.4
     import-local: ^3.0.2
-    jest-config: ^27.2.1
-    jest-util: ^27.2.0
-    jest-validate: ^27.2.0
+    jest-config: ^27.2.4
+    jest-util: ^27.2.4
+    jest-validate: ^27.2.4
     prompts: ^2.0.1
-    yargs: ^16.0.3
+    yargs: ^16.2.0
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -2952,53 +2949,53 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: 9dcd024d92798f3ee0c50196f93bd2a7b78ef6a2ab5eacc202281a97c75fd9e949d67afbb0b01de83d9c5f0ff641f0b1b76a6d0a6a7fe6f1965c3de1829afee9
+  checksum: 0625be080be881f699a93b9eb7afc5f53cee3b486718c0dad930de5199eeb524258d602a4b21b442d971a4f2470046b5289eb3518886de216c183d7a3a8c54fb
   languageName: node
   linkType: hard
 
-"jest-config@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-config@npm:27.2.1"
+"jest-config@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-config@npm:27.2.4"
   dependencies:
     "@babel/core": ^7.1.0
-    "@jest/test-sequencer": ^27.2.1
-    "@jest/types": ^27.1.1
-    babel-jest: ^27.2.1
+    "@jest/test-sequencer": ^27.2.4
+    "@jest/types": ^27.2.4
+    babel-jest: ^27.2.4
     chalk: ^4.0.0
     deepmerge: ^4.2.2
     glob: ^7.1.1
     graceful-fs: ^4.2.4
     is-ci: ^3.0.0
-    jest-circus: ^27.2.1
-    jest-environment-jsdom: ^27.2.0
-    jest-environment-node: ^27.2.0
+    jest-circus: ^27.2.4
+    jest-environment-jsdom: ^27.2.4
+    jest-environment-node: ^27.2.4
     jest-get-type: ^27.0.6
-    jest-jasmine2: ^27.2.1
+    jest-jasmine2: ^27.2.4
     jest-regex-util: ^27.0.6
-    jest-resolve: ^27.2.0
-    jest-runner: ^27.2.1
-    jest-util: ^27.2.0
-    jest-validate: ^27.2.0
+    jest-resolve: ^27.2.4
+    jest-runner: ^27.2.4
+    jest-util: ^27.2.4
+    jest-validate: ^27.2.4
     micromatch: ^4.0.4
-    pretty-format: ^27.2.0
+    pretty-format: ^27.2.4
   peerDependencies:
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
     ts-node:
       optional: true
-  checksum: fbc2c60e6d9f1670f7c19f689d742b61de57f0d5d7792230f8975c1d5313c96ef80503f22168a19e4b757d2a738d5030d00f384267f21e33304adb2796d4f8bc
+  checksum: 97149121228d0967c52ba1b0455d0a0263ea1c7e0070fd316a4069b826712a65b1b7f2fbca0aefe15ddc5253dc93c97acf3481d2df474cf3e912ffb479b94f71
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^27.0.0, jest-diff@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-diff@npm:27.2.0"
+"jest-diff@npm:^27.0.0, jest-diff@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-diff@npm:27.2.4"
   dependencies:
     chalk: ^4.0.0
     diff-sequences: ^27.0.6
     jest-get-type: ^27.0.6
-    pretty-format: ^27.2.0
-  checksum: c4acdc19f94db308b3eb7908912c76f743cea8c17e227baa8ca5b6f4ba42adca6ffaa218978ca967931a961ac6dc3a839c10b23a9b3bbf28b066f2d429cc8980
+    pretty-format: ^27.2.4
+  checksum: ba292cac623720611705a0b46ee108123747ea6510725c215a9dc4cb22826dc289d0475ce2d746dcdad26042d76cd25ac1d098459277dda5807ec3ec03698957
   languageName: node
   linkType: hard
 
@@ -3011,45 +3008,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-each@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-each@npm:27.2.0"
+"jest-each@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-each@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     chalk: ^4.0.0
     jest-get-type: ^27.0.6
-    jest-util: ^27.2.0
-    pretty-format: ^27.2.0
-  checksum: d8ad948dbb6a9c05b998b76acec83112a9af584772d0a3534f2dec1b2e4da62afbe7a9de27391eaebb0e6178165aa45abcf806e26aec10fe69275a166c4ae2ef
+    jest-util: ^27.2.4
+    pretty-format: ^27.2.4
+  checksum: 74cb7ecd39c20480125139a90bf6ad93a443c9a5499428371e914e3eb2d2d461a41abe4a85c46fea16ec7152b10a79678242841e7f20d5c5bb2616ff5ebb7fcc
   languageName: node
   linkType: hard
 
-"jest-environment-jsdom@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-environment-jsdom@npm:27.2.0"
+"jest-environment-jsdom@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-environment-jsdom@npm:27.2.4"
   dependencies:
-    "@jest/environment": ^27.2.0
-    "@jest/fake-timers": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/environment": ^27.2.4
+    "@jest/fake-timers": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
-    jest-mock: ^27.1.1
-    jest-util: ^27.2.0
+    jest-mock: ^27.2.4
+    jest-util: ^27.2.4
     jsdom: ^16.6.0
-  checksum: b5ef231a2956168ad06c61f3e891197612f6e20d4ef22d72c74809c24e27dc9bd324c65b4dcbd2fc7b1ef3a84126c473bf6c683d3bb883f5e1a056cabcd0d689
+  checksum: 527e1b4d5f3a3998b6de8225f4a3ecbe95d0b82e6c9fe0a28980b0cbc9f9a38dd2a6ff6a1d5ef0c447e196e87afd88feef5bb15a3342fb5a5dc3db117c557bc9
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-environment-node@npm:27.2.0"
+"jest-environment-node@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-environment-node@npm:27.2.4"
   dependencies:
-    "@jest/environment": ^27.2.0
-    "@jest/fake-timers": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/environment": ^27.2.4
+    "@jest/fake-timers": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
-    jest-mock: ^27.1.1
-    jest-util: ^27.2.0
-  checksum: 0a2d6541e620de6ecb050cee27389ec52c4c74421e65fe357576943fa274c29080cfb3e5f78b76ad94ef0c3287f59b993942d2bf7d9e79df5416c011d7edffe4
+    jest-mock: ^27.2.4
+    jest-util: ^27.2.4
+  checksum: 363b27608ae137109f832de94a30204508873594dcd7c2b6d735de045274de51a31dbf6b2f2e3d70e170f54667205bcfc7f9d0e838273446c8c35442bdc116d1
   languageName: node
   linkType: hard
 
@@ -3060,11 +3057,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-haste-map@npm:27.2.0"
+"jest-haste-map@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-haste-map@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     "@types/graceful-fs": ^4.1.2
     "@types/node": "*"
     anymatch: ^3.0.3
@@ -3073,89 +3070,89 @@ __metadata:
     graceful-fs: ^4.2.4
     jest-regex-util: ^27.0.6
     jest-serializer: ^27.0.6
-    jest-util: ^27.2.0
-    jest-worker: ^27.2.0
+    jest-util: ^27.2.4
+    jest-worker: ^27.2.4
     micromatch: ^4.0.4
     walker: ^1.0.7
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 216581fd593f7bbab4c7aff5805dc3f6715bef18539c8064e46bdba5b65a7649b33ea35d0cffa204b227a1e813ee7ba012189eeee48dc3dd13589cb7d2e3dc63
+  checksum: 5c904ee25193746ae0edec12dd48d4e085ff6cf7bd76437337962d01cd8e0bf57891dc2476be9aa96ee9fb2398a2302f82707e6c57a8083b50f812aa4bf3e5f1
   languageName: node
   linkType: hard
 
-"jest-jasmine2@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-jasmine2@npm:27.2.1"
+"jest-jasmine2@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-jasmine2@npm:27.2.4"
   dependencies:
     "@babel/traverse": ^7.1.0
-    "@jest/environment": ^27.2.0
+    "@jest/environment": ^27.2.4
     "@jest/source-map": ^27.0.6
-    "@jest/test-result": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/test-result": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     chalk: ^4.0.0
     co: ^4.6.0
-    expect: ^27.2.1
+    expect: ^27.2.4
     is-generator-fn: ^2.0.0
-    jest-each: ^27.2.0
-    jest-matcher-utils: ^27.2.0
-    jest-message-util: ^27.2.0
-    jest-runtime: ^27.2.1
-    jest-snapshot: ^27.2.1
-    jest-util: ^27.2.0
-    pretty-format: ^27.2.0
+    jest-each: ^27.2.4
+    jest-matcher-utils: ^27.2.4
+    jest-message-util: ^27.2.4
+    jest-runtime: ^27.2.4
+    jest-snapshot: ^27.2.4
+    jest-util: ^27.2.4
+    pretty-format: ^27.2.4
     throat: ^6.0.1
-  checksum: ddacd1f125867b54b4d05a922ccde8d5545ea35e3378fbf9611b8b465b37132e30d1a42299ca6f75f8250f420bba3990039431fb9b29c4d6024b3ec4d9359a16
+  checksum: 9c1a0f7f3a7bdc9c23e5806de74101af2058ba6227de300b4b7cb6b07f4dabc8f370aae7116f0387862711702abc38bef42c3215fb69c1774ecceb80b8dff116
   languageName: node
   linkType: hard
 
-"jest-leak-detector@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-leak-detector@npm:27.2.0"
+"jest-leak-detector@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-leak-detector@npm:27.2.4"
   dependencies:
     jest-get-type: ^27.0.6
-    pretty-format: ^27.2.0
-  checksum: 923341729a96fe6b1eb9f3f789e3f3c541c58e41510dd71e980073f93c4d849c259be6f91d3f0b553d95ef554ac7a2c36c56126e9bb0a9c670fa39ea6a74126b
+    pretty-format: ^27.2.4
+  checksum: 76d9056491f7bff61d5047f0ddebec5d3a61e710551f91a9d00df78748b56ca4f28e962bf7144b2a78f73ef6bd116aa998786ad6224a3038266d780a10dada8e
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-matcher-utils@npm:27.2.0"
+"jest-matcher-utils@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-matcher-utils@npm:27.2.4"
   dependencies:
     chalk: ^4.0.0
-    jest-diff: ^27.2.0
+    jest-diff: ^27.2.4
     jest-get-type: ^27.0.6
-    pretty-format: ^27.2.0
-  checksum: 680986fe4818ca6732dfcfc341b94db70ab2713831c6fbd8a2d8381ce5db394a7f6ccaaaf9457d7f4496e44450e45c9582186d8b7bb9babe946428580eb77f45
+    pretty-format: ^27.2.4
+  checksum: 5ad84e195f3d10b0a79e9de52d8ee7d8c82374258e41f6ecd42ad0a3372fe59aa7add4612951177f83d702badddb524cbfdaa2f97e5147959b562345166efc76
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-message-util@npm:27.2.0"
+"jest-message-util@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-message-util@npm:27.2.4"
   dependencies:
     "@babel/code-frame": ^7.12.13
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
     graceful-fs: ^4.2.4
     micromatch: ^4.0.4
-    pretty-format: ^27.2.0
+    pretty-format: ^27.2.4
     slash: ^3.0.0
     stack-utils: ^2.0.3
-  checksum: 7624b60e521d1454f753c2d35461d23d8b13be9e1e7e59bfb4cf9013864e71912209a79728b16145dfd9953933ada0ae55ead5c303062c57c7e2e91126d560f3
+  checksum: cf655aec2bcca25b3e3cacec1c894c591c90a3a5002d6ae79d19394ee34174cf999b08746bb967af3f560af95a57984489b3527520880ecfc703b1ee487dd0f6
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^27.1.1":
-  version: 27.1.1
-  resolution: "jest-mock@npm:27.1.1"
+"jest-mock@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-mock@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     "@types/node": "*"
-  checksum: 820dc14e8ef0e4d53162915d1b6e9cf473e9d82306e83458e2ede4103beb7c457c354b7962c0e2f8b40ad18060d163b6dc278135eb8c0874dd8425488e74387e
+  checksum: b23dc6c87dcb7b753e5dc243e5e17e0535bda1832ad45ff73f2045ed6e3957969bc1b9e1bacd4d0fdefed55bcbf07864a42f1f8195210dacf54a589f31d5eada
   languageName: node
   linkType: hard
 
@@ -3178,77 +3175,77 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-resolve-dependencies@npm:27.2.1"
+"jest-resolve-dependencies@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-resolve-dependencies@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     jest-regex-util: ^27.0.6
-    jest-snapshot: ^27.2.1
-  checksum: 995830f29a305c8f224c8372ebfd3d936d8498cea80f9ef2450d3efd7e553f3e769859f3662bfb4c2590c17c5943cd390e4dcdac7d4e4ccf47231a66dd8ee7ef
+    jest-snapshot: ^27.2.4
+  checksum: cdc6291b461b731717df813a5fb40f68a90afe8bcbaccc9ac0e73e6aff92928ae52daeea6c7326d7c7ad402a1f311b1be4958fc84c196400aff8d9dafb224e3a
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:27.2.0, jest-resolve@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-resolve@npm:27.2.0"
+"jest-resolve@npm:27.2.4, jest-resolve@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-resolve@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     chalk: ^4.0.0
     escalade: ^3.1.1
     graceful-fs: ^4.2.4
-    jest-haste-map: ^27.2.0
+    jest-haste-map: ^27.2.4
     jest-pnp-resolver: ^1.2.2
-    jest-util: ^27.2.0
-    jest-validate: ^27.2.0
+    jest-util: ^27.2.4
+    jest-validate: ^27.2.4
     resolve: ^1.20.0
     slash: ^3.0.0
-  checksum: 3cd436e73f7cc3bd8f93ea5919e642edf5bc621928043cb628deaecc77a1a1aad09451ca85c1e4fcbc834ae4a9e69d39bc39c318b08ed52f34de80768f84f71e
+  checksum: a7aa7c339871c2895d22f4342ec0d3942d3ee4e8535d3d1869ff51f8537916079db6131bca52079b2623e866ca64eb6e9cfc6514d0eb42b3ec4cf4b35d0fdeec
   languageName: node
   linkType: hard
 
-"jest-runner@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-runner@npm:27.2.1"
+"jest-runner@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-runner@npm:27.2.4"
   dependencies:
-    "@jest/console": ^27.2.0
-    "@jest/environment": ^27.2.0
-    "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/console": ^27.2.4
+    "@jest/environment": ^27.2.4
+    "@jest/test-result": ^27.2.4
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     chalk: ^4.0.0
     emittery: ^0.8.1
     exit: ^0.1.2
     graceful-fs: ^4.2.4
     jest-docblock: ^27.0.6
-    jest-environment-jsdom: ^27.2.0
-    jest-environment-node: ^27.2.0
-    jest-haste-map: ^27.2.0
-    jest-leak-detector: ^27.2.0
-    jest-message-util: ^27.2.0
-    jest-resolve: ^27.2.0
-    jest-runtime: ^27.2.1
-    jest-util: ^27.2.0
-    jest-worker: ^27.2.0
+    jest-environment-jsdom: ^27.2.4
+    jest-environment-node: ^27.2.4
+    jest-haste-map: ^27.2.4
+    jest-leak-detector: ^27.2.4
+    jest-message-util: ^27.2.4
+    jest-resolve: ^27.2.4
+    jest-runtime: ^27.2.4
+    jest-util: ^27.2.4
+    jest-worker: ^27.2.4
     source-map-support: ^0.5.6
     throat: ^6.0.1
-  checksum: 48236b0d8a6e75a507f5047bc9290c29590ec743f27ad0e59796f8c3e475d7b70174ca2149019b56d10151d5a9dcc88eac6593040420212faa03bd5844f9a5ad
+  checksum: 6d30053b0c7b86da96d0a0286d6344507f817a037f6f2b45b5b0411e5367bbfc29a4e90454d18a9d39d365b7753868c7a5d2d4180acad25d8ac0479d7216e29e
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-runtime@npm:27.2.1"
+"jest-runtime@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-runtime@npm:27.2.4"
   dependencies:
-    "@jest/console": ^27.2.0
-    "@jest/environment": ^27.2.0
-    "@jest/fake-timers": ^27.2.0
-    "@jest/globals": ^27.2.1
+    "@jest/console": ^27.2.4
+    "@jest/environment": ^27.2.4
+    "@jest/fake-timers": ^27.2.4
+    "@jest/globals": ^27.2.4
     "@jest/source-map": ^27.0.6
-    "@jest/test-result": ^27.2.0
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/test-result": ^27.2.4
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
     cjs-module-lexer: ^1.0.0
@@ -3257,18 +3254,18 @@ __metadata:
     exit: ^0.1.2
     glob: ^7.1.3
     graceful-fs: ^4.2.4
-    jest-haste-map: ^27.2.0
-    jest-message-util: ^27.2.0
-    jest-mock: ^27.1.1
+    jest-haste-map: ^27.2.4
+    jest-message-util: ^27.2.4
+    jest-mock: ^27.2.4
     jest-regex-util: ^27.0.6
-    jest-resolve: ^27.2.0
-    jest-snapshot: ^27.2.1
-    jest-util: ^27.2.0
-    jest-validate: ^27.2.0
+    jest-resolve: ^27.2.4
+    jest-snapshot: ^27.2.4
+    jest-util: ^27.2.4
+    jest-validate: ^27.2.4
     slash: ^3.0.0
     strip-bom: ^4.0.0
-    yargs: ^16.0.3
-  checksum: e236ebeb7c8917f2484c9928e73a3e7c7762c3b9a9171c8e3e6a4c2bc165e158bbcb3bc0ef2a6199986a53f345c59e77a11764b0b7519fe7ec113155ad50e095
+    yargs: ^16.2.0
+  checksum: 3c27e6efc17e9a42af21a51e028a53e26a77e7a7f7b553f3339cbd8ec5254830b1cc3592cdc09aafcf67676b165cc9975443c91143c12c9c993e8d141b6e52ac
   languageName: node
   linkType: hard
 
@@ -3282,9 +3279,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest-snapshot@npm:27.2.1"
+"jest-snapshot@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-snapshot@npm:27.2.4"
   dependencies:
     "@babel/core": ^7.7.2
     "@babel/generator": ^7.7.2
@@ -3292,68 +3289,68 @@ __metadata:
     "@babel/plugin-syntax-typescript": ^7.7.2
     "@babel/traverse": ^7.7.2
     "@babel/types": ^7.0.0
-    "@jest/transform": ^27.2.1
-    "@jest/types": ^27.1.1
+    "@jest/transform": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/babel__traverse": ^7.0.4
     "@types/prettier": ^2.1.5
     babel-preset-current-node-syntax: ^1.0.0
     chalk: ^4.0.0
-    expect: ^27.2.1
+    expect: ^27.2.4
     graceful-fs: ^4.2.4
-    jest-diff: ^27.2.0
+    jest-diff: ^27.2.4
     jest-get-type: ^27.0.6
-    jest-haste-map: ^27.2.0
-    jest-matcher-utils: ^27.2.0
-    jest-message-util: ^27.2.0
-    jest-resolve: ^27.2.0
-    jest-util: ^27.2.0
+    jest-haste-map: ^27.2.4
+    jest-matcher-utils: ^27.2.4
+    jest-message-util: ^27.2.4
+    jest-resolve: ^27.2.4
+    jest-util: ^27.2.4
     natural-compare: ^1.4.0
-    pretty-format: ^27.2.0
+    pretty-format: ^27.2.4
     semver: ^7.3.2
-  checksum: 6c3bfb7d46e8942d1f153bb9641c8ea6f35ee6c6fbdc872341d3acea2beea9fec458a71926362c5c4ff1056d0693a536fe3760eee540ec555eb6031f2cdd8dd9
+  checksum: ab1a81d71538c3908ab737d273de8c3b4edfb261ff7066795588876554ba168d3e9a7fb9471720c87c3498c92625fbaf2bf93deda659800a7f21c14a215377c5
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-util@npm:27.2.0"
+"jest-util@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-util@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     chalk: ^4.0.0
     graceful-fs: ^4.2.4
     is-ci: ^3.0.0
     picomatch: ^2.2.3
-  checksum: 5087b4ee091f0a1d2379baaa81961705ee6eda86bf3c27f4cb90ce527897962374a94e455a0751260e5969fa0b3e946a9835c91660bb76d22ccfa6ddd9f38124
+  checksum: ae8b7d816d0d955e814edaf42a4e275ac1972dd442aa0397b9630b592aff228fb836ee15b36a81758b4e8e98d98f075ef9c0da5e5bd779f324dc12b023b67f67
   languageName: node
   linkType: hard
 
-"jest-validate@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-validate@npm:27.2.0"
+"jest-validate@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-validate@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
+    "@jest/types": ^27.2.4
     camelcase: ^6.2.0
     chalk: ^4.0.0
     jest-get-type: ^27.0.6
     leven: ^3.1.0
-    pretty-format: ^27.2.0
-  checksum: 99c8b789bd5bce9493d2437f1f5d5a8244bda7f0242cb2ad3dc85f5577265ed633cb03bffa11bdf3af545ed675abd130e388bb26534835f2bd517a627f565a35
+    pretty-format: ^27.2.4
+  checksum: 2c0096c1997de1eff374b2a22da97c0e4acd7f93401a4db148eda3c8b53333c7ee3630fb046738daf6d860678ee12db966fa86b981c64d6d911240564ba7f2ef
   languageName: node
   linkType: hard
 
-"jest-watcher@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-watcher@npm:27.2.0"
+"jest-watcher@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-watcher@npm:27.2.4"
   dependencies:
-    "@jest/test-result": ^27.2.0
-    "@jest/types": ^27.1.1
+    "@jest/test-result": ^27.2.4
+    "@jest/types": ^27.2.4
     "@types/node": "*"
     ansi-escapes: ^4.2.1
     chalk: ^4.0.0
-    jest-util: ^27.2.0
+    jest-util: ^27.2.4
     string-length: ^4.0.1
-  checksum: af108534fc206c39b27aaac20963a15f79ccf6a4522c4d89080e88710418e6f566f84b3567ea096cfc45c984dd8c9e39a62624ecedf64fb0528d60209429df4e
+  checksum: e39da0df04663e0c9504fad32b61e20b7ebb309d04825ea507299da477eba9f516f7e4486d3d69a6a1c2fc740bda1929ee92e285da0d5c06c19d519d25765216
   languageName: node
   linkType: hard
 
@@ -3368,24 +3365,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "jest-worker@npm:27.2.0"
+"jest-worker@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest-worker@npm:27.2.4"
   dependencies:
     "@types/node": "*"
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
-  checksum: 3e78f2ffd7c211ab2d1b206ffee86d4f1a0ff2eca00a3b2ab6512cef8b61eba0e9b54ccfba7c5c4d758eed1ea0c602868d393ff21116517545ad38a30a27561b
+  checksum: 38a5f42f2415ce1e021c0c91afcf01f9f630c21af61965209c51b4251887afdf6522d7b64c026f33791ddb3c4781e3ffd1c73ac239bb0de4552c6ba2e03f0f2d
   languageName: node
   linkType: hard
 
-"jest@npm:^27.2.1":
-  version: 27.2.1
-  resolution: "jest@npm:27.2.1"
+"jest@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "jest@npm:27.2.4"
   dependencies:
-    "@jest/core": ^27.2.1
+    "@jest/core": ^27.2.4
     import-local: ^3.0.2
-    jest-cli: ^27.2.1
+    jest-cli: ^27.2.4
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -3393,7 +3390,7 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: 3af057e98bee8d0aaed41ffce376fce61de4cc50958096c87f0f42527e3c9d3d391a420849ad88c09274fe8ec5dee88c7a5653d4a445df02b5db26f51ab4195b
+  checksum: 9879cb39e195681127f9e47b3180d5333d489bfbb25c49b8e6ce7c5cb206b03762c9381553576a86e7f41ffc144c44b7e165d1723fc63bd2a4332f2bd4db8105
   languageName: node
   linkType: hard
 
@@ -3665,19 +3662,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.49.0":
-  version: 1.49.0
-  resolution: "mime-db@npm:1.49.0"
-  checksum: c5ac8ff35fad969136dd07da73dc5d13a121a9e444954a9f4afb7ebf988989f5a502e35c29ac8a590276f7d0443330d0014cfbbc98eaffc487c3b7c5b005af60
+"mime-db@npm:1.50.0":
+  version: 1.50.0
+  resolution: "mime-db@npm:1.50.0"
+  checksum: a147e91333f1e1a6c2cb64090150559572863587babbfa80062da9ec53b821650fc179a2f7c4e93d3f503c4dac3af41021116fbd9e586e72237b981de0c7df8e
   languageName: node
   linkType: hard
 
 "mime-types@npm:^2.1.12":
-  version: 2.1.32
-  resolution: "mime-types@npm:2.1.32"
+  version: 2.1.33
+  resolution: "mime-types@npm:2.1.33"
   dependencies:
-    mime-db: 1.49.0
-  checksum: 91addbdc0c2a91bb142ecfe13bffe6b1d41f2ec12931756c54c9d85737f022f507d1e5a441ec50c21d59ae8e6f2a118a55a7f6d8467d49fe06ef6d25151d9657
+    mime-db: 1.50.0
+  checksum: 4db6ea7f5e7796aa8c4003ac447f74cd4fd9c7dd55c06087fe17ba3abc0ec98166cc51b843d305deefe7daf8f8b519dab1680cee20493cd299571af61873dbf4
   languageName: node
   linkType: hard
 
@@ -3813,20 +3810,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanocolors@npm:^0.1.0, nanocolors@npm:^0.1.5":
-  version: 0.1.12
-  resolution: "nanocolors@npm:0.1.12"
-  checksum: be3529320c895fcd16b79185c830c3c997c83026ca14d1119025d817b9ddcf175ac2b04b50f7e8928edf4082b98a0a106e6723ebc5ad73ccfd7366aeb8ce66a6
-  languageName: node
-  linkType: hard
-
-"nanocolors@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "nanocolors@npm:0.2.1"
-  checksum: 56180fb09c3d48b248ec6819b3d9f809735d514449ae18ae861d4a9c5b64fc3d3c37009b64d725ece0fb789c6376ebbc9db060f0524d803af62f25988db24f96
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -3875,10 +3858,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^1.1.76":
-  version: 1.1.76
-  resolution: "node-releases@npm:1.1.76"
-  checksum: 965c5a4f5a3d8953e95388178d9d0df76da443eb8108817dc19e7fc9a6c97e3f4c6f7f7728b99912c41d7f80f468573395b47c9c6bdd3e319a61b4bb173fcac4
+"node-releases@npm:^1.1.77":
+  version: 1.1.77
+  resolution: "node-releases@npm:1.1.77"
+  checksum: acc54c73e9a23a854bc04c3e5b948e9f043498e744b8bc7b9169331fed0fba291cb60adc4552809d6d95ef9ed45d16047441205cd80d33c140c68ee0fb767dfc
   languageName: node
   linkType: hard
 
@@ -3997,13 +3980,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-each-series@npm:^2.1.0":
-  version: 2.2.0
-  resolution: "p-each-series@npm:2.2.0"
-  checksum: d5a0896eb75e3e511055e664f7aaae695a67c0ed3696e560693d49fb3a19f554d017afeccc90df40d2d01681f972dc47d353015f38558ddef866f28ab291b743
-  languageName: node
-  linkType: hard
-
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -4093,6 +4069,13 @@ __metadata:
   version: 1.2.0
   resolution: "pend@npm:1.2.0"
   checksum: 35da01b2aa52458fbda2dceaeb5305c0d6c7262beca67d9f4c97bd70e4a8f4457f5fa01ffea3b3f786fb310b9b3b98515c52de3d7ae0b50dfb50b2a2d38d042b
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "picocolors@npm:0.2.1"
+  checksum: 84da675558ed004c61a7fa7b0bcce6338c8e3ef1eadb43b5263059d1d745f4567464aa6aa603c506a82942a5a7dfda5bb023605a5f4c9888d7adc154845d579e
   languageName: node
   linkType: hard
 
@@ -4200,15 +4183,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.0.0, pretty-format@npm:^27.2.0":
-  version: 27.2.0
-  resolution: "pretty-format@npm:27.2.0"
+"pretty-format@npm:^27.0.0, pretty-format@npm:^27.2.4":
+  version: 27.2.4
+  resolution: "pretty-format@npm:27.2.4"
   dependencies:
-    "@jest/types": ^27.1.1
-    ansi-regex: ^5.0.0
+    "@jest/types": ^27.2.4
+    ansi-regex: ^5.0.1
     ansi-styles: ^5.0.0
     react-is: ^17.0.1
-  checksum: 40195914b7ada7a5acc3a85ae7e1bed1cca38f88d8901004f7abfd685ebf20357933d43b6c47614f53a4045f81265d9edf1bc0b318db5d07a21891a3776d704d
+  checksum: 8893b30d3bde8faad2a9052b1646a3b10b9a56ad1e3591ba77fa6938baed85f0511404580fe6a0d749743b1797e40d361b9d620316e8a19a53333e3eabca7482
   languageName: node
   linkType: hard
 
@@ -4470,17 +4453,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
-  version: 5.1.2
-  resolution: "safe-buffer@npm:5.1.2"
-  checksum: 2708587c1b5e70a5e420714ceb59f30f5791c6e831d39812125a008eca63a4ac18578abd020a0776ea497ff03b4543f2b2a223a7b9073bf2d6c7af9ec6829218
-  languageName: node
-  linkType: hard
-
-"safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 0bb57f0d8f9d1fa4fe35ad8a2db1f83a027d48f2822d59ede88fd5cd4ddad83c0b497213feb7a70fbf90597a70c5217f735b0eb1850df40ce9b4ae81dd22b3f9
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 2708587c1b5e70a5e420714ceb59f30f5791c6e831d39812125a008eca63a4ac18578abd020a0776ea497ff03b4543f2b2a223a7b9073bf2d6c7af9ec6829218
   languageName: node
   linkType: hard
 
@@ -4552,17 +4535,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
   version: 3.0.5
   resolution: "signal-exit@npm:3.0.5"
   checksum: 2e747e53f09b40f1c7c9950ce2a039e58e12f9c2eb139668e9c0a7f7a5f0463377d0589d8a6dda3ab7248b80c6325470c1c4766cf85df260cf7a9f60e63b52ec
-  languageName: node
-  linkType: hard
-
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "signal-exit@npm:3.0.3"
-  checksum: f8f3fec95c8d1f9ad7e3cce07e1195f84e7a85cdcb4e825e8a2b76aa5406a039083d2bc9662b3cf40e6948262f41277047d20e6fbd58c77edced0b18fab647d8
   languageName: node
   linkType: hard
 
@@ -4721,13 +4697,13 @@ __metadata:
   linkType: hard
 
 "string-width@npm:^4.1.0, string-width@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "string-width@npm:4.2.2"
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
   dependencies:
     emoji-regex: ^8.0.0
     is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.0
-  checksum: d42484f5fdc50b4a573be784a06bc971e124d3fdc08779848a58d632bc88b349a33af54d1f0e1904dbd5dcbbe50651e4b39938799ebb1011a730421af1381892
+    strip-ansi: ^6.0.1
+  checksum: 748c97988904505fc6af52ccdf6f354445c714c38d067f22e0cdc6a3ad3d9c5ea29582ef9a6277dc7a813775bb48390ea064b488913239d58601b6d1fcb725b4
   languageName: node
   linkType: hard
 
@@ -4767,12 +4743,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "strip-ansi@npm:6.0.0"
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
   dependencies:
-    ansi-regex: ^5.0.0
-  checksum: 10568c91cadbef182a807c38dfa718dce15a35b12fcc97b96b6b2029d0508ef66ca93fabddeb49482d9b027495d1e18591858e80f27ad26861c4967c60fd207f
+    ansi-regex: ^5.0.1
+  checksum: 9d3061240b03abe5beaf403893464fdc924f43664debe822d5e9146b56c1398b88003f8afdb97eb0cea955c568f6bbfa4923d2b2a08a3a079fd09ee3b5402efb
   languageName: node
   linkType: hard
 
@@ -4851,10 +4827,10 @@ __metadata:
     csso: ^4.2.0
     del: ^6.0.0
     eslint: ^7.32.0
-    jest: ^27.2.1
+    jest: ^27.2.4
     mock-stdin: ^1.0.0
-    nanocolors: ^0.2.1
     node-fetch: ^2.6.2
+    picocolors: ^0.2.1
     pixelmatch: ^5.2.1
     playwright: ^1.14.1
     pngjs: ^6.0.0
@@ -5124,14 +5100,14 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"v8-to-istanbul@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "v8-to-istanbul@npm:8.0.0"
+"v8-to-istanbul@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "v8-to-istanbul@npm:8.1.0"
   dependencies:
     "@types/istanbul-lib-coverage": ^2.0.1
     convert-source-map: ^1.6.0
     source-map: ^0.7.3
-  checksum: ada29177f2944438eecb6a2fafb2144553c9dc9e623a253083149f4bbb193d862f93bda3cfde93178f3ca799df67da8f0b87222bde8d415a06550476893de0fc
+  checksum: a43c4feab9014ed55a0ba62513a96f4a68a156ddccede380934f934bc7c63a992e506033ef133a06013540cc7fcbbce1ec8c2b0352c376033854a94b93cbde44
   languageName: node
   linkType: hard
 
@@ -5310,7 +5286,7 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.3":
+"yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
Ref https://github.com/ai/nanocolors#nano-colors

Nanocolors is deprecated in favour of picocolors to avoid drama.
All dependencies already migrated. Also fixed one vulnerability.

The main change is step away from named exports and dual modules
support in favour of smaller package.