### PR TITLE
fix(reusePaths): reuse defs tag if exists and remove redundant nodes

### DIFF
--- a/test/plugins/reusePaths.04.svg
+++ b/test/plugins/reusePaths.04.svg
@@ -1,0 +1,23 @@
+Don't create a new defs tag if one already exists as a direct child of the svg
+element.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-29.947 60.987 69.975 102.505">
+  <defs></defs>
+  <path fill="#000" d="M0 0v1h.5Z"/>
+  <path fill="#000" d="M0 0v1h.5Z"/>
+  <path fill="#000" d="M0 0v1h.5Z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-29.947 60.987 69.975 102.505">
+    <defs>
+        <path fill="#000" d="M0 0v1h.5Z" id="reuse-0"/>
+    </defs>
+    <use xlink:href="#reuse-0"/>
+    <use xlink:href="#reuse-0"/>
+    <use xlink:href="#reuse-0"/>
+</svg>

--- a/test/plugins/reusePaths.05.svg
+++ b/test/plugins/reusePaths.05.svg
@@ -1,0 +1,33 @@
+When merging existing defs, remove redundant paths with no attributes or only
+an ID attribute.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0" viewBox="0 0 400 360">
+  <defs>
+    <path id="a" d="M51.94 428.2c14.5-32.39 36.88-59.5 64.38-81.96 13.76-11.23 65.04-24.09 73.86-16.58 9.45 8.06 13.45 26.18 5.53 38.45-1.23 1.9-37.38 26.83-39.1 28.32-2.19 1.9-38.65 17.58-43.76 19.51-14.02 5.28-29.47 10.43-44.31 12.71-3.19.5-14.98 3.85-16.6-.45z"/>
+    <path id="b" d="M51.94 428.2c14.5-32.39 36.88-59.5 64.38-81.96 13.76-11.23 65.04-24.09 73.86-16.58 9.45 8.06 13.45 26.18 5.53 38.45-1.23 1.9-37.38 26.83-39.1 28.32-2.19 1.9-38.65 17.58-43.76 19.51-14.02 5.28-29.47 10.43-44.31 12.71-3.19.5-14.98 3.85-16.6-.45z"/>
+    <clipPath id="c">
+      <use xlink:href="#b" width="100%" height="100%" overflow="visible"/>
+    </clipPath>
+  </defs>
+  <g transform="matrix(.491 0 0 .491 10.63 63.15)">
+    <use xlink:href="#b" width="100%" height="100%" fill="#fff" fill-rule="evenodd" clip-rule="evenodd" overflow="visible"/>
+    <path fill="none" stroke="#c8cacc" stroke-miterlimit="3.86" stroke-width="66.34" d="M48.33 412.36c14.5-32.39 36.89-59.5 64.39-81.96 13.75-11.23 65.03-24.09 73.85-16.58 9.45 8.06 13.45 26.18 5.53 38.45-1.22 1.9-37.38 26.83-39.09 28.32-2.2 1.9-38.65 17.58-43.77 19.51-14.01 5.28-29.47 10.44-44.3 12.71-3.2.5-14.99 3.85-16.61-.45z" clip-path="url(#c)"/>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0" viewBox="0 0 400 360">
+    <defs>
+        <clipPath id="c">
+            <use xlink:href="#a" width="100%" height="100%" overflow="visible"/>
+        </clipPath>
+        <path id="a" d="M51.94 428.2c14.5-32.39 36.88-59.5 64.38-81.96 13.76-11.23 65.04-24.09 73.86-16.58 9.45 8.06 13.45 26.18 5.53 38.45-1.23 1.9-37.38 26.83-39.1 28.32-2.19 1.9-38.65 17.58-43.76 19.51-14.02 5.28-29.47 10.43-44.31 12.71-3.19.5-14.98 3.85-16.6-.45z"/>
+    </defs>
+    <g transform="matrix(.491 0 0 .491 10.63 63.15)">
+        <use xlink:href="#a" width="100%" height="100%" fill="#fff" fill-rule="evenodd" clip-rule="evenodd" overflow="visible"/>
+        <path fill="none" stroke="#c8cacc" stroke-miterlimit="3.86" stroke-width="66.34" d="M48.33 412.36c14.5-32.39 36.89-59.5 64.39-81.96 13.75-11.23 65.03-24.09 73.85-16.58 9.45 8.06 13.45 26.18 5.53 38.45-1.22 1.9-37.38 26.83-39.09 28.32-2.2 1.9-38.65 17.58-43.77 19.51-14.01 5.28-29.47 10.44-44.3 12.71-3.2.5-14.99 3.85-16.61-.45z" clip-path="url(#c)"/>
+    </g>
+</svg>


### PR DESCRIPTION
If an SVG already had a `defs` tag, the `reusePaths` plugin would create a new one anyway. This changes it so if a `defs` tag is found to exist in the document already, reuse and append to it.

This avoids having 2 `defs` in the same document after optimizing, which is unexpected, and also reducing the SVG size further.

When reusing paths in an existing `defs` tag, it kept around useless nodes that sometimes even broke the SVG. This removes the node if it's an `href` only, and removes it if it's an `id` only pointing to another `href`, and points elements directly to that `href` instead.

## Example

The plugin used to output this before, which includes some redundant nodes that broke SVGs:

```xml
<defs>
  <use xlink:href="#a"/>
  <use id="b" xlink:href="#a"/>
  <clipPath id="c">
    <use href="#b" width="100%" height="100%" overflow="visible"/>
  </clipPath>
</defs>
```

* `<use xlink:href="#a"/>` is literally doing nothing.
* `<use id="b" xlink:href="#a"/>` this can go, and replace references of `#b` with `#a`.

## Metrics

Taking the SVG from the bug reports, this both fixes the problem while producing an even smaller final output. The test was performed with only `reusePaths` enabled.

| | Time | % reduced | final KiB |
|---|---|---|---|
| Before | 39 ms | 8.1% | 100.613 |
| After | 45 ms | 8.7% | 99.886 |

I've also tested this in combination https://github.com/svg/svgo/pull/1784 which still works correctly.

## Related

* Closes https://github.com/svg/svgo/issues/1737
* Will cause conflicts for https://github.com/svg/svgo/pull/1784 (I'll just fix them, no worries.)

## Notes

* When set as a default plugin, test-regression had 3 mismatches before, still at 3.