### PR TITLE
Add `funding` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
     "type": "git",
     "url": "git://github.com/svg/svgo.git"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/svgo"
+  },
   "main": "./lib/svgo-node.js",
   "bin": "./bin/svgo",
   "files": [


### PR DESCRIPTION
This will add a notification about how to fund the package to the npmjs.com page (example from webpack):

![image](https://user-images.githubusercontent.com/23049315/158357572-3f660770-9296-4380-b9b4-163aad80ca3a.png)

See [package-json#funding](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#funding).