### PR TITLE
Consider that any item within <defs> is visible

### DIFF
--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -82,6 +82,11 @@ exports.fn = () => {
         if (node.attributes.transform != null) {
           return visitSkip;
         }
+        
+        // consider that any item within <defs> is visible
+        if (node.name === 'defs') {
+          return visitSkip;
+        }
 
         if (
           node.name === 'path' &&


### PR DESCRIPTION
This PR fix the problem with removeOffCanvasPath in which it falsely removes elements within <defs> tags as mentioned this issuse #1732 