### PR TITLE
fix(cleanupIds): handle when 2 ids referenced in one attr

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@types/css-tree": "^2.0.0",
-    "@types/csso": "^5.0.0",
+    "@types/csso": "^5.0.1",
     "@types/jest": "^29.5.5",
     "del": "^6.0.0",
     "eslint": "^8.24.0",

--- a/test/plugins/cleanupIds.22.svg
+++ b/test/plugins/cleanupIds.22.svg
@@ -1,0 +1,31 @@
+When two IDs are referenced in the same attribute.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1950.1315" height="1740.1298">
+  <linearGradient id="a">
+    <stop stop-color="#f00" offset="0"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3520" href="#a" gradientUnits="userSpaceOnUse" gradientTransform="translate(7991.4092,-7484.0182)" x1="475.01208" y1="29234.521" x2="-1343.6307" y2="29445.83"/>
+  <filter id="c" style="color-interpolation-filters:sRGB" x="-0.2760295" width="1.5520591" y="-0.33142158" height="1.6628431">
+    <feGaussianBlur stdDeviation="331.22039"/>
+  </filter>
+  <g transform="matrix(5.8862959,0,0,5.8862959,-228.3949,1414.6785)">
+    <path d="m 6416.0915,21026.021 c 496.2734,-430.162 1156.7926,-524.889 1495.2326,-581.643 1461.5227,-245.087 1539.467,2033.775 96.1224,2234.099 -524.6707,72.82 -1265.3758,450.675 -1679.5812,-402.754 -315.0174,-535.208 -91.5956,-1058.609 88.2262,-1249.702 z" style="opacity:1;fill:url(#linearGradient3520);fill-opacity:1;stroke:none;stroke-width:16.60000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#c)" transform="matrix(0.07412091,0,0,0.07412091,-359.59058,-1695.4044)"/>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1950.1315" height="1740.1298">
+    <linearGradient id="a">
+        <stop stop-color="#f00" offset="0"/>
+    </linearGradient>
+    <linearGradient id="b" href="#a" gradientUnits="userSpaceOnUse" gradientTransform="translate(7991.4092,-7484.0182)" x1="475.01208" y1="29234.521" x2="-1343.6307" y2="29445.83"/>
+    <filter id="c" style="color-interpolation-filters:sRGB" x="-0.2760295" width="1.5520591" y="-0.33142158" height="1.6628431">
+        <feGaussianBlur stdDeviation="331.22039"/>
+    </filter>
+    <g transform="matrix(5.8862959,0,0,5.8862959,-228.3949,1414.6785)">
+        <path d="m 6416.0915,21026.021 c 496.2734,-430.162 1156.7926,-524.889 1495.2326,-581.643 1461.5227,-245.087 1539.467,2033.775 96.1224,2234.099 -524.6707,72.82 -1265.3758,450.675 -1679.5812,-402.754 -315.0174,-535.208 -91.5956,-1058.609 88.2262,-1249.702 z" style="opacity:1;fill:url(#b);fill-opacity:1;stroke:none;stroke-width:16.60000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#c)" transform="matrix(0.07412091,0,0,0.07412091,-359.59058,-1695.4044)"/>
+    </g>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,12 +1009,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/csso@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@types/csso@npm:5.0.0"
+"@types/csso@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@types/csso@npm:5.0.1"
   dependencies:
     "@types/css-tree": "*"
-  checksum: 4aba6f76c4b402cb045525773b18f86fba7f61dc8be451b6c94b926f99c1f83c5c4b3ec62c1423da6f75437b954c8b4eaf9c4008e7a85bb10dd892a8fc42a0ae
+  checksum: 62c7e534dfde79c1bf3b3761baec06ac2aa2b568da9be4a548b95e709b65b3944b8ad4cd4d8926de2b4bb301b4f102fb0f8c1354cb203a92ebccf59e58c957a6
   languageName: node
   linkType: hard
 
@@ -4725,7 +4725,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^14.1.0
     "@trysound/sax": 0.2.0
     "@types/css-tree": ^2.0.0
-    "@types/csso": ^5.0.0
+    "@types/csso": ^5.0.1
     "@types/jest": ^29.5.5
     commander: ^7.2.0
     css-select: ^5.1.0


### PR DESCRIPTION
The `cleanupIds` plugin was only checking for the first reference to an ID in any given attribute. If the attribute referenced a second ID, that reference wouldn't be counted.

This resulted in nodes being removed wrongfully because we missed where it was referenced due to backing out early.

* Updates the `regReferencesUrl` regex to be global, and we iterate results instead of take the first only.
* No longer copies the attribute value before iterating, as this can mutate between iterations. 

## Metrics

With only `cleanupIds` enabled.

| [SVG](https://upload.wikimedia.org/wikipedia/commons/1/19/Logo_TVE-1.svg) | time | % reduced | final size | borked |
|---|---|---|---|---|
| Original | | | 7.462 KiB |
| v3.0.2 | 6 ms | 16.4% | 6.239 KiB | borked | 
| main (82593c6134e29a3b6195b48eb3e4d5046de4bee9) | 6 ms | 16.4% | 6.239 KiB | borked | 
| this branch | 6 ms | 16.5% | 6.233 KiB |

With only `preset-default` enabled.

| [SVG](https://upload.wikimedia.org/wikipedia/commons/1/19/Logo_TVE-1.svg) | time | % reduced | final size | borked |
|---|---|---|---|---|
| Original | | | 7.462 KiB |
| v3.0.2 | 26 ms | 69.6% | 2.267 KiB | borked | 
| main (82593c6134e29a3b6195b48eb3e4d5046de4bee9) | 24 ms | 69.6% | 2.267 KiB | borked | 
| this branch | 23 ms | 67.8% | 2.403 KiB |

## Related

* Closes https://github.com/svg/svgo/issues/1722