### PR TITLE
Don't remove an empty container if parent is "switch"

### DIFF
--- a/plugins/removeEmptyContainers.js
+++ b/plugins/removeEmptyContainers.js
@@ -49,6 +49,9 @@ exports.fn = () => {
         if (node.name === 'mask' && node.attributes.id != null) {
           return;
         }
+        if (parentNode.type === 'element' && parentNode.name === 'switch') {
+          return;
+        }
         detachNodeFromParent(node, parentNode);
       },
     },

--- a/test/plugins/removeEmptyContainers.06.svg
+++ b/test/plugins/removeEmptyContainers.06.svg
@@ -1,0 +1,25 @@
+In switch elements, don't remove non-rendering children that contain
+conditional attributes like requiredFeatures, requiredExtensions, or
+systemLanguage.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 462 352">
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+    <a transform="translate(0,-5)" href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+      <text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text>
+    </a>
+  </switch>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 462 352">
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
Fix #1410