### PR TITLE
fix(inlineStyles): remove all classes in multiclass selector

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -38,11 +38,6 @@ const compareSpecificity = (a, b) => {
 };
 
 /**
- * @type {(value: any) => any}
- */
-const toAny = (value) => value;
-
-/**
  * Moves + merges styles from style elements to element styles
  *
  * Options
@@ -323,17 +318,13 @@ exports.fn = (root, params) => {
                 ? null
                 : selectedEl.attributes.class.split(' ')
             );
-            /**
-             * csstree v2 changed this type
-             * @type {csstree.CssNode}
-             */
-            const firstSubSelector = toAny(selector.node.children.first);
-            if (
-              firstSubSelector != null &&
-              firstSubSelector.type === 'ClassSelector'
-            ) {
-              classList.delete(firstSubSelector.name);
+
+            for (const child of selector.node.children) {
+              if (child.type === 'ClassSelector') {
+                classList.delete(child.name);
+              }
             }
+
             if (classList.size === 0) {
               delete selectedEl.attributes.class;
             } else {
@@ -341,13 +332,13 @@ exports.fn = (root, params) => {
             }
 
             // ID
+            const firstSubSelector = selector.node.children.first;
             if (
               firstSubSelector != null &&
-              firstSubSelector.type === 'IdSelector'
+              firstSubSelector.type === 'IdSelector' &&
+              selectedEl.attributes.id === firstSubSelector.name
             ) {
-              if (selectedEl.attributes.id === firstSubSelector.name) {
-                delete selectedEl.attributes.id;
-              }
+              delete selectedEl.attributes.id;
             }
           }
         }
@@ -360,8 +351,7 @@ exports.fn = (root, params) => {
               if (
                 node.type === 'Rule' &&
                 node.prelude.type === 'SelectorList' &&
-                // csstree v2 changed this type
-                toAny(node.prelude.children.isEmpty)
+                node.prelude.children.isEmpty
               ) {
                 list.remove(item);
               }
@@ -369,7 +359,7 @@ exports.fn = (root, params) => {
           });
 
           // csstree v2 changed this type
-          if (toAny(style.cssAst.children.isEmpty)) {
+          if (style.cssAst.children.isEmpty) {
             // remove emtpy style element
             detachNodeFromParent(style.node, style.parentNode);
           } else {

--- a/test/plugins/inlineStyles.21.svg
+++ b/test/plugins/inlineStyles.21.svg
@@ -1,0 +1,24 @@
+Selectors matching two classes should remove both classes from the matched
+element.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1570.062" height="2730" viewBox="0 0 415.412 722.312">
+  <style>
+    .segment.minor {
+      stroke-width: 1.5;
+      stroke: #15c6aa;
+    }
+  </style>
+  <g transform="translate(200.662 362.87)">
+    <path d="M163.502-303.979h3.762" class="segment minor"/>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1570.062" height="2730" viewBox="0 0 415.412 722.312">
+    <g transform="translate(200.662 362.87)">
+        <path d="M163.502-303.979h3.762" style="stroke-width:1.5;stroke:#15c6aa"/>
+    </g>
+</svg>

--- a/test/plugins/inlineStyles.22.svg
+++ b/test/plugins/inlineStyles.22.svg
@@ -1,0 +1,26 @@
+Selectors matching two classes should remove both classes from the matched
+element, and further selectors of those classes should still apply.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1570.062" height="2730" viewBox="0 0 415.412 722.312">
+  <style>
+    .segment.minor {
+      stroke-width: 1.5;
+    }
+    .minor {
+      stroke: #15c6aa;
+    }
+  </style>
+  <g transform="translate(200.662 362.87)">
+    <path d="M163.502-303.979h3.762" class="segment minor"/>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1570.062" height="2730" viewBox="0 0 415.412 722.312">
+    <g transform="translate(200.662 362.87)">
+        <path d="M163.502-303.979h3.762" style="stroke-width:1.5;stroke:#15c6aa"/>
+    </g>
+</svg>


### PR DESCRIPTION
When running into a multi-class selector with `inlineStyles`, it would only remove the first class of the selector instead of all of them.

This iterates the classes in the selector instead of only taking the first. Also performs some minor refactors.

## Related

* Discovered in https://github.com/svg/svgo/issues/1743#issuecomment-1734948374