### PR TITLE
fix(reusePaths): dont reuse id if referenced in href

### DIFF
--- a/test/plugins/reusePaths.06.svg
+++ b/test/plugins/reusePaths.06.svg
@@ -1,0 +1,40 @@
+Don't remove and reuse the ID of the duplicate path if it's already being linked
+in an href by another node.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-29.947 60.987 69.975 102.505">
+  <g transform="translate(-59 64)">
+    <g id="b">
+      <path id="a" fill="#000" d="M0 0v1h.5Z" transform="rotate(18 3.157 -.5)"/>
+      <use xlink:href="#a" width="1" height="1" transform="scale(-1 1)"/>
+    </g>
+    <use xlink:href="#b" width="1" height="1" transform="rotate(72)"/>
+    <use xlink:href="#b" width="1" height="1" transform="rotate(-72)"/>
+    <use xlink:href="#b" width="1" height="1" transform="rotate(144)"/>
+    <use xlink:href="#b" width="1" height="1" transform="rotate(-144)"/>
+  </g>
+  <path id="c" fill="#000" d="M0 0v1h.5Z" transform="rotate(18 3.157 -.5)"/>
+  <use xlink:href="#c" width="1" height="1" transform="scale(-1 1)"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-29.947 60.987 69.975 102.505">
+    <defs>
+        <path id="reuse-0" fill="#000" d="M0 0v1h.5Z"/>
+    </defs>
+    <g transform="translate(-59 64)">
+        <g id="b">
+            <use id="a" transform="rotate(18 3.157 -.5)" xlink:href="#reuse-0"/>
+            <use xlink:href="#a" width="1" height="1" transform="scale(-1 1)"/>
+        </g>
+        <use xlink:href="#b" width="1" height="1" transform="rotate(72)"/>
+        <use xlink:href="#b" width="1" height="1" transform="rotate(-72)"/>
+        <use xlink:href="#b" width="1" height="1" transform="rotate(144)"/>
+        <use xlink:href="#b" width="1" height="1" transform="rotate(-144)"/>
+    </g>
+    <use id="c" transform="rotate(18 3.157 -.5)" xlink:href="#reuse-0"/>
+    <use xlink:href="#c" width="1" height="1" transform="scale(-1 1)"/>
+</svg>


### PR DESCRIPTION
Fixes a bug where the `reusePaths` plugin would reuse the node ID that it's optimizing, but that ID was also referenced in a `href` elsewhere in the document, so it unintentionally applied the path to other nodes.

## Example

```svg
<svg xmlns="http://www.w3.org/2000/svg"
  xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-29.947 60.987 69.975 102.505">
  <g transform="translate(-59 64)">
    <g id="b">
      <path id="a" fill="#000" d="M0 0v1h.5Z" transform="rotate(18 3.157 -.5)"/>
      <use xlink:href="#a" width="1" height="1" transform="scale(-1 1)"/>
    </g>
    <use xlink:href="#b" width="1" height="1" transform="rotate(72)"/>
    <use xlink:href="#b" width="1" height="1" transform="rotate(-72)"/>
    <use xlink:href="#b" width="1" height="1" transform="rotate(144)"/>
    <use xlink:href="#b" width="1" height="1" transform="rotate(-144)"/>
  </g>
  <path id="c" fill="#000" d="M0 0v1h.5Z" transform="rotate(18 3.157 -.5)"/>
  <use xlink:href="#c" width="1" height="1" transform="scale(-1 1)"/>
</svg>
```

In this document, `svg g g path#a` and `svg path#c` both have a reusable path. Before, since the first path has an ID, the behavior was that it would take and reuse that.

But that's not ideal in this case, because `svg g g use[xlink:href]` is referencing `#a` already. By making that change, it changed what that node was referencing to an entirely different path.

This PR checks if the ID is already being referenced by another node. If so, create a new ID anyway instead of reusing and deleting the existing one.

## Related

* Closes https://github.com/svg/svgo/issues/1733
* Will cause conflicts for https://github.com/svg/svgo/pull/1785 (I'll just fix them, no worries.)

## Notes

* When set as a default plugin, test-regression had 3 mismatches before, still at 3.