### PR TITLE
fix(inlineStyles): case insensitive style props

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -252,7 +252,7 @@ exports.fn = (root, params) => {
             csstree.walk(styleDeclarationList, {
               visit: 'Declaration',
               enter(node, item) {
-                styleDeclarationItems.set(node.property, item);
+                styleDeclarationItems.set(node.property.toLowerCase(), item);
               },
             });
             // merge declarations

--- a/test/regression.js
+++ b/test/regression.js
@@ -38,8 +38,6 @@ const runTests = async ({ list }) => {
       name === 'w3c-svg-11-test-suite/svg/filters-composite-05-f.svg' ||
       // removing wrapping <g> breaks :first-child pseudo-class
       name === 'w3c-svg-11-test-suite/svg/styling-pres-04-f.svg' ||
-      // messed case insensitivity while inlining styles
-      name === 'w3c-svg-11-test-suite/svg/styling-css-10-f.svg' ||
       // rect is converted to path which matches wrong styles
       name === 'w3c-svg-11-test-suite/svg/styling-css-08-f.svg' ||
       // external image


### PR DESCRIPTION
To enable another regression test, I've resolved the issue that was causing it to fail.

Style property names are case-insensitive, for example `fill`, `FILL`, and `FiLl` are all valid but refer to the same property. So when inlining styles, we compare the lowercase strings and only use the last instance of the property rather than embed them all.

This also results in smaller files in the case that properties are assigned more than once with different capitalization… though I doubt that really happens in the wild.

## Example

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 360">
  <style>
      #c {fill: red }
      #c {FiLl: oRaNgE }
  </style>
  <circle id="c" fill="blue" cx="140" cy="220" r="50"/>
</svg>
```

Before this would output an inline style like: `style="FiLl:orange;fill:red"`.  
Now instead it produces just `style="FiLl:orange"`.