### PR TITLE
Replace closestByName utility with visitSkip

### DIFF
--- a/lib/xast.js
+++ b/lib/xast.js
@@ -39,21 +39,6 @@ const matches = (node, selector) => {
 };
 exports.matches = matches;
 
-/**
- * @type {(node: XastChild, name: string) => null | XastChild}
- */
-const closestByName = (node, name) => {
-  let currentNode = node;
-  while (currentNode) {
-    if (currentNode.type === 'element' && currentNode.name === name) {
-      return currentNode;
-    }
-    // @ts-ignore parentNode is hidden from public usage
-    currentNode = currentNode.parentNode;
-  }
-  return null;
-};
-exports.closestByName = closestByName;
 
 const visitSkip = Symbol();
 exports.visitSkip = visitSkip;

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -39,7 +39,6 @@ const matches = (node, selector) => {
 };
 exports.matches = matches;
 
-
 const visitSkip = Symbol();
 exports.visitSkip = visitSkip;
 


### PR DESCRIPTION
The last usagee of closestByName utility based on node.parentNode
is removed here. One step closer to clean ast in v3.