### PR TITLE
fix: warn and do not crash on null plugin

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -65,12 +65,20 @@ const optimize = (input, config) => {
     info.multipassCount = i;
     const ast = parseSvg(input, config.path);
     const plugins = config.plugins || ['preset-default'];
-    if (Array.isArray(plugins) === false) {
+    if (!Array.isArray(plugins)) {
       throw Error(
-        "Invalid plugins list. Provided 'plugins' in config should be an array."
+        'malformed config, `plugins` property must be an array.\nSee more info here: https://github.com/svg/svgo#configuration'
       );
     }
-    const resolvedPlugins = plugins.map(resolvePluginConfig);
+    const resolvedPlugins = plugins
+      .filter((plugin) => plugin != null)
+      .map(resolvePluginConfig);
+
+    if (resolvedPlugins.length < plugins.length) {
+      console.warn(
+        'Warning: plugins list includes null or undefined elements, these will be ignored.'
+      );
+    }
     const globalOverrides = {};
     if (config.floatPrecision != null) {
       globalOverrides.floatPrecision = config.floatPrecision;


### PR DESCRIPTION
If we received null/undefined/empty plugins, instead of crashing, log a warning and ignore them.

Also updates the error message when a malformed configuration comes in to direct users to the documentation. Later I want to take a page from Vercel's book and made a dedicated page in the docs for various errors, but I will come to this later.

## Related

* Closes https://github.com/svg/svgo/issues/1727