### PR TITLE
feat: remove useless closing path segments

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -811,6 +811,7 @@ function filters(path, params, { maybeHasStrokeAndLinecap, hasRoundLinejoinAndLi
       if (
         params.removeUseless &&
         hasRoundLinejoinAndLinecap &&
+        !hasMarkerMid &&
         relSubpoint[0] === pathBase[0] &&
         relSubpoint[1] === pathBase[1]
       ) {


### PR DESCRIPTION
The difference between those 2, is that the left side has has no close path command but is still closed due to ending at the start point.
```diff
- M12 22c6.23-.05 7.87-5.57 7.5-10-.36-4.34-3.95-9.96-7.5-10-3.55.04-7.14 5.66-7.5 10-.37 4.43 1.27 9.95 7.5 10z
+ M12 22c6.23-.05 7.87-5.57 7.5-10-.36-4.34-3.95-9.96-7.5-10-3.55.04-7.14 5.66-7.5 10-.37 4.43 1.27 9.95 7.5 10
```

<img width="50%" src="https://user-images.githubusercontent.com/25524993/219328058-ad09f324-a436-4b59-8558-86dba5e57691.svg"/><img width="50%" src="https://user-images.githubusercontent.com/25524993/219327832-e44eac0c-5fab-4f14-8551-178677247600.svg"/>

