### PR TITLE
Fix rollup build breaking on missing exception arg

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -123,7 +123,7 @@ exports.fn = (root, params) => {
             parseValue: false,
             parseCustomProperty: false,
           });
-        } catch {
+        } catch (e) {
           return;
         }
         if (cssAst.type === 'StyleSheet') {


### PR DESCRIPTION
For some reason I'm building using Rollup on node `14.19.0` and it's breaking on `} catch {` missing a `(e)`.
Not sure who's exactly to blame, but this sure avoids it.