### PR TITLE
Remove `stable` package in favor of native stable sort

### DIFF
--- a/lib/css-tools.js
+++ b/lib/css-tools.js
@@ -2,7 +2,6 @@
 
 var csstree = require('css-tree'),
   List = csstree.List,
-  stable = require('stable'),
   specificity = require('csso/lib/restructure/prepare/specificity');
 
 /**
@@ -162,7 +161,7 @@ function _bySelectorSpecificity(selectorA, selectorB) {
  * @return {Array} Stable sorted selectors
  */
 function sortSelectors(selectors) {
-  return stable(selectors, _bySelectorSpecificity);
+  return [...selectors].sort(_bySelectorSpecificity);
 }
 
 /**

--- a/lib/style.js
+++ b/lib/style.js
@@ -13,7 +13,6 @@
  * @typedef {import('./types').XastChild} XastChild
  */
 
-const stable = require('stable');
 const csstree = require('css-tree');
 // @ts-ignore not defined in @types/csso
 const specificity = require('csso/lib/restructure/prepare/specificity');
@@ -249,9 +248,7 @@ const collectStylesheet = (root) => {
     },
   });
   // sort by selectors specificity
-  stable.inplace(rules, (a, b) =>
-    compareSpecificity(a.specificity, b.specificity)
-  );
+  rules.sort((a, b) => compareSpecificity(a.specificity, b.specificity));
   return { rules, parents };
 };
 exports.collectStylesheet = collectStylesheet;

--- a/package.json
+++ b/package.json
@@ -109,8 +109,7 @@
     "css-select": "^5.1.0",
     "css-tree": "^1.1.3",
     "csso": "^4.2.0",
-    "picocolors": "^1.0.0",
-    "stable": "^0.1.8"
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -9,7 +9,6 @@
 const csstree = require('css-tree');
 // @ts-ignore not defined in @types/csso
 const specificity = require('csso/lib/restructure/prepare/specificity');
-const stable = require('stable');
 const {
   visitSkip,
   querySelectorAll,
@@ -200,11 +199,13 @@ exports.fn = (root, params) => {
           return;
         }
         // stable sort selectors
-        const sortedSelectors = stable(selectors, (a, b) => {
-          const aSpecificity = specificity(a.item.data);
-          const bSpecificity = specificity(b.item.data);
-          return compareSpecificity(aSpecificity, bSpecificity);
-        }).reverse();
+        const sortedSelectors = [...selectors]
+          .sort((a, b) => {
+            const aSpecificity = specificity(a.item.data);
+            const bSpecificity = specificity(b.item.data);
+            return compareSpecificity(aSpecificity, bSpecificity);
+          })
+          .reverse();
 
         for (const selector of sortedSelectors) {
           // match selectors

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,13 +4396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stable@npm:^0.1.8":
-  version: 0.1.8
-  resolution: "stable@npm:0.1.8"
-  checksum: 2ff482bb100285d16dd75cd8f7c60ab652570e8952c0bfa91828a2b5f646a0ff533f14596ea4eabd48bb7f4aeea408dce8f8515812b975d958a4cc4fa6b9dfeb
-  languageName: node
-  linkType: hard
-
 "stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "stack-utils@npm:2.0.3"
@@ -4583,7 +4576,6 @@ __metadata:
     prettier: ^2.7.1
     rollup: ^2.79.1
     rollup-plugin-terser: ^7.0.2
-    stable: ^0.1.8
     tar-stream: ^2.2.0
     typescript: ^4.8.4
   bin:


### PR DESCRIPTION
Currently when installing `svgo` the following warning is displayed:
> npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility

This PR removes that warning by removing `stable`. As the `stable` package notice says `Array.sort(..)` guarantees a stable sort for reasonable recent versions of JavaScript already. See [caniuse](https://caniuse.com/mdn-javascript_builtins_array_sort_stable) data to decide whether to accept this PR.