### PR TITLE
Allow --input to be a single file when --output is a folder

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -215,7 +215,7 @@ async function action(args, opts, command) {
   // --output
   if (output) {
     if (input.length && input[0] != '-') {
-      if (output.length == 1 && checkIsDir(output[0])) {
+      if (output.length == 1 && !path.extname(output[0])) {
         var dir = output[0];
         for (var i = 0; i < input.length; i++) {
           output[i] = checkIsDir(input[i])

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -215,7 +215,7 @@ async function action(args, opts, command) {
   // --output
   if (output) {
     if (input.length && input[0] != '-') {
-      if (output.length == 1 && !path.extname(output[0])) {
+      if (output.length == 1 && output[0] != '-' && !path.extname(output[0])) {
         var dir = output[0];
         for (var i = 0; i < input.length; i++) {
           output[i] = checkIsDir(input[i])


### PR DESCRIPTION
The README currently has example CLI usage, where you can either:
a) process one or more single input files into the same number of output files:  
`svgo one.svg two.svg -o one.min.svg two.min.svg`  
or  
b) process a directory of files, into an output directory:  
`svgo -f ./path/to/folder/with/svg/files -o ./path/to/folder/with/svg/output`

I had hoped that I'd be able to do an in-between, with a single file as the input and a directory as the --output:  
`svgo one.svg -o ./path/to/folder/with/svg/output`

That would let me use chokidar in my project's package.json, to watch any SVGs that are updated, and re-run SVGO on them:  
`"svg:watch": "chokidar src/assets/svg/*.svg -c 'svgo --input {path} --output dist/assets/svg'"`

Unfortunately, I ran into an issue where if any layer of the output directory did not exist before SVGO ran, it would have unexpected results, like `Error: ENOENT: no such file or directory`, or creating a weird `assets/svg` file, that should have been `assets/svg/mySvg.svg`.

My fix replaces the check to see if a single --output string matches a pre-existing _directory_, with a check that it's simply a directory string (rather than a filename string with a file extension). That way, if you intend to put files into an output directory, but the directory doesn't yet exist, the surrounding code in coa.js successfully creates both the intended directory and output file inside it.

If this PR is accepted, it might be helpful to put a relevant single-input folder-output example in the CLI usage section of the README, to show that this can now be done?