### PR TITLE
feat: make xlink configurable [plugin reusePaths]

### DIFF
--- a/plugins/plugins-types.ts
+++ b/plugins/plugins-types.ts
@@ -220,7 +220,9 @@ export type BuiltinsWithOptionalParams = DefaultPlugins & {
   removeScriptElement: void;
   removeStyleElement: void;
   removeXMLNS: void;
-  reusePaths: void;
+  reusePaths: {
+    noXlink?: boolean;
+  };
 };
 
 export type BuiltinsWithRequiredParams = {

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -20,7 +20,7 @@ exports.description =
  *
  * @type {import('./plugins-types').Plugin<'reusePaths'>}
  */
-exports.fn = () => {
+exports.fn = (root, params) => {
   /**
    * @type {Map<string, Array<XastElement>>}
    */
@@ -91,7 +91,9 @@ exports.fn = () => {
               // convert paths to <use>
               for (const pathNode of list) {
                 pathNode.name = 'use';
-                pathNode.attributes['xlink:href'] = '#' + id;
+                params.noXlink
+                  ? (pathNode.attributes['href'] = '#' + id)
+                  : (pathNode.attributes['xlink:href'] = '#' + id);
                 delete pathNode.attributes.d;
                 delete pathNode.attributes.stroke;
                 delete pathNode.attributes.fill;
@@ -99,8 +101,11 @@ exports.fn = () => {
             }
           }
           if (defsTag.children.length !== 0) {
-            if (node.attributes['xmlns:xlink'] == null) {
+            if (!params.noXlink && node.attributes['xmlns:xlink'] == null) {
               node.attributes['xmlns:xlink'] = 'http://www.w3.org/1999/xlink';
+            }
+            if (params.noXlink && node.attributes['xmlns'] == null) {
+              node.attributes['xmlns'] = 'http://www.w3.org/2000/svg';
             }
             node.children.unshift(defsTag);
           }

--- a/test/plugins/reusePaths.04.svg
+++ b/test/plugins/reusePaths.04.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+    <path transform="translate(10, 10)"
+          d="M 10,50 c 20,30 40,50 60,70 C 20,30 40,50 60,70"/>
+    <path transform="translate(20, 20)"
+          d="M 10,50 c 20,30 40,50 60,70 C 20,30 40,50 60,70"/>
+    <path d="M 10,50 c 20,30 40,50 60,70 C 20,30 40,50 60,70"/>
+    <path id="test1" d="M 10,50 l 20,30 L 20,30"/>
+    <path d="M 10,50 a 20,60 45 0,1 40,70 A 20,60 45 0,1 40,70"/>
+    <path d="M 20,30 a 20,60 45 0,1 40,70 A 20,60 45 0,1 40,70"/>
+    <g>
+      <path id="test2" d="M 10,50 l 20,30 L 20,30"/>
+    </g>
+    <path d="M 10,50 c 20,30 40,50 60,70 C 20,30 40,50 60,70"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+        <path d="M 10,50 c 20,30 40,50 60,70 C 20,30 40,50 60,70" id="reuse-0"/>
+    </defs>
+    <use href="#test0"/>
+    <use transform="translate(10, 10)" href="#reuse-0"/>
+    <use transform="translate(20, 20)" href="#reuse-0"/>
+    <use href="#reuse-0"/>
+    <use id="test1" href="#test0"/>
+    <path d="M 10,50 a 20,60 45 0,1 40,70 A 20,60 45 0,1 40,70"/>
+    <path d="M 20,30 a 20,60 45 0,1 40,70 A 20,60 45 0,1 40,70"/>
+    <g>
+        <use id="test2" href="#test0"/>
+    </g>
+    <use href="#reuse-0"/>
+</svg>
+
+@@@
+
+{"noXlink": true}

--- a/test/plugins/reusePaths.05.svg
+++ b/test/plugins/reusePaths.05.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test1" stroke="red" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test3" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test4" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test1" stroke="red" fill="green" d="M 10,50 l 20,30 L 20,30"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+        <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    </defs>
+    <use href="#test0"/>
+    <path id="test1" stroke="red" d="M 10,50 l 20,30 L 20,30"/>
+    <use href="#test2"/>
+    <use id="test3" href="#test0"/>
+    <use id="test4" href="#test2"/>
+    <path id="test1" stroke="red" fill="green" d="M 10,50 l 20,30 L 20,30"/>
+</svg>
+
+@@@
+
+{"noXlink": true}

--- a/test/plugins/reusePaths.06.svg
+++ b/test/plugins/reusePaths.06.svg
@@ -1,0 +1,27 @@
+<svg>
+    <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test1" stroke="red" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test3" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test4" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    <path id="test1" stroke="red" fill="green" d="M 10,50 l 20,30 L 20,30"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="test0" d="M 10,50 l 20,30 L 20,30"/>
+        <path id="test2" stroke="blue" d="M 10,50 l 20,30 L 20,30"/>
+    </defs>
+    <use href="#test0"/>
+    <path id="test1" stroke="red" d="M 10,50 l 20,30 L 20,30"/>
+    <use href="#test2"/>
+    <use id="test3" href="#test0"/>
+    <use id="test4" href="#test2"/>
+    <path id="test1" stroke="red" fill="green" d="M 10,50 l 20,30 L 20,30"/>
+</svg>
+
+@@@
+
+{"noXlink": true}


### PR DESCRIPTION
Updates the [reusePaths](https://github.com/svg/svgo/blob/main/plugins/reusePaths.js) plugin

Since [xlink is deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) it should be configurable whether it should be used or not.

The implementation is backward compatible, it will not break any existing configuration. However, for version 4.x it might make sense to enable noXlink by default.

- [x] Linter passed
- [x] Tests added and passed
- [x] Types passed 