### PR TITLE
Type fix for custom / external plugins

### DIFF
--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -6,7 +6,8 @@ import type {
 
 type CustomPlugin = {
   name: string;
-  fn: PluginFn<void>;
+  fn: PluginFn<any>;
+  params: any;
 };
 
 type PluginConfig =


### PR DESCRIPTION
I've included a small type fix for using custom / external plugins with svgo
If you're trying to define a plugin which takes parameters it tends to complain
as the type checking assumes the parameter has to be void

The type warning also shows up with the example already provided within the Readme without this fix
Since there's no way to know the type of parameters being passed through a custom plugin and the CustomPlugin type isn't exported, it's why I've used the any type here.

Currently I'm having to use `// @ts-ignore` above where the plugin is defined in the config
or add 'as any' to the end of the line