### PR TITLE
Respect finalNewline setting in pretty mode

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -124,14 +124,20 @@ const stringifySvg = (data, userOptions = {}) => {
     config.textEnd += eol;
   }
   let svg = stringifyNode(data, config, state);
-  if (config.finalNewline && svg.length > 0 && svg[svg.length - 1] !== eol) {
+
+  if (config.finalNewline && svg.length > 0 && svg[svg.length - 1] !== '\n') {
     svg += eol;
   } else if (
-    config.pretty &&
     !config.finalNewline &&
-    svg[svg.length - 1] == eol
+    config.pretty &&
+    svg.length > 0 &&
+    svg[svg.length - 1] === '\n'
   ) {
-    svg = svg.slice(0, -1);
+    if(svg.length > 1 && svg[svg.length - 2] === '\r'){
+      svg = svg.slice(0, -2);
+    } else {
+      svg = svg.slice(0, -1);
+    }
   }
   return {
     data: svg,

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -124,8 +124,14 @@ const stringifySvg = (data, userOptions = {}) => {
     config.textEnd += eol;
   }
   let svg = stringifyNode(data, config, state);
-  if (config.finalNewline && svg.length > 0 && svg[svg.length - 1] !== '\n') {
+  if (config.finalNewline && svg.length > 0 && svg[svg.length - 1] !== eol) {
     svg += eol;
+  } else if (
+    config.pretty &&
+    !config.finalNewline &&
+    svg[svg.length - 1] == eol
+  ) {
+    svg = svg.slice(0, -1);
   }
   return {
     data: svg,


### PR DESCRIPTION
Pretty mode will add a newline to the end of each 'element'. This means that a newline at the end is always created when setting `js2svg.pretty: true`. The setting `js2svg.finalNewLine` will be completely ignored because there already is a newline.

This change removes this unexpected behavior by stripping the last newline if `pretty: true` and `finalNewLine: false` are set. 

Ref: https://github.com/twbs/icons/pull/1148#discussion_r773155861