### PR TITLE
fix: dont trim pre elements

### DIFF
--- a/docs/03-plugins/convert-one-stop-gradients.mdx
+++ b/docs/03-plugins/convert-one-stop-gradients.mdx
@@ -8,7 +8,7 @@ Converts the [`<linearGradient>`](https://developer.mozilla.org/docs/Web/SVG/Ele
 
 These nodes contain [`<stop>`](https://developer.mozilla.org/docs/Web/SVG/Element/stop) elements, which represent various colors to transition between. However, if a gradient only contains a single `<stop>`, then it's effecitively a solid fill.
 
-Definitions of the gradients are removed, and the parent [`<defs>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs) node is removed if it has no children after optimization. The `xlink:href` namespace is also removed if there are no remaining elements using this attribute.
+Definitions of the gradients are removed, and the parent [`<defs>`](https://developer.mozilla.org/docs/Web/SVG/Element/defs) node is removed if it has no children after optimization. The `xlink:href` namespace is also removed if there are no remaining elements using this attribute.
 
 ## Usage
 

--- a/docs/03-plugins/merge-paths.mdx
+++ b/docs/03-plugins/merge-paths.mdx
@@ -10,7 +10,7 @@ svgo:
       description: Number of decimal places to round to, using conventional rounding rules.
       default: null
     noSpaceAfterFlags:
-      description: If to omit spaces after flags. Flags are values that can only be <code>0</code> or <code>1</code> and are used by some path commands, namely <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#elliptical_arc_curve" target="_blank"><code>A</code> and <code>a</code></a>.
+      description: If to omit spaces after flags. Flags are values that can only be <code>0</code> or <code>1</code> and are used by some path commands, namely <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/d#elliptical_arc_curve" target="_blank"><code>A</code> and <code>a</code></a>.
       default: false
 ---
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -15,7 +15,7 @@
 
 // @ts-ignore sax will be replaced with something else later
 const SAX = require('@trysound/sax');
-const { textElems } = require('../plugins/_collections.js');
+const { textElems } = require('../plugins/_collections');
 
 class SvgoParserError extends Error {
   /**

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -12,7 +12,7 @@
  * @typedef {import('./types').StringifyOptions} StringifyOptions
  */
 
-const { textElems } = require('../plugins/_collections.js');
+const { textElems } = require('../plugins/_collections');
 
 /**
  * @typedef {{

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -93,13 +93,19 @@ exports.elemsGroups = {
   ],
 };
 
-exports.textElems = exports.elemsGroups.textContent.concat('title');
+/**
+ * Elements where adding or removing whitespace may effect rendering, metadata,
+ * or semantic meaning.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
+ */
+exports.textElems = [...exports.elemsGroups.textContent, 'title', 'pre'];
 
 exports.pathElems = ['path', 'glyph', 'missing-glyph'];
 
-// https://www.w3.org/TR/SVG11/intro.html#Definitions
 /**
  * @type {Record<string, Array<string>>}
+ * @see https://www.w3.org/TR/SVG11/intro.html#Definitions
  */
 exports.attrsGroups = {
   animationAddition: ['additive', 'accumulate'],
@@ -363,7 +369,6 @@ exports.attrsGroupsDefaults = {
   },
 };
 
-// https://www.w3.org/TR/SVG11/eltindex.html
 /**
  * @type {Record<string, {
  *   attrsGroups: Array<string>,
@@ -372,6 +377,7 @@ exports.attrsGroupsDefaults = {
  *   contentGroups?: Array<string>,
  *   content?: Array<string>,
  * }>}
+ * @see https://www.w3.org/TR/SVG11/eltindex.html
  */
 exports.elems = {
   a: {
@@ -1948,7 +1954,9 @@ exports.editorNamespaces = [
   'http://www.vector.evaxdesign.sk',
 ];
 
-// https://www.w3.org/TR/SVG11/linking.html#processingIRI
+/**
+ * @see https://www.w3.org/TR/SVG11/linking.html#processingIRI
+ */
 exports.referencesProps = [
   'clip-path',
   'color-profile',
@@ -1962,7 +1970,9 @@ exports.referencesProps = [
   'style',
 ];
 
-// https://www.w3.org/TR/SVG11/propidx.html
+/**
+ * @see https://www.w3.org/TR/SVG11/propidx.html
+ */
 exports.inheritableAttrs = [
   'clip-rule',
   'color',
@@ -2216,7 +2226,9 @@ exports.colorsShortNames = {
   '#f5deb3': 'wheat',
 };
 
-// https://www.w3.org/TR/SVG11/single-page.html#types-DataTypeColor
+/**
+ * @see https://www.w3.org/TR/SVG11/single-page.html#types-DataTypeColor
+ */
 exports.colorsProps = [
   'color',
   'fill',

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -97,7 +97,7 @@ exports.elemsGroups = {
  * Elements where adding or removing whitespace may effect rendering, metadata,
  * or semantic meaning.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
+ * @see https://developer.mozilla.org/docs/Web/HTML/Element/pre
  */
 exports.textElems = [...exports.elemsGroups.textContent, 'title', 'pre'];
 

--- a/plugins/convertOneStopGradients.js
+++ b/plugins/convertOneStopGradients.js
@@ -22,8 +22,8 @@ exports.description =
  *
  * @author Seth Falco <seth@falco.fun>
  * @type {import('./plugins-types').Plugin<'convertOneStopGradients'>}
- * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient
- * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient
+ * @see https://developer.mozilla.org/docs/Web/SVG/Element/linearGradient
+ * @see https://developer.mozilla.org/docs/Web/SVG/Element/radialGradient
  */
 exports.fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -69,7 +69,7 @@ exports.description =
  *   ↓
  * <rect x="0" y="0" width="100" height="100"/>
  *
- * @link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors|MDN CSS Selectors
+ * @link https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors|MDN CSS Selectors
  *
  * @author Bradley Mease
  *

--- a/plugins/removeDesc.js
+++ b/plugins/removeDesc.js
@@ -12,7 +12,7 @@ const standardDescs = /^(Created with|Created using)/;
  * Removes only standard editors content or empty elements 'cause it can be used for accessibility.
  * Enable parameter 'removeAny' to remove any description.
  *
- * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc
+ * https://developer.mozilla.org/docs/Web/SVG/Element/desc
  *
  * @author Daniel Wabyick
  *

--- a/plugins/removeTitle.js
+++ b/plugins/removeTitle.js
@@ -8,7 +8,7 @@ exports.description = 'removes <title>';
 /**
  * Remove <title>.
  *
- * https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title
+ * https://developer.mozilla.org/docs/Web/SVG/Element/title
  *
  * @author Igor Kalashnikov
  *

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -36,7 +36,7 @@ exports.fn = (root) => {
    * element if one exists.
    *
    * @type {XastElement}
-   * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
+   * @see https://developer.mozilla.org/docs/Web/SVG/Element/defs
    */
   let svgDefs;
 

--- a/test/svgo/_index.test.js
+++ b/test/svgo/_index.test.js
@@ -69,4 +69,19 @@ describe('svgo', () => {
     });
     expect(normalize(result.data)).toEqual(expected);
   });
+  it('should not trim whitespace at start and end of pre element', async () => {
+    const [original, expected] = await parseFixture('pre-element.svg');
+    const result = optimize(original, {
+      path: 'input.svg',
+    });
+    expect(normalize(result.data)).toEqual(expected);
+  });
+  it('should not add whitespace in pre element', async () => {
+    const [original, expected] = await parseFixture('pre-element-pretty.svg');
+    const result = optimize(original, {
+      path: 'input.svg',
+      js2svg: { pretty: true },
+    });
+    expect(normalize(result.data)).toEqual(expected);
+  });
 });

--- a/test/svgo/pre-element-pretty.svg
+++ b/test/svgo/pre-element-pretty.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 854 340">
+  <foreignObject width="100%" height="100%">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <pre style="text-align:center"> OOO   PPPP   EEEEE  N   N  SSSSS   OOO   U   U  RRRR    CCCC  EEEEE
+O   O  P   P  E      NN  N  SS     O   O  U   U  R   R  C      E    
+O   O  PPPP   EEE    N N N   SSS   O   O  U   U  RRRR   C      EEE  
+O   O  P      E      N  NN     SS  O   O  U   U  R R    C      E    
+ OOO   P      EEEEE  N   N  SSSSS   OOO    UUU   R  R    CCCC  EEEEE
+
+M   M   AAA   IIIII  N   N  TTTTT   AAA   IIIII  N   N  EEEEE  RRRR 
+MM MM  A   A    I    NN  N    T    A   A    I    NN  N  E      R   R
+M M M  AAAAA    I    N N N    T    AAAAA    I    N N N  EEE    RRRR 
+M   M  A   A    I    N  NN    T    A   A    I    N  NN  E      R R  
+M   M  A   A  IIIII  N   N    T    A   A  IIIII  N   N  EEEEE  R  R </pre>
+    </div>
+  </foreignObject>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 854 340">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <pre style="text-align:center"> OOO   PPPP   EEEEE  N   N  SSSSS   OOO   U   U  RRRR    CCCC  EEEEE
+O   O  P   P  E      NN  N  SS     O   O  U   U  R   R  C      E    
+O   O  PPPP   EEE    N N N   SSS   O   O  U   U  RRRR   C      EEE  
+O   O  P      E      N  NN     SS  O   O  U   U  R R    C      E    
+ OOO   P      EEEEE  N   N  SSSSS   OOO    UUU   R  R    CCCC  EEEEE
+
+M   M   AAA   IIIII  N   N  TTTTT   AAA   IIIII  N   N  EEEEE  RRRR 
+MM MM  A   A    I    NN  N    T    A   A    I    NN  N  E      R   R
+M M M  AAAAA    I    N N N    T    AAAAA    I    N N N  EEE    RRRR 
+M   M  A   A    I    N  NN    T    A   A    I    N  NN  E      R R  
+M   M  A   A  IIIII  N   N    T    A   A  IIIII  N   N  EEEEE  R  R </pre>
+        </div>
+    </foreignObject>
+</svg>

--- a/test/svgo/pre-element.svg
+++ b/test/svgo/pre-element.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 854 340">
+  <foreignObject width="100%" height="100%">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <pre style="text-align:center"> OOO   PPPP   EEEEE  N   N  SSSSS   OOO   U   U  RRRR    CCCC  EEEEE
+O   O  P   P  E      NN  N  SS     O   O  U   U  R   R  C      E    
+O   O  PPPP   EEE    N N N   SSS   O   O  U   U  RRRR   C      EEE  
+O   O  P      E      N  NN     SS  O   O  U   U  R R    C      E    
+ OOO   P      EEEEE  N   N  SSSSS   OOO    UUU   R  R    CCCC  EEEEE
+
+M   M   AAA   IIIII  N   N  TTTTT   AAA   IIIII  N   N  EEEEE  RRRR 
+MM MM  A   A    I    NN  N    T    A   A    I    NN  N  E      R   R
+M M M  AAAAA    I    N N N    T    AAAAA    I    N N N  EEE    RRRR 
+M   M  A   A    I    N  NN    T    A   A    I    N  NN  E      R R  
+M   M  A   A  IIIII  N   N    T    A   A  IIIII  N   N  EEEEE  R  R </pre>
+    </div>
+  </foreignObject>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 854 340"><foreignObject width="100%" height="100%"><div xmlns="http://www.w3.org/1999/xhtml"><pre style="text-align:center"> OOO   PPPP   EEEEE  N   N  SSSSS   OOO   U   U  RRRR    CCCC  EEEEE
+O   O  P   P  E      NN  N  SS     O   O  U   U  R   R  C      E    
+O   O  PPPP   EEE    N N N   SSS   O   O  U   U  RRRR   C      EEE  
+O   O  P      E      N  NN     SS  O   O  U   U  R R    C      E    
+ OOO   P      EEEEE  N   N  SSSSS   OOO    UUU   R  R    CCCC  EEEEE
+
+M   M   AAA   IIIII  N   N  TTTTT   AAA   IIIII  N   N  EEEEE  RRRR 
+MM MM  A   A    I    NN  N    T    A   A    I    NN  N  E      R   R
+M M M  AAAAA    I    N N N    T    AAAAA    I    N N N  EEE    RRRR 
+M   M  A   A    I    N  NN    T    A   A    I    N  NN  E      R R  
+M   M  A   A  IIIII  N   N    T    A   A  IIIII  N   N  EEEEE  R  R </pre></div></foreignObject></svg>


### PR DESCRIPTION
While working on the demo for https://github.com/svg/svgo/issues/1794, I noticed an issue with how we handle `pre` tags in a `foreignObject`.

The `pre` tag is space sensitive, so adding or removing whitespace from either end will change the result. This expands the list of elements that we don't trim to include `pre`. I did not do this in `_collections.js` since that was focused on SVG nodes, so I've put it in `tools.js`.

Feedback welcome if you know a better place this constant could live, but I would prefer if we didn't maintain it twice between `parser.js` and `stringifier.js`.

## MRE

![minimal](https://github.com/svg/svgo/assets/22801583/31998993-9c8a-4734-8af7-bfc311032977)

## main (82593c6134e29a3b6195b48eb3e4d5046de4bee9)

Before it would output one of the following depending on if `js2svg.pretty` was enabled or not.

![optimized](https://github.com/svg/svgo/assets/22801583/17471fee-1ed6-4249-8fde-a3622651f76a)

![optimized](https://github.com/svg/svgo/assets/22801583/68a8214d-93c6-46cd-8723-127813badc1b)
