### PR TITLE
Correct typo in comment in removeDimensions plugin

### DIFF
--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -18,7 +18,7 @@ exports.description =
  * <svg viewBox="0 0 100 50" />
  *
  * @param {Object} item current iteration item
- * @return {Boolean} if true, with and height will be filtered out
+ * @return {Boolean} if true, width and height will be filtered out
  *
  * @author Benny Schudel
  */


### PR DESCRIPTION
This addresses a very minor typo, but came across this while reading up on the plugin itself.