### PR TITLE
feat: Add suffixPattern and doesPreserveClasses parameters to addClassesToSVGElement plugin

### DIFF
--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -8,6 +8,7 @@ exports.description = 'adds classnames to an outer <svg> element';
 var ENOCLS = `Error in plugin "addClassesToSVGElement": absent parameters.
 It should have a list of classes in "classNames" or one "className".
 Config example:
+
 plugins: [
   {
     name: "addClassesToSVGElement",
@@ -16,11 +17,26 @@ plugins: [
     }
   }
 ]
+
 plugins: [
   {
     name: "addClassesToSVGElement",
     params: {
       classNames: ["mySvg", "size-big"]
+    }
+  }
+]
+
+Optionally, the "suffixPattern" can be added to include a duplicate of each
+class name with an added suffix string. The magic keyword "$FILENAME" can 
+be added to include the filename as part of the suffix string. For example:
+
+plugins: [
+  {
+    name: "addClassesToSVGElement",
+    params: {
+      classNames: ["mySvg"],
+      suffixPattern: "__$FILENAME"
     }
   }
 ]
@@ -46,7 +62,17 @@ plugins: [
  *     }
  *   }
  * ]
- *
+ * 
+ * plugins: [
+ *   {
+ *     name: "addClassesToSVGElement",
+ *     params: {
+ *       classNames: ["mySvg"],
+ *       suffixPattern: '__$FILENAME'
+ *     }
+ *   }
+ * ]
+ * 
  * @author April Arcus
  *
  * @type {import('./plugins-types').Plugin<'addClassesToSVGElement'>}

--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const path = require('path');
+
 exports.name = 'addClassesToSVGElement';
 exports.description = 'adds classnames to an outer <svg> element';
 
 var ENOCLS = `Error in plugin "addClassesToSVGElement": absent parameters.
 It should have a list of classes in "classNames" or one "className".
 Config example:
-
 plugins: [
   {
     name: "addClassesToSVGElement",
@@ -15,7 +16,6 @@ plugins: [
     }
   }
 ]
-
 plugins: [
   {
     name: "addClassesToSVGElement",
@@ -51,7 +51,7 @@ plugins: [
  *
  * @type {import('./plugins-types').Plugin<'addClassesToSVGElement'>}
  */
-exports.fn = (root, params) => {
+exports.fn = (root, params, info) => {
   if (
     !(Array.isArray(params.classNames) && params.classNames.some(String)) &&
     !params.className
@@ -60,6 +60,26 @@ exports.fn = (root, params) => {
     return null;
   }
   const classNames = params.classNames || [params.className];
+
+  /**
+   * If we have a suffix pattern,
+   * duplicate the existing class names and add a copy with the suffix.
+   * If the suffix pattern contains the magic keyword '$FILENAME',
+   * it is replaced with the actual filename. For example,
+   * if the className param is 'mySvg' and the suffixPattern
+   * param is '__$FILENAME`, then for 'cat.svg`, the final classes
+   * will be 'mySvg mySvg__cat'. For 'dog.svg', the final classes
+   * will be 'mySvg mSvg__dog'.
+   */
+  if (typeof params.suffixPattern !== 'undefined') {
+    let suffixPattern = params.suffixPattern;
+    const filename = path.basename(info.path, '.svg');
+    suffixPattern = suffixPattern.replace('$FILENAME', filename);
+    for (var i = 0, len = classNames.length; i < len; i++) {
+      classNames.push(classNames[i] + suffixPattern);
+    }
+  }
+
   return {
     element: {
       enter: (node, parentNode) => {

--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -68,7 +68,7 @@ plugins: [
  *     name: "addClassesToSVGElement",
  *     params: {
  *       classNames: ["mySvg"],
- *       suffixPattern: '__$FILENAME'
+ *       suffixPattern: "__$FILENAME"
  *     }
  *   }
  * ]

--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -26,11 +26,9 @@ plugins: [
     }
   }
 ]
-
 Optionally, the "suffixPattern" can be added to include a duplicate of each
-class name with an added suffix string. The magic keyword "$FILENAME" can 
+class name with an added suffix string. The magic keyword "$FILENAME" can
 be added to include the filename as part of the suffix string. For example:
-
 plugins: [
   {
     name: "addClassesToSVGElement",
@@ -62,7 +60,10 @@ plugins: [
  *     }
  *   }
  * ]
- * 
+ *
+ * Use the suffixPattern parameter to add an arbitrary suffix to
+ * the class names.
+ *
  * plugins: [
  *   {
  *     name: "addClassesToSVGElement",
@@ -72,8 +73,22 @@ plugins: [
  *     }
  *   }
  * ]
- * 
- * @author April Arcus
+ *
+ * Use the boolean doesPreserveClasses parameter to preserve any
+ * existing classes on the SVG element, otherwise any existing
+ * classes will be removed.
+ *
+ * plugins: [
+ *   {
+ *     name: "addClassesToSVGElement",
+ *     params: {
+ *       classNames: ["mySvg"],
+ *       doesPreserveClasses: true
+ *     }
+ *   }
+ * ]
+ *
+ * @author April Arcus, Anselm Bradford
  *
  * @type {import('./plugins-types').Plugin<'addClassesToSVGElement'>}
  */
@@ -110,6 +125,7 @@ exports.fn = (root, params, info) => {
     element: {
       enter: (node, parentNode) => {
         if (node.name === 'svg' && parentNode.type === 'root') {
+          params.doesPreserveClasses ? null : (node.attributes.class = null);
           const classList = new Set(
             node.attributes.class == null
               ? null


### PR DESCRIPTION
This PR adds a `suffixPattern` parameter to the `addClassesToSVGElement` plugin, which allows adding of a suffix to the custom classes added on the SVG element.

This PR also adds a `doesPreserveClasses` parameter, which when `true` will retain the existing classes on the SVG element, otherwise it will clear the existing classes and only use those from any `className` and `suffixPattern` parameters passed into the plugin.