### PR TITLE
Improve mergePaths performance on large files

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "rollup": "^2.79.1",
     "rollup-plugin-terser": "^7.0.2",
     "tar-stream": "^3.1.6",
-    "typescript": "^4.8.4"
+    "typescript": "^5.3.3"
   }
 }

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -154,7 +154,8 @@ exports.fn = (root, params) => {
             precision !== false
               ? +Math.pow(0.1, precision).toFixed(precision)
               : 1e-2;
-          roundData = precision > 0 && precision < 20 ? strongRound : round;
+          roundData =
+            precision && precision > 0 && precision < 20 ? strongRound : round;
           if (makeArcs) {
             arcThreshold = makeArcs.threshold;
             arcTolerance = makeArcs.tolerance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,7 +4449,7 @@ __metadata:
     rollup: ^2.79.1
     rollup-plugin-terser: ^7.0.2
     tar-stream: ^3.1.6
-    typescript: ^4.8.4
+    typescript: ^5.3.3
   bin:
     svgo: ./bin/svgo
   languageName: unknown
@@ -4572,23 +4572,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=a1c5e5"
+"typescript@patch:typescript@^5.3.3#~builtin<compat/typescript>":
+  version: 5.3.3
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed unneeded calls from mergePaths plugin.
1) Instead of calling detachNodeFromParent, nodes are tagged and removed after each node has been looped through. 
2) Eliminated unneeded js2path and path2js conversion by keeping the current path in memory for the duration of the loop.

