### PR TITLE
Speed up stringifyNumber

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { removeLeadingZero } = require('./svgo/tools');
+
 /**
  * @typedef {import('./types').PathDataItem} PathDataItem
  * @typedef {import('./types').PathDataCommand} PathDataCommand
@@ -249,7 +251,7 @@ const stringifyNumber = (number, precision) => {
     number = Math.round(number * ratio) / ratio;
   }
   // remove zero whole from decimal number
-  return number.toString().replace(/^0\./, '.').replace(/^-0\./, '-.');
+  return removeLeadingZero(number);
 };
 
 /**


### PR DESCRIPTION
I'm currently profiling my build setup and noticed that `stringifyNumber` pops up here and there. Instead of going with the double regex replace approach, we'll go with the faster approach in `removeLeadingZero`.

In total the changes in this PR speed up the build by about `0.9s` in my project.

<img width="798" alt="stringifyNumber" src="https://user-images.githubusercontent.com/1062408/204154146-ce67d0c9-faf2-40a1-8186-8d34caea74a5.png">

