### PR TITLE
Add support for image/jpeg mimetype

### DIFF
--- a/plugins/removeRasterImages.js
+++ b/plugins/removeRasterImages.js
@@ -21,7 +21,7 @@ exports.fn = () => {
         if (
           node.name === 'image' &&
           node.attributes['xlink:href'] != null &&
-          /(\.|image\/)(jpg|png|gif)/.test(node.attributes['xlink:href'])
+          /(\.|image\/)(jpe?g|png|gif)/.test(node.attributes['xlink:href'])
         ) {
           detachNodeFromParent(node, parentNode);
         }


### PR DESCRIPTION
In practice, this plugin does not work to remove embedded jpg images.

On further inspection, it's because the plugin is looking for `image/jpg`, which I'm not even sure is a valid mimetype. Inkscape uses `image/jpeg` as the mimetype for embedded JPG images.