### PR TITLE
Refactor README to be easier to read through

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ You can also specify a relative or absolute path and customize the current worki
 const config = await loadConfig(configFile, cwd);
 ```
 
+## Troubleshooting
+
+### SVG won't scale when CSS is applied on it.
+
+**Observed Problem:** I'm using my SVG files on a website. It looks like the rendered SVG doesn't scale when the dimensions are altered using CSS.
+
+**Possible Solution:** Try disabling `removeViewBox` in the configuration. See [issue #1128](https://github.com/svg/svgo/issues/1128) for details and discussion.
+
 ## Built-in plugins
 
 | Plugin                                                                                                            | Description                                                                                                                                              | Default |

--- a/README.md
+++ b/README.md
@@ -12,21 +12,27 @@ SVG files, especially those exported from various editors, usually contain a lot
 
 ## Installation
 
+Via npm:
 ```sh
-# Via npm
 npm -g install svgo
-# Via yarn
+```
+Via yarn:
+```sh
 yarn global add svgo
 ```
 
 ## CLI usage
 
+Processing single files:
 ```sh
-# Processing single files:
 svgo one.svg two.svg -o one.min.svg two.min.svg
-# Processing directory of svg files, recursively using `-f`, `--folder` :
+```
+Processing directory of svg files, recursively using `-f`, `--folder`:
+```sh
 svgo -f ./path/to/folder/with/svg/files -o ./path/to/folder/with/svg/output
-# Help for advanced usage
+```
+Help for advanced usage:
+```sh
 svgo --help
 ```
 
@@ -88,42 +94,7 @@ module.exports = {
 };
 ```
 
-Default preset includes the following list of plugins:
-
-- removeDoctype
-- removeXMLProcInst
-- removeComments
-- removeMetadata
-- removeEditorsNSData
-- cleanupAttrs
-- mergeStyles
-- inlineStyles
-- minifyStyles
-- cleanupIds
-- removeUselessDefs
-- cleanupNumericValues
-- convertColors
-- removeUnknownsAndDefaults
-- removeNonInheritableGroupAttrs
-- removeUselessStrokeAndFill
-- removeViewBox
-- cleanupEnableBackground
-- removeHiddenElems
-- removeEmptyText
-- convertShapeToPath
-- convertEllipseToCircle
-- moveElemsAttrsToGroup
-- moveGroupAttrsToElems
-- collapseGroups
-- convertPathData
-- convertTransform
-- removeEmptyAttrs
-- removeEmptyContainers
-- mergePaths
-- removeUnusedNS
-- sortDefsChildren
-- removeTitle
-- removeDesc
+The default preset includes plugins marked with 'Yes' in the plugin list below.
 
 ### Custom plugin
 
@@ -171,90 +142,94 @@ If you write a tool on top of SVGO you might need a way to load SVGO config.
 ```js
 const { loadConfig } = require('svgo');
 const config = await loadConfig();
+```
 
-// you can also specify a relative or absolute path and customize the current working directory
+You can also specify a relative or absolute path and customize the current working directory.
+```js
 const config = await loadConfig(configFile, cwd);
 ```
 
 ## Built-in plugins
 
-| Plugin                                                                                                              | Description                                                                                                                                              | Default    |
-| ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| [cleanupAttrs](https://github.com/svg/svgo/blob/main/plugins/cleanupAttrs.js)                                     | cleanup attributes from newlines, trailing, and repeating spaces                                                                                         | `enabled`  |
-| [mergeStyles](https://github.com/svg/svgo/blob/main/plugins/mergeStyles.js)                                       | merge multiple style elements into one                                                                                                                   | `enabled`  |
-| [inlineStyles](https://github.com/svg/svgo/blob/main/plugins/inlineStyles.js)                                     | move and merge styles from `<style>` elements to element `style` attributes                                                                              | `enabled`  |
-| [removeDoctype](https://github.com/svg/svgo/blob/main/plugins/removeDoctype.js)                                   | remove `doctype` declaration                                                                                                                             | `enabled`  |
-| [removeXMLProcInst](https://github.com/svg/svgo/blob/main/plugins/removeXMLProcInst.js)                           | remove XML processing instructions                                                                                                                       | `enabled`  |
-| [removeComments](https://github.com/svg/svgo/blob/main/plugins/removeComments.js)                                 | remove comments                                                                                                                                          | `enabled`  |
-| [removeMetadata](https://github.com/svg/svgo/blob/main/plugins/removeMetadata.js)                                 | remove `<metadata>`                                                                                                                                      | `enabled`  |
-| [removeTitle](https://github.com/svg/svgo/blob/main/plugins/removeTitle.js)                                       | remove `<title>`                                                                                                                                         | `enabled`  |
-| [removeDesc](https://github.com/svg/svgo/blob/main/plugins/removeDesc.js)                                         | remove `<desc>`                                                                                                                                          | `enabled`  |
-| [removeUselessDefs](https://github.com/svg/svgo/blob/main/plugins/removeUselessDefs.js)                           | remove elements of `<defs>` without `id`                                                                                                                 | `enabled`  |
-| [removeXMLNS](https://github.com/svg/svgo/blob/main/plugins/removeXMLNS.js)                                       | removes the `xmlns` attribute (for inline SVG)                                                                                                           | `disabled` |
-| [removeEditorsNSData](https://github.com/svg/svgo/blob/main/plugins/removeEditorsNSData.js)                       | remove editors namespaces, elements, and attributes                                                                                                      | `enabled`  |
-| [removeEmptyAttrs](https://github.com/svg/svgo/blob/main/plugins/removeEmptyAttrs.js)                             | remove empty attributes                                                                                                                                  | `enabled`  |
-| [removeHiddenElems](https://github.com/svg/svgo/blob/main/plugins/removeHiddenElems.js)                           | remove hidden elements                                                                                                                                   | `enabled`  |
-| [removeEmptyText](https://github.com/svg/svgo/blob/main/plugins/removeEmptyText.js)                               | remove empty Text elements                                                                                                                               | `enabled`  |
-| [removeEmptyContainers](https://github.com/svg/svgo/blob/main/plugins/removeEmptyContainers.js)                   | remove empty Container elements                                                                                                                          | `enabled`  |
-| [removeViewBox](https://github.com/svg/svgo/blob/main/plugins/removeViewBox.js)                                   | remove `viewBox` attribute when possible                                                                                                                 | `enabled`  |
-| [cleanupEnableBackground](https://github.com/svg/svgo/blob/main/plugins/cleanupEnableBackground.js)               | remove or cleanup `enable-background` attribute when possible                                                                                            | `enabled`  |
-| [minifyStyles](https://github.com/svg/svgo/blob/main/plugins/minifyStyles.js)                                     | minify `<style>` elements content with [CSSO](https://github.com/css/csso)                                                                               | `enabled`  |
-| [convertStyleToAttrs](https://github.com/svg/svgo/blob/main/plugins/convertStyleToAttrs.js)                       | convert styles into attributes                                                                                                                           | `disabled` |
-| [convertColors](https://github.com/svg/svgo/blob/main/plugins/convertColors.js)                                   | convert colors (from `rgb()` to `#rrggbb`, from `#rrggbb` to `#rgb`)                                                                                     | `enabled`  |
-| [convertPathData](https://github.com/svg/svgo/blob/main/plugins/convertPathData.js)                               | convert Path data to relative or absolute (whichever is shorter), convert one segment to another, trim useless delimiters, smart rounding, and much more | `enabled`  |
-| [convertTransform](https://github.com/svg/svgo/blob/main/plugins/convertTransform.js)                             | collapse multiple transforms into one, convert matrices to the short aliases, and much more                                                              | `enabled`  |
-| [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/main/plugins/removeUnknownsAndDefaults.js)           | remove unknown elements content and attributes, remove attributes with default values                                                                    | `enabled`  |
-| [removeNonInheritableGroupAttrs](https://github.com/svg/svgo/blob/main/plugins/removeNonInheritableGroupAttrs.js) | remove non-inheritable group's "presentation" attributes                                                                                                 | `enabled`  |
-| [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/main/plugins/removeUselessStrokeAndFill.js)         | remove useless `stroke` and `fill` attributes                                                                                                            | `enabled`  |
-| [removeUnusedNS](https://github.com/svg/svgo/blob/main/plugins/removeUnusedNS.js)                                 | remove unused namespaces declaration                                                                                                                     | `enabled`  |
-| [prefixIds](https://github.com/svg/svgo/blob/main/plugins/prefixIds.js)                                           | prefix IDs and classes with the SVG filename or an arbitrary string                                                                                      | `disabled` |
-| [cleanupIds](https://github.com/svg/svgo/blob/main/plugins/cleanupIds.js)                                         | remove unused and minify used IDs                                                                                                                        | `enabled`  |
-| [cleanupNumericValues](https://github.com/svg/svgo/blob/main/plugins/cleanupNumericValues.js)                     | round numeric values to the fixed precision, remove default `px` units                                                                                   | `enabled`  |
-| [cleanupListOfValues](https://github.com/svg/svgo/blob/main/plugins/cleanupListOfValues.js)                       | round numeric values in attributes that take a list of numbers (like `viewBox` or `enable-background`)                                                   | `disabled` |
-| [moveElemsAttrsToGroup](https://github.com/svg/svgo/blob/main/plugins/moveElemsAttrsToGroup.js)                   | move elements' attributes to their enclosing group                                                                                                       | `enabled`  |
-| [moveGroupAttrsToElems](https://github.com/svg/svgo/blob/main/plugins/moveGroupAttrsToElems.js)                   | move some group attributes to the contained elements                                                                                                     | `enabled`  |
-| [collapseGroups](https://github.com/svg/svgo/blob/main/plugins/collapseGroups.js)                                 | collapse useless groups                                                                                                                                  | `enabled`  |
-| [removeRasterImages](https://github.com/svg/svgo/blob/main/plugins/removeRasterImages.js)                         | remove raster images                                                                                                                                     | `disabled` |
-| [mergePaths](https://github.com/svg/svgo/blob/main/plugins/mergePaths.js)                                         | merge multiple Paths into one                                                                                                                            | `enabled`  |
-| [convertShapeToPath](https://github.com/svg/svgo/blob/main/plugins/convertShapeToPath.js)                         | convert some basic shapes to `<path>`                                                                                                                    | `enabled`  |
-| [convertEllipseToCircle](https://github.com/svg/svgo/blob/main/plugins/convertEllipseToCircle.js)                 | convert non-eccentric `<ellipse>` to `<circle>`                                                                                                          | `enabled`  |
-| [sortAttrs](https://github.com/svg/svgo/blob/main/plugins/sortAttrs.js)                                           | sort element attributes for epic readability                                                                                                             | `enabled` |
-| [sortDefsChildren](https://github.com/svg/svgo/blob/main/plugins/sortDefsChildren.js)                             | sort children of `<defs>` in order to improve compression                                                                                                | `enabled`  |
-| [removeDimensions](https://github.com/svg/svgo/blob/main/plugins/removeDimensions.js)                             | remove `width`/`height` and add `viewBox` if it's missing (opposite to removeViewBox, disable it first)                                                  | `disabled` |
-| [removeAttrs](https://github.com/svg/svgo/blob/main/plugins/removeAttrs.js)                                       | remove attributes by pattern                                                                                                                             | `disabled` |
-| [removeAttributesBySelector](https://github.com/svg/svgo/blob/main/plugins/removeAttributesBySelector.js)         | removes attributes of elements that match a CSS selector                                                                                                 | `disabled` |
-| [removeElementsByAttr](https://github.com/svg/svgo/blob/main/plugins/removeElementsByAttr.js)                     | remove arbitrary elements by `ID` or `className`                                                                                                         | `disabled` |
-| [addClassesToSVGElement](https://github.com/svg/svgo/blob/main/plugins/addClassesToSVGElement.js)                 | add classnames to an outer `<svg>` element                                                                                                               | `disabled` |
-| [addAttributesToSVGElement](https://github.com/svg/svgo/blob/main/plugins/addAttributesToSVGElement.js)           | adds attributes to an outer `<svg>` element                                                                                                              | `disabled` |
-| [removeOffCanvasPaths](https://github.com/svg/svgo/blob/main/plugins/removeOffCanvasPaths.js)                     | removes elements that are drawn outside of the viewbox                                                                                                   | `disabled` |
-| [removeStyleElement](https://github.com/svg/svgo/blob/main/plugins/removeStyleElement.js)                         | remove `<style>` elements                                                                                                                                | `disabled` |
-| [removeScriptElement](https://github.com/svg/svgo/blob/main/plugins/removeScriptElement.js)                       | remove `<script>` elements                                                                                                                               | `disabled` |
-| [reusePaths](https://github.com/svg/svgo/blob/main/plugins/reusePaths.js)                                         | Find duplicated <path> elements and replace them with <use> links                                                                                        | `disabled` |
+| Plugin                                                                                                            | Description                                                                                                                                              | Default |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| [addAttributesToSVGElement](https://github.com/svg/svgo/blob/main/plugins/addAttributesToSVGElement.js)           | adds attributes to an outer `<svg>` element                                                                                                              |         |
+| [addClassesToSVGElement](https://github.com/svg/svgo/blob/main/plugins/addClassesToSVGElement.js)                 | add classnames to an outer `<svg>` element                                                                                                               |         |
+| [cleanupAttrs](https://github.com/svg/svgo/blob/main/plugins/cleanupAttrs.js)                                     | cleanup attributes from newlines, trailing, and repeating spaces                                                                                         | Yes     |
+| [cleanupEnableBackground](https://github.com/svg/svgo/blob/main/plugins/cleanupEnableBackground.js)               | remove or cleanup `enable-background` attribute when possible                                                                                            | Yes     |
+| [cleanupIds](https://github.com/svg/svgo/blob/main/plugins/cleanupIds.js)                                         | remove unused and minify used IDs                                                                                                                        | Yes     |
+| [cleanupListOfValues](https://github.com/svg/svgo/blob/main/plugins/cleanupListOfValues.js)                       | round numeric values in attributes that take a list of numbers (like `viewBox` or `enable-background`)                                                   |         |
+| [cleanupNumericValues](https://github.com/svg/svgo/blob/main/plugins/cleanupNumericValues.js)                     | round numeric values to the fixed precision, remove default `px` units                                                                                   | Yes     |
+| [collapseGroups](https://github.com/svg/svgo/blob/main/plugins/collapseGroups.js)                                 | collapse useless groups                                                                                                                                  | Yes     |
+| [convertColors](https://github.com/svg/svgo/blob/main/plugins/convertColors.js)                                   | convert colors (from `rgb()` to `#rrggbb`, from `#rrggbb` to `#rgb`)                                                                                     | Yes     |
+| [convertEllipseToCircle](https://github.com/svg/svgo/blob/main/plugins/convertEllipseToCircle.js)                 | convert non-eccentric `<ellipse>` to `<circle>`                                                                                                          | Yes     |
+| [convertPathData](https://github.com/svg/svgo/blob/main/plugins/convertPathData.js)                               | convert Path data to relative or absolute (whichever is shorter), convert one segment to another, trim useless delimiters, smart rounding, and much more | Yes     |
+| [convertShapeToPath](https://github.com/svg/svgo/blob/main/plugins/convertShapeToPath.js)                         | convert some basic shapes to `<path>`                                                                                                                    | Yes     |
+| [convertStyleToAttrs](https://github.com/svg/svgo/blob/main/plugins/convertStyleToAttrs.js)                       | convert styles into attributes                                                                                                                           |         |
+| [convertTransform](https://github.com/svg/svgo/blob/main/plugins/convertTransform.js)                             | collapse multiple transforms into one, convert matrices to the short aliases, and much more                                                              | Yes     |
+| [inlineStyles](https://github.com/svg/svgo/blob/main/plugins/inlineStyles.js)                                     | move and merge styles from `<style>` elements to element `style` attributes                                                                              | Yes     |
+| [mergePaths](https://github.com/svg/svgo/blob/main/plugins/mergePaths.js)                                         | merge multiple Paths into one                                                                                                                            | Yes     |
+| [mergeStyles](https://github.com/svg/svgo/blob/main/plugins/mergeStyles.js)                                       | merge multiple style elements into one                                                                                                                   | Yes     |
+| [minifyStyles](https://github.com/svg/svgo/blob/main/plugins/minifyStyles.js)                                     | minify `<style>` elements content with [CSSO](https://github.com/css/csso)                                                                               | Yes     |
+| [moveElemsAttrsToGroup](https://github.com/svg/svgo/blob/main/plugins/moveElemsAttrsToGroup.js)                   | move elements' attributes to their enclosing group                                                                                                       | Yes     |
+| [moveGroupAttrsToElems](https://github.com/svg/svgo/blob/main/plugins/moveGroupAttrsToElems.js)                   | move some group attributes to the contained elements                                                                                                     | Yes     |
+| [prefixIds](https://github.com/svg/svgo/blob/main/plugins/prefixIds.js)                                           | prefix IDs and classes with the SVG filename or an arbitrary string                                                                                      |         |
+| [removeAttributesBySelector](https://github.com/svg/svgo/blob/main/plugins/removeAttributesBySelector.js)         | removes attributes of elements that match a CSS selector                                                                                                 |         |
+| [removeAttrs](https://github.com/svg/svgo/blob/main/plugins/removeAttrs.js)                                       | remove attributes by pattern                                                                                                                             |         |
+| [removeComments](https://github.com/svg/svgo/blob/main/plugins/removeComments.js)                                 | remove comments                                                                                                                                          | Yes     |
+| [removeDesc](https://github.com/svg/svgo/blob/main/plugins/removeDesc.js)                                         | remove `<desc>`                                                                                                                                          | Yes     |
+| [removeDimensions](https://github.com/svg/svgo/blob/main/plugins/removeDimensions.js)                             | remove `width`/`height` and add `viewBox` if it's missing (opposite to removeViewBox, disable it first)                                                  |         |
+| [removeDoctype](https://github.com/svg/svgo/blob/main/plugins/removeDoctype.js)                                   | remove `doctype` declaration                                                                                                                             | Yes     |
+| [removeEditorsNSData](https://github.com/svg/svgo/blob/main/plugins/removeEditorsNSData.js)                       | remove editors namespaces, elements, and attributes                                                                                                      | Yes     |
+| [removeElementsByAttr](https://github.com/svg/svgo/blob/main/plugins/removeElementsByAttr.js)                     | remove arbitrary elements by `ID` or `className`                                                                                                         |         |
+| [removeEmptyAttrs](https://github.com/svg/svgo/blob/main/plugins/removeEmptyAttrs.js)                             | remove empty attributes                                                                                                                                  | Yes     |
+| [removeEmptyContainers](https://github.com/svg/svgo/blob/main/plugins/removeEmptyContainers.js)                   | remove empty Container elements                                                                                                                          | Yes     |
+| [removeEmptyText](https://github.com/svg/svgo/blob/main/plugins/removeEmptyText.js)                               | remove empty Text elements                                                                                                                               | Yes     |
+| [removeHiddenElems](https://github.com/svg/svgo/blob/main/plugins/removeHiddenElems.js)                           | remove hidden elements                                                                                                                                   | Yes     |
+| [removeMetadata](https://github.com/svg/svgo/blob/main/plugins/removeMetadata.js)                                 | remove `<metadata>`                                                                                                                                      | Yes     |
+| [removeNonInheritableGroupAttrs](https://github.com/svg/svgo/blob/main/plugins/removeNonInheritableGroupAttrs.js) | remove non-inheritable group's "presentation" attributes                                                                                                 | Yes     |
+| [removeOffCanvasPaths](https://github.com/svg/svgo/blob/main/plugins/removeOffCanvasPaths.js)                     | removes elements that are drawn outside of the viewbox                                                                                                   |         |
+| [removeRasterImages](https://github.com/svg/svgo/blob/main/plugins/removeRasterImages.js)                         | remove raster images                                                                                                                                     |         |
+| [removeScriptElement](https://github.com/svg/svgo/blob/main/plugins/removeScriptElement.js)                       | remove `<script>` elements                                                                                                                               |         |
+| [removeStyleElement](https://github.com/svg/svgo/blob/main/plugins/removeStyleElement.js)                         | remove `<style>` elements                                                                                                                                |         |
+| [removeTitle](https://github.com/svg/svgo/blob/main/plugins/removeTitle.js)                                       | remove `<title>`                                                                                                                                         | Yes     |
+| [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/main/plugins/removeUnknownsAndDefaults.js)           | remove unknown elements content and attributes, remove attributes with default values                                                                    | Yes     |
+| [removeUnusedNS](https://github.com/svg/svgo/blob/main/plugins/removeUnusedNS.js)                                 | remove unused namespaces declaration                                                                                                                     | Yes     |
+| [removeUselessDefs](https://github.com/svg/svgo/blob/main/plugins/removeUselessDefs.js)                           | remove elements of `<defs>` without `id`                                                                                                                 | Yes     |
+| [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/main/plugins/removeUselessStrokeAndFill.js)         | remove useless `stroke` and `fill` attributes                                                                                                            | Yes     |
+| [removeViewBox](https://github.com/svg/svgo/blob/main/plugins/removeViewBox.js)                                   | remove `viewBox` attribute when possible                                                                                                                 | Yes     |
+| [removeXMLNS](https://github.com/svg/svgo/blob/main/plugins/removeXMLNS.js)                                       | removes the `xmlns` attribute (for inline SVG)                                                                                                           |         |
+| [removeXMLProcInst](https://github.com/svg/svgo/blob/main/plugins/removeXMLProcInst.js)                           | remove XML processing instructions                                                                                                                       | Yes     |
+| [reusePaths](https://github.com/svg/svgo/blob/main/plugins/reusePaths.js)                                         | Find duplicated <path> elements and replace them with <use> links                                                                                        |         |
+| [sortAttrs](https://github.com/svg/svgo/blob/main/plugins/sortAttrs.js)                                           | sort element attributes for epic readability                                                                                                             | Yes     |
+| [sortDefsChildren](https://github.com/svg/svgo/blob/main/plugins/sortDefsChildren.js)                             | sort children of `<defs>` in order to improve compression                                                                                                | Yes     |
 
-## Other Ways to Use SVGO
+## Other ways to use SVGO
 
-- as a web app – [SVGOMG](https://jakearchibald.github.io/svgomg/)
-- as a GitHub Action – [SVGO Action](https://github.com/marketplace/actions/svgo-action)
-- as a Grunt task – [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
-- as a Gulp task – [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin)
-- as a Mimosa module – [mimosa-minify-svg](https://github.com/dbashford/mimosa-minify-svg)
-- as an OSX Folder Action – [svgo-osx-folder-action](https://github.com/svg/svgo-osx-folder-action)
-- as a webpack loader – [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader)
-- as a Telegram Bot – [svgo_bot](https://github.com/maksugr/svgo_bot)
-- as a PostCSS plugin – [postcss-svgo](https://github.com/ben-eb/postcss-svgo)
-- as an Inkscape plugin – [inkscape-svgo](https://github.com/konsumer/inkscape-svgo)
-- as a Sketch plugin - [svgo-compressor](https://github.com/BohemianCoding/svgo-compressor)
-- as a macOS app - [Image Shrinker](https://image-shrinker.com)
-- as a Rollup plugin - [rollup-plugin-svgo](https://github.com/porsager/rollup-plugin-svgo)
-- as a VS Code plugin - [vscode-svgo](https://github.com/1000ch/vscode-svgo)
-- as a Atom plugin - [atom-svgo](https://github.com/1000ch/atom-svgo)
-- as a Sublime plugin - [Sublime-svgo](https://github.com/1000ch/Sublime-svgo)
-- as a Figma plugin - [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export)
-- as a Linux app - [Oh My SVG](https://github.com/sonnyp/OhMySVG)
-- as a Browser extension - [SVG Gobbler](https://github.com/rossmoody/svg-gobbler)
-- as an API - [Vector Express](https://github.com/smidyo/vectorexpress-api#convertor-svgo)
+| Method | Reference |
+| ------ | --------- |
+| Web app | [SVGOMG](https://jakearchibald.github.io/svgomg/) |
+| GitHub Action | [SVGO Action](https://github.com/marketplace/actions/svgo-action) |
+| Grunt task | [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin) |
+| Gulp task | [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin) |
+| Mimosa module | [mimosa-minify-svg](https://github.com/dbashford/mimosa-minify-svg) |
+| OSX Folder Action | [svgo-osx-folder-action](https://github.com/svg/svgo-osx-folder-action) |
+| Webpack loader | [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader) |
+| Telegram Bot | [svgo_bot](https://github.com/maksugr/svgo_bot) |
+| PostCSS plugin | [postcss-svgo](https://github.com/ben-eb/postcss-svgo) |
+| Inkscape plugin | [inkscape-svgo](https://github.com/konsumer/inkscape-svgo) |
+| Sketch plugin | [svgo-compressor](https://github.com/BohemianCoding/svgo-compressor) |
+| macOS app | [Image Shrinker](https://image-shrinker.com) |
+| Rollup plugin | [rollup-plugin-svgo](https://github.com/porsager/rollup-plugin-svgo) |
+| VS Code plugin | [vscode-svgo](https://github.com/1000ch/vscode-svgo) |
+| Atom plugin | [atom-svgo](https://github.com/1000ch/atom-svgo) |
+| Sublime plugin | [Sublime-svgo](https://github.com/1000ch/Sublime-svgo) |
+| Figma plugin | [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export) |
+| Linux app | [Oh My SVG](https://github.com/sonnyp/OhMySVG) |
+| Browser extension | [SVG Gobbler](https://github.com/rossmoody/svg-gobbler) |
+| API | [Vector Express](https://github.com/smidyo/vectorexpress-api#convertor-svgo) |
 
-## Donators
+## Donors
 
 | [<img src="https://sheetjs.com/sketch128.png" width="80">](https://sheetjs.com/) | [<img src="https://raw.githubusercontent.com/fontello/fontello/8.0.0/fontello-image.svg" width="80">](https://fontello.com/) |
 | :------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------: |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ module.exports = {
 };
 ```
 
-The default preset includes plugins marked with 'Yes' in the plugin list below.
+The default preset includes plugins marked with 'Yes' in the [plugin list](#built-in-plugins) below.
 
 ### Custom plugin
 


### PR DESCRIPTION
Preview: https://github.com/ADTC/svgo/blob/patch-1/README.md

* Split up code blocks by moving text outside them. (This also ensures that the Copy function makes sense. _See screenshot:_)
  * <img width="380" alt="image" src="https://user-images.githubusercontent.com/6047296/211246090-64749e5f-3f1e-413b-be39-a99fa2f1b425.png">
* Remove the redundant list of default plugins and refer to the table instead.
* Sort the table of plugins alphabetically. (It's easier to scan for a plugin.)
  * _I suggest maintaining the sort when adding new items._
* Replace the enabled/disabled code in Default column with just Yes or blank.
* Tabulate the "Other ways to use" section and remove redundant "as a/an".
* Correct the word Donators to Donors.
* Add a new section called _Troubleshooting_.