### PR TITLE
More helpful preset warnings

### DIFF
--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -85,8 +85,8 @@ test('warn when user tries enable plugins in preset', () => {
     js2svg: { pretty: true, indent: 2 },
   });
   expect(warn)
-    .toBeCalledWith(`You are trying to enable cleanupListOfValues which is not part of preset.
-Try to put it before or after preset, for example
+    .toBeCalledWith(`You are trying to configure cleanupListOfValues which is not part of preset-default.
+Try to put it before or after, for example
 
 plugins: [
   {

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -87,8 +87,9 @@ const createPreset = ({ name, plugins }) => {
         globalOverrides.floatPrecision = floatPrecision;
       }
       if (overrides) {
+        const pluginNames = plugins.map(({ name }) => name);
         for (const pluginName of Object.keys(overrides)) {
-          if (!plugins.find(({name}) => name === pluginName)) {
+          if (!pluginNames.includes(pluginName)) {
             console.warn(
               `You are trying to configure ${pluginName} which is not part of ${name}.\n` +
                 `Try to put it before or after, for example\n\n` +

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -87,16 +87,16 @@ const createPreset = ({ name, plugins }) => {
         globalOverrides.floatPrecision = floatPrecision;
       }
       if (overrides) {
-        for (const [pluginName, override] of Object.entries(overrides)) {
-          if (override === true) {
+        for (const pluginName of Object.keys(overrides)) {
+          if (!plugins.find(({name}) => name === pluginName)) {
             console.warn(
-              `You are trying to enable ${pluginName} which is not part of preset.\n` +
-                `Try to put it before or after preset, for example\n\n` +
+              `You are trying to configure ${pluginName} which is not part of ${name}.\n` +
+                `Try to put it before or after, for example\n\n` +
                 `plugins: [\n` +
                 `  {\n` +
-                `    name: 'preset-default',\n` +
+                `    name: '${name}',\n` +
                 `  },\n` +
-                `  'cleanupListOfValues'\n` +
+                `  '${pluginName}'\n` +
                 `]\n`
             );
           }

--- a/plugins/preset-default.js
+++ b/plugins/preset-default.js
@@ -38,7 +38,7 @@ const removeTitle = require('./removeTitle.js');
 const removeDesc = require('./removeDesc.js');
 
 const presetDefault = createPreset({
-  name: 'presetDefault',
+  name: 'preset-default',
   plugins: [
     removeDoctype,
     removeXMLProcInst,


### PR DESCRIPTION
Preset documentation and warning [here](https://github.com/svg/svgo/commit/cb7e9be623b6e2fbbfcb9b67c4c85131e1477925) got me confused. I think these changes should reduce others confusion.

* warn **any** override that is not in the default list
* use actual plugin names in the warning message

## How I got here
For context, I'm migrating from SVGO v1 and I came straight to the config docs here (https://github.com/svg/svgo#configuration) when I realised there were config changes.

I read the `preset-default` docs and saw the `overrides` option, quickly copy pasted my previous config over and changed to the new API:
```js
name: 'preset-default',
params: {
  overrides: {
    removeXMLNS: true,
    removeTitle: true,
    removeViewBox: false,
    addAttributesToSVGElement: {/* ... */},
  },
},
```
And see the new warning:
```
You are trying to enable removeXMLNS which is not part of preset.
Try to put it before or after preset, for example

plugins: [
  {
    name: 'preset-default',
  },
  'cleanupListOfValues'
]
```
My first thought is that `removeXMLNS` was no longer part of the built-in plugins. The warning suggests using `cleanupListOfValues`, I thought maybe that functionality was moved into this new plugin.

I go back to the documentation and see no, the plugin is still there, it just needs to be enabled in a different way now.