### PR TITLE
fix: begin's attribute incorrectly modification

### DIFF
--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -10,9 +10,9 @@ const { referencesProps } = require('./_collections.js');
 exports.name = 'cleanupIds';
 exports.description = 'removes unused IDs and minifies used';
 
-const regReferencesUrl = /\burl\(("|')?#(.+?)\1\)/;
+const regReferencesUrl = /\burl\((["'])?#(.+?)\1\)/;
 const regReferencesHref = /^#(.+?)$/;
-const regReferencesBegin = /(\w+)\./;
+const regReferencesBegin = /(\D+)\./;
 const generateIdChars = [
   'a',
   'b',

--- a/test/plugins/cleanupIds.21.svg
+++ b/test/plugins/cleanupIds.21.svg
@@ -1,0 +1,43 @@
+<svg width="379px" height="134px" viewBox="0 0 379 134" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle id="6" cx="110.5" cy="5.5" r="5.5">
+        <animate begin="2.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle id="5" cx="89.5" cy="5.5" r="5.5">
+        <animate begin="2s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle id="4" cx="68.5" cy="5.5" r="5.5">
+        <animate begin="1.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle id="3" cx="47.5" cy="5.5" r="5.5">
+        <animate begin="1s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle id="2" cx="26.5" cy="5.5" r="5.5">
+        <animate begin="0.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle id="1" cx="5.5" cy="5.5" r="5.5">
+        <animate attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+</svg>
+
+@@@
+
+<svg width="379px" height="134px" viewBox="0 0 379 134" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle cx="110.5" cy="5.5" r="5.5">
+        <animate begin="2.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="89.5" cy="5.5" r="5.5">
+        <animate begin="2s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="68.5" cy="5.5" r="5.5">
+        <animate begin="1.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="47.5" cy="5.5" r="5.5">
+        <animate begin="1s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="26.5" cy="5.5" r="5.5">
+        <animate begin="0.5s" attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="5.5" cy="5.5" r="5.5">
+        <animate attributeName="fill" calcMode="discrete" values="#6ebe28;#D8D8D8" dur="5s" keyTimes="0;0.15" repeatCount="indefinite"/>
+    </circle>
+</svg>


### PR DESCRIPTION
Hello!
The problem is with `<animate>'s` `begin` clearing. For example if both `id="2"` and `<animate begin="2.5s">` are present in svg, it changes to `id="a"` and `<animate begin="a.5s">` which is incorrect value.

This bug was originally found here https://github.com/svg-sprite/svg-sprite/issues/526