### PR TITLE
test: add check for keyframe selector to

### DIFF
--- a/test/svgo/_index.test.js
+++ b/test/svgo/_index.test.js
@@ -61,4 +61,12 @@ describe('svgo', () => {
     });
     expect(normalize(result.data)).toEqual(expected);
   });
+  it('should preserve "to" keyframe selector', async () => {
+    const [original, expected] = await parseFixture('keyframe-selectors.svg');
+    const result = optimize(original, {
+      path: 'input.svg',
+      js2svg: { pretty: true },
+    });
+    expect(normalize(result.data)).toEqual(expected);
+  });
 });

--- a/test/svgo/keyframe-selectors.svg
+++ b/test/svgo/keyframe-selectors.svg
@@ -1,0 +1,13 @@
+<svg width="48" height="48" viewBox="0 0 12.7 12.7" xmlns="http://www.w3.org/2000/svg">
+  <style>@keyframes a{0%,to{clip-path:inset(84%0 0)}4%,96%{clip-path:inset(74%0 0)}16%,52%,84%{clip-path:inset(16%0 0)}20%,48%{clip-path:inset(19%0 0)}24%,44%{clip-path:inset(26%0 0)}28%,64%,72%{clip-path:inset(29%0 0)}32%{clip-path:inset(45%0 0)}36%,40%{clip-path:inset(35%0 0)}60%,76%{clip-path:inset(23%0 0)}68%{clip-path:inset(32%0 0)}}</style>
+  <path d="M2.117 2.249h2.38v8.202h-2.38z" fill="#FFF" style="animation:a 1.25s linear infinite"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 12.7 12.7">
+    <style>
+        @keyframes a{0%,to{clip-path:inset(84%0 0)}4%,96%{clip-path:inset(74%0 0)}16%,52%,84%{clip-path:inset(16%0 0)}20%,48%{clip-path:inset(19%0 0)}24%,44%{clip-path:inset(26%0 0)}28%,64%,72%{clip-path:inset(29%0 0)}32%{clip-path:inset(45%0 0)}36%,40%{clip-path:inset(35%0 0)}60%,76%{clip-path:inset(23%0 0)}68%{clip-path:inset(32%0 0)}}
+    </style>
+    <path fill="#FFF" d="M2.117 2.249h2.38v8.202h-2.38z" style="animation:a 1.25s linear infinite"/>
+</svg>


### PR DESCRIPTION
Adds test for issue reported regarding keyframe selectors.

This issue was caused by an upstream bug in [csstree](https://github.com/csstree/csstree/issues/178), which [CSSO](https://github.com/css/csso/commit/d0eecfbd29ca9d9af1681bfe6386489b8de74082) resolved on their end.

I can confirm that with svgo v3.0.2 the issue on longer occurs. However, I think it's worth including a unit test for this before closing the issue.

Uses a simplified version of my original SVG for the test. This is primarily to ensure it does not remove the `to` keyword, which was the original bug.

## Related

* For https://github.com/svg/svgo/issues/1631