### PR TITLE
fix: resolve regression test for removeHiddenElems

### DIFF
--- a/test/regression.js
+++ b/test/regression.js
@@ -28,8 +28,6 @@ const runTests = async ({ list }) => {
     if (
       // hard to detect the end of animation
       name.startsWith('w3c-svg-11-test-suite/svg/animate-') ||
-      // breaks because of optimisation despite of script
-      name === 'w3c-svg-11-test-suite/svg/interact-pointer-04-f.svg' ||
       // messed gradients
       name === 'w3c-svg-11-test-suite/svg/pservers-grad-18-b.svg' ||
       // animated filter


### PR DESCRIPTION
We were skipping a regression test because one of our default plugins broke it.
This resolves the issue with the plugin, so the test doesn't have to be skipped anymore.

The problem was that it was detaching non-rendered elements from the document as well (`mask`), but non-rendered elements still apply even if they are set to be invisible. From manual testing, similar logic is needed for `linearGradient` too.

We already had a workaround for this that was specific to `clipPath`, this just expands it to work across non-rendered elements.

To preserve backward compatibility with existing tests, I added logic at the end that will still detach some non-rendered elements.

* If it doesn't have an ID, so can't be referenced elsewhere in the document.
* If after cleaning up, no nodes are referencing the ID of the non-rendered element.

## Metrics

Executed with only `preset-default` enabled:

| [SVG](https://commons.wikimedia.org/wiki/File:Coat_of_Arms_of_the_President_of_Austria_(Order_of_Charles_III).svg) | Time | % reduced | final size |
|---|---|---|---|
| Original | N/A | N/A | 15060.532 KiB |
| v3.0.2 | 14915 ms | 31.4% | 10326.444 KiB |
| main | 14641 ms | 31.4% | 10326.567 KiB |
| this branch | 18357 ms | 31.4% | 10326.567 KiB |


Executed with only `preset-default` enabled: