### PR TITLE
fix SVGO ignoring config for `datauri` and `path`

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -21,6 +21,7 @@ const optimize = (input, config) => {
     throw Error('Config should be an object');
   }
   const maxPassCount = config.multipass ? 10 : 1;
+  let maxOptimizationReached = true;
   let prevResultSize = Number.POSITIVE_INFINITY;
   let svgjs = null;
   const info = {};
@@ -54,16 +55,23 @@ const optimize = (input, config) => {
     }
     svgjs = invokePlugins(svgjs, info, resolvedPlugins, null, globalOverrides);
     svgjs = stringifySvg(svgjs, config.js2svg);
+
     if (svgjs.data.length < prevResultSize) {
       input = svgjs.data;
       prevResultSize = svgjs.data.length;
     } else {
+      maxOptimizationReached = true;
+    }
+
+    if (maxOptimizationReached || i >= maxPassCount - 1) {
       if (config.datauri) {
         svgjs.data = encodeSVGDatauri(svgjs.data, config.datauri);
       }
+
       if (config.path != null) {
         svgjs.path = config.path;
       }
+
       return svgjs;
     }
   }


### PR DESCRIPTION
The currently implemented code for multipass leads SVGO to completely ignore config options for `datauri` and `path` in most cases so that it will never base64-encode to datauri.