### PR TITLE
Re-add prefix parameter on cleanupIds to fix unique ids

### DIFF
--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -111,10 +111,10 @@ const generateId = (currentId) => {
 /**
  * Get string from generated ID array.
  *
- * @type {(arr: Array<number>) => string}
+ * @type {(arr: Array<number>, prefix: string) => string}
  */
-const getIdString = (arr) => {
-  return arr.map((i) => generateIdChars[i]).join('');
+const getIdString = (arr, prefix) => {
+  return prefix + arr.map((i) => generateIdChars[i]).join('');
 };
 
 /**
@@ -129,6 +129,7 @@ exports.fn = (_root, params) => {
   const {
     remove = true,
     minify = true,
+    prefix= '',
     preserve = [],
     preservePrefixes = [],
     force = false,
@@ -250,7 +251,7 @@ exports.fn = (_root, params) => {
               let currentIdString = null;
               do {
                 currentId = generateId(currentId);
-                currentIdString = getIdString(currentId);
+                currentIdString = getIdString(currentId, prefix);
               } while (isIdPreserved(currentIdString));
               node.attributes.id = currentIdString;
               for (const { element, name, value } of refs) {

--- a/plugins/plugins-types.ts
+++ b/plugins/plugins-types.ts
@@ -14,6 +14,7 @@ type DefaultPlugins = {
   cleanupIds: {
     remove?: boolean;
     minify?: boolean;
+    prefix?: string;
     preserve?: Array<string>;
     preservePrefixes?: Array<string>;
     force?: boolean;


### PR DESCRIPTION
Fixed: #1746

SVGO [v3.0.0](https://github.com/svg/svgo/releases/tag/v3.0.0) removed the `prefix` parameter in the `cleanupIds` plugin in favor of `prefixIds` plugin. This created a regression with id conflicts with multiple SVGs.

The PR propose a revert of the https://github.com/svg/svgo/commit/bc07c483c3b986c66834b5fe019bb75597dd45ab commit to re-add the parameter and let user add a prefix with a custom hash.

Exemple implementation to resolve the id conflicts.

```js
const crypto = require('crypto');

module.exports = {
    plugins: [
        {
            name: 'preset-default',
            params: {
                overrides: {
                    cleanupIDs: {
                        prefix: {
                            toString() {
                                return crypto.randomBytes(20).toString('hex').slice(0, 4);
                            }
                        }
                    }
                }
            }
        }
    ]
}
```