### PR TITLE
[Docs] Added Remark plugin as another way to use SVGO

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ const config = await loadConfig(configFile, cwd);
 | Sketch plugin | [svgo-compressor](https://github.com/BohemianCoding/svgo-compressor) |
 | macOS app | [Image Shrinker](https://image-shrinker.com) |
 | Rollup plugin | [rollup-plugin-svgo](https://github.com/porsager/rollup-plugin-svgo) |
-| Remark plugin | [remark-inline-svg](https://github.com/alvinometric/remark-inline-svg)
+| Remark plugin | [remark-inline-svg](https://github.com/alvinometric/remark-inline-svg) |
 | VS Code plugin | [vscode-svgo](https://github.com/1000ch/vscode-svgo) |
 | Atom plugin | [atom-svgo](https://github.com/1000ch/atom-svgo) |
 | Sublime plugin | [Sublime-svgo](https://github.com/1000ch/Sublime-svgo) |

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ const config = await loadConfig(configFile, cwd);
 - as a Atom plugin - [atom-svgo](https://github.com/1000ch/atom-svgo)
 - as a Sublime plugin - [Sublime-svgo](https://github.com/1000ch/Sublime-svgo)
 - as a Figma plugin - [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export)
+- as a Remark plugin - [remark-inline-svg](https://github.com/alvinometric/remark-inline-svg)
 - as a Linux app - [Oh My SVG](https://github.com/sonnyp/OhMySVG)
 - as a Browser extension - [SVG Gobbler](https://github.com/rossmoody/svg-gobbler)
 - as an API - [Vector Express](https://github.com/smidyo/vectorexpress-api#convertor-svgo)


### PR DESCRIPTION
Hello,
Thank you for the great work! I made a remark plugin to inline SVG image files within Markdown and optimise them with SVGO. This PR adds a link to the plugin in `Other Ways to Use SVGO` in the Readme.