### PR TITLE
chore: use external xast type declarations

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,16 +1,17 @@
 'use strict';
 
 /**
- * @typedef {import('./types').XastNode} XastNode
- * @typedef {import('./types').XastInstruction} XastInstruction
- * @typedef {import('./types').XastDoctype} XastDoctype
- * @typedef {import('./types').XastComment} XastComment
- * @typedef {import('./types').XastRoot} XastRoot
- * @typedef {import('./types').XastElement} XastElement
- * @typedef {import('./types').XastCdata} XastCdata
- * @typedef {import('./types').XastText} XastText
- * @typedef {import('./types').XastParent} XastParent
- * @typedef {import('./types').XastChild} XastChild
+ * @typedef {import('xast').Cdata} Cdata
+ * @typedef {import('xast').Comment} Comment
+ * @typedef {import('xast').Doctype} Doctype
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').ElementContent} ElementContent
+ * @typedef {import('xast').Instruction} Instruction
+ * @typedef {import('xast').Node} Node
+ * @typedef {import('xast').Parents} Parents
+ * @typedef {import('xast').Root} Root
+ * @typedef {import('xast').RootContent} RootContent
+ * @typedef {import('xast').Text} Text
  */
 
 // @ts-ignore sax will be replaced with something else later
@@ -87,25 +88,22 @@ const config = {
 /**
  * Convert SVG (XML) string to SVG-as-JS object.
  *
- * @type {(data: string, from?: string) => XastRoot}
+ * @type {(data: string, from?: string) => Root}
  */
 const parseSvg = (data, from) => {
   const sax = SAX.parser(config.strict, config);
-  /**
-   * @type {XastRoot}
-   */
+
+  /** @type {Root} */
   const root = { type: 'root', children: [] };
-  /**
-   * @type {XastParent}
-   */
+
+  /** @type {Parents} */
   let current = root;
-  /**
-   * @type {Array<XastParent>}
-   */
+
+  /** @type {Array<Parents>} */
   const stack = [root];
 
   /**
-   * @type {(node: XastChild) => void}
+   * @param {RootContent | ElementContent} node
    */
   const pushToContent = (node) => {
     // TODO remove legacy parentNode in v4
@@ -113,6 +111,7 @@ const parseSvg = (data, from) => {
       writable: true,
       value: current,
     });
+    // @ts-ignore
     current.children.push(node);
   };
 
@@ -120,9 +119,7 @@ const parseSvg = (data, from) => {
    * @type {(doctype: string) => void}
    */
   sax.ondoctype = (doctype) => {
-    /**
-     * @type {XastDoctype}
-     */
+    /** @type {Doctype} */
     const node = {
       type: 'doctype',
       // TODO parse doctype for name, public and system to match xast
@@ -147,9 +144,7 @@ const parseSvg = (data, from) => {
    * @type {(data: { name: string, body: string }) => void}
    */
   sax.onprocessinginstruction = (data) => {
-    /**
-     * @type {XastInstruction}
-     */
+    /** @type {Instruction} */
     const node = {
       type: 'instruction',
       name: data.name,
@@ -158,13 +153,9 @@ const parseSvg = (data, from) => {
     pushToContent(node);
   };
 
-  /**
-   * @type {(comment: string) => void}
-   */
+  /** @type {(comment: string) => void} */
   sax.oncomment = (comment) => {
-    /**
-     * @type {XastComment}
-     */
+    /** @type {Comment} */
     const node = {
       type: 'comment',
       value: comment.trim(),
@@ -176,9 +167,7 @@ const parseSvg = (data, from) => {
    * @type {(cdata: string) => void}
    */
   sax.oncdata = (cdata) => {
-    /**
-     * @type {XastCdata}
-     */
+    /** @type {Cdata} */
     const node = {
       type: 'cdata',
       value: cdata,
@@ -190,9 +179,7 @@ const parseSvg = (data, from) => {
    * @type {(data: { name: string, attributes: Record<string, { value: string }>}) => void}
    */
   sax.onopentag = (data) => {
-    /**
-     * @type {XastElement}
-     */
+    /** @type {Element} */
     let element = {
       type: 'element',
       name: data.name,
@@ -207,25 +194,19 @@ const parseSvg = (data, from) => {
     stack.push(element);
   };
 
-  /**
-   * @type {(text: string) => void}
-   */
+  /** @type {(text: string) => void} */
   sax.ontext = (text) => {
     if (current.type === 'element') {
       // prevent trimming of meaningful whitespace inside textual tags
       if (textElems.includes(current.name)) {
-        /**
-         * @type {XastText}
-         */
+        /** @type {Text} */
         const node = {
           type: 'text',
           value: text,
         };
         pushToContent(node);
       } else if (/\S/.test(text)) {
-        /**
-         * @type {XastText}
-         */
+        /** @type {Text} */
         const node = {
           type: 'text',
           value: text.trim(),

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -1,30 +1,24 @@
 'use strict';
 
 /**
- * @typedef {import('./types').XastParent} XastParent
- * @typedef {import('./types').XastRoot} XastRoot
- * @typedef {import('./types').XastElement} XastElement
- * @typedef {import('./types').XastInstruction} XastInstruction
- * @typedef {import('./types').XastDoctype} XastDoctype
- * @typedef {import('./types').XastText} XastText
- * @typedef {import('./types').XastCdata} XastCdata
- * @typedef {import('./types').XastComment} XastComment
+ * @typedef {import('xast').Cdata} Cdata
+ * @typedef {import('xast').Comment} Comment
+ * @typedef {import('xast').Doctype} Doctype
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Instruction} Instruction
+ * @typedef {import('xast').Parents} Parents
+ * @typedef {import('xast').Root} Root
+ * @typedef {import('xast').Text} Text
+ * @typedef {Required<StringifyOptions>} Options
  * @typedef {import('./types').StringifyOptions} StringifyOptions
- */
-
-const { textElems } = require('../plugins/_collections.js');
-
-/**
  * @typedef {{
  *   indent: string,
- *   textContext: null | XastElement,
+ *   textContext: Element | null,
  *   indentLevel: number,
  * }} State
  */
 
-/**
- * @typedef {Required<StringifyOptions>} Options
- */
+const { textElems } = require('../plugins/_collections.js');
 
 /**
  * @type {(char: string) => string}
@@ -79,7 +73,7 @@ const entities = {
 /**
  * convert XAST to SVG string
  *
- * @type {(data: XastRoot, config: StringifyOptions) => string}
+ * @type {(data: Root, config: StringifyOptions) => string}
  */
 const stringifySvg = (data, userOptions = {}) => {
   /**
@@ -121,7 +115,7 @@ const stringifySvg = (data, userOptions = {}) => {
 exports.stringifySvg = stringifySvg;
 
 /**
- * @type {(node: XastParent, config: Options, state: State) => string}
+ * @type {(node: Parents, config: Options, state: State) => string}
  */
 const stringifyNode = (data, config, state) => {
   let svg = '';
@@ -164,14 +158,17 @@ const createIndent = (config, state) => {
 };
 
 /**
- * @type {(node: XastDoctype, config: Options) => string}
+ * @param {Doctype} node
+ * @param {Options} config
+ * @returns {string}
  */
 const stringifyDoctype = (node, config) => {
+  // @ts-ignore
   return config.doctypeStart + node.data.doctype + config.doctypeEnd;
 };
 
 /**
- * @type {(node: XastInstruction, config: Options) => string}
+ * @type {(node: Instruction, config: Options) => string}
  */
 const stringifyInstruction = (node, config) => {
   return (
@@ -180,14 +177,14 @@ const stringifyInstruction = (node, config) => {
 };
 
 /**
- * @type {(node: XastComment, config: Options) => string}
+ * @type {(node: Comment, config: Options) => string}
  */
 const stringifyComment = (node, config) => {
   return config.commentStart + node.value + config.commentEnd;
 };
 
 /**
- * @type {(node: XastCdata, config: Options, state: State) => string}
+ * @type {(node: Cdata, config: Options, state: State) => string}
  */
 const stringifyCdata = (node, config, state) => {
   return (
@@ -199,7 +196,7 @@ const stringifyCdata = (node, config, state) => {
 };
 
 /**
- * @type {(node: XastElement, config: Options, state: State) => string}
+ * @type {(node: Element, config: Options, state: State) => string}
  */
 const stringifyElement = (node, config, state) => {
   // empty element and short tag
@@ -268,13 +265,13 @@ const stringifyElement = (node, config, state) => {
 };
 
 /**
- * @type {(node: XastElement, config: Options) => string}
+ * @type {(node: Element, config: Options) => string}
  */
 const stringifyAttributes = (node, config) => {
   let attrs = '';
   for (const [name, value] of Object.entries(node.attributes)) {
     // TODO remove attributes without values support in v3
-    if (value !== undefined) {
+    if (value != undefined) {
       const encodedValue = value
         .toString()
         .replace(config.regValEntities, config.encodeEntity);
@@ -287,7 +284,7 @@ const stringifyAttributes = (node, config) => {
 };
 
 /**
- * @type {(node: XastText, config: Options, state: State) => string}
+ * @type {(node: Text, config: Options, state: State) => string}
  */
 const stringifyText = (node, config, state) => {
   return (

--- a/lib/style.js
+++ b/lib/style.js
@@ -2,15 +2,15 @@
 
 /**
  * @typedef {import('css-tree').Rule} CsstreeRule
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').ElementContent} ElementContent
+ * @typedef {import('xast').Parents} Parents
+ * @typedef {import('xast').Root} Root
  * @typedef {import('./types').Specificity} Specificity
  * @typedef {import('./types').Stylesheet} Stylesheet
  * @typedef {import('./types').StylesheetRule} StylesheetRule
  * @typedef {import('./types').StylesheetDeclaration} StylesheetDeclaration
  * @typedef {import('./types').ComputedStyles} ComputedStyles
- * @typedef {import('./types').XastRoot} XastRoot
- * @typedef {import('./types').XastElement} XastElement
- * @typedef {import('./types').XastParent} XastParent
- * @typedef {import('./types').XastChild} XastChild
  */
 
 const csstree = require('css-tree');
@@ -132,18 +132,18 @@ const parseStyleDeclarations = (css) => {
 };
 
 /**
- * @type {(stylesheet: Stylesheet, node: XastElement) => ComputedStyles}
+ * @param {Stylesheet} stylesheet
+ * @param {Element} node
+ * @returns {ComputedStyles}
  */
 const computeOwnStyle = (stylesheet, node) => {
-  /**
-   * @type {ComputedStyles}
-   */
+  /** @type {ComputedStyles} */
   const computedStyle = {};
   const importantStyles = new Map();
 
   // collect attributes
   for (const [name, value] of Object.entries(node.attributes)) {
-    if (attrsGroups.presentation.includes(name)) {
+    if (attrsGroups.presentation.includes(name) && value != null) {
       computedStyle[name] = { type: 'static', inherited: false, value };
       importantStyles.set(name, false);
     }
@@ -215,17 +215,16 @@ const compareSpecificity = (a, b) => {
 };
 
 /**
- * @type {(root: XastRoot) => Stylesheet}
+ * @param {Root} root
+ * @returns {Stylesheet}}
  */
 const collectStylesheet = (root) => {
-  /**
-   * @type {Array<StylesheetRule>}
-   */
+  /** @type {Array<StylesheetRule>} */
   const rules = [];
-  /**
-   * @type {Map<XastElement, XastParent>}
-   */
+
+  /** @type {Map<Element, Parents>} */
   const parents = new Map();
+
   visit(root, {
     element: {
       enter: (node, parentNode) => {
@@ -258,7 +257,9 @@ const collectStylesheet = (root) => {
 exports.collectStylesheet = collectStylesheet;
 
 /**
- * @type {(stylesheet: Stylesheet, node: XastElement) => ComputedStyles}
+ * @param {Stylesheet} stylesheet
+ * @param {Element} node
+ * @returns {ComputedStyles}
  */
 const computeStyle = (stylesheet, node) => {
   const { parents } = stylesheet;

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * @typedef {import('./types').XastParent} XastParent
- * @typedef {import('./types').XastElement} XastElement
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Root} Root
  */
 
 const { collectStylesheet, computeStyle } = require('./style.js');
@@ -10,11 +10,11 @@ const { visit } = require('./xast.js');
 const { parseSvg } = require('./parser.js');
 
 /**
- * @type {(node: XastParent, id: string) => XastElement}
+ * @type {(node: Root, id: string) => Element}
  */
 const getElementById = (node, id) => {
   /**
-   * @type {null | XastElement}
+   * @type {Element | null}
    */
   let matched = null;
   visit(node, {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,55 +1,4 @@
-export type XastDoctype = {
-  type: 'doctype';
-  name: string;
-  data: {
-    doctype: string;
-  };
-};
-
-export type XastInstruction = {
-  type: 'instruction';
-  name: string;
-  value: string;
-};
-
-export type XastComment = {
-  type: 'comment';
-  value: string;
-};
-
-export type XastCdata = {
-  type: 'cdata';
-  value: string;
-};
-
-export type XastText = {
-  type: 'text';
-  value: string;
-};
-
-export type XastElement = {
-  type: 'element';
-  name: string;
-  attributes: Record<string, string>;
-  children: Array<XastChild>;
-};
-
-export type XastChild =
-  | XastDoctype
-  | XastInstruction
-  | XastComment
-  | XastCdata
-  | XastText
-  | XastElement;
-
-export type XastRoot = {
-  type: 'root';
-  children: Array<XastChild>;
-};
-
-export type XastParent = XastRoot | XastElement;
-
-export type XastNode = XastRoot | XastChild;
+import type { Parents, Root, Doctype, Instruction, Comment, Cdata, Text, Element } from 'xast';
 
 export type StringifyOptions = {
   doctypeStart?: string;
@@ -81,22 +30,22 @@ export type StringifyOptions = {
 };
 
 type VisitorNode<Node> = {
-  enter?: (node: Node, parentNode: XastParent) => void | symbol;
-  exit?: (node: Node, parentNode: XastParent) => void;
+  enter?: (node: Node, parentNode: Parents) => void | symbol;
+  exit?: (node: Node, parentNode: Parents) => void;
 };
 
 type VisitorRoot = {
-  enter?: (node: XastRoot, parentNode: null) => void;
-  exit?: (node: XastRoot, parentNode: null) => void;
+  enter?: (node: Root, parentNode: null) => void;
+  exit?: (node: Root, parentNode: null) => void;
 };
 
 export type Visitor = {
-  doctype?: VisitorNode<XastDoctype>;
-  instruction?: VisitorNode<XastInstruction>;
-  comment?: VisitorNode<XastComment>;
-  cdata?: VisitorNode<XastCdata>;
-  text?: VisitorNode<XastText>;
-  element?: VisitorNode<XastElement>;
+  doctype?: VisitorNode<Doctype>;
+  instruction?: VisitorNode<Instruction>;
+  comment?: VisitorNode<Comment>;
+  cdata?: VisitorNode<Cdata>;
+  text?: VisitorNode<Text>;
+  element?: VisitorNode<Element>;
   root?: VisitorRoot;
 };
 
@@ -106,7 +55,7 @@ export type PluginInfo = {
 };
 
 export type Plugin<Params> = (
-  root: XastRoot,
+  root: Root,
   params: Params,
   info: PluginInfo
 ) => null | Visitor;
@@ -128,7 +77,7 @@ export type StylesheetRule = {
 
 export type Stylesheet = {
   rules: Array<StylesheetRule>;
-  parents: Map<XastElement, XastParent>;
+  parents: Map<Element, Parents>;
 };
 
 type StaticStyle = {

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -1,9 +1,11 @@
 'use strict';
 
 /**
- * @typedef {import('./types').XastNode} XastNode
- * @typedef {import('./types').XastChild} XastChild
- * @typedef {import('./types').XastParent} XastParent
+ * @typedef {import('xast').ElementContent} ElementContent
+ * @typedef {import('xast').Node} Node
+ * @typedef {import('xast').Parents} Parents
+ * @typedef {import('xast').Root} Root
+ * @typedef {import('xast').RootContent} RootContent
  * @typedef {import('./types').Visitor} Visitor
  */
 
@@ -16,7 +18,7 @@ const cssSelectOptions = {
 };
 
 /**
- * @type {(node: XastNode, selector: string) => Array<XastChild>}
+ * @type {(node: Node, selector: string) => Array<ElementContent>}
  */
 const querySelectorAll = (node, selector) => {
   return selectAll(selector, node, cssSelectOptions);
@@ -24,7 +26,7 @@ const querySelectorAll = (node, selector) => {
 exports.querySelectorAll = querySelectorAll;
 
 /**
- * @type {(node: XastNode, selector: string) => null | XastChild}
+ * @type {(node: Node, selector: string) => null | ElementContent}
  */
 const querySelector = (node, selector) => {
   return selectOne(selector, node, cssSelectOptions);
@@ -32,7 +34,7 @@ const querySelector = (node, selector) => {
 exports.querySelector = querySelector;
 
 /**
- * @type {(node: XastChild, selector: string) => boolean}
+ * @type {(node: ElementContent, selector: string) => boolean}
  */
 const matches = (node, selector) => {
   return is(node, selector, cssSelectOptions);
@@ -43,7 +45,9 @@ const visitSkip = Symbol();
 exports.visitSkip = visitSkip;
 
 /**
- * @type {(node: XastNode, visitor: Visitor, parentNode?: any) => void}
+ * @param {Root|RootContent} node
+ * @param {Visitor} visitor
+ * @param {Parents} [parentNode]
  */
 const visit = (node, visitor, parentNode) => {
   const callbacks = visitor[node.type];
@@ -62,7 +66,7 @@ const visit = (node, visitor, parentNode) => {
     }
   }
   // visit element children if still attached to parent
-  if (node.type === 'element') {
+  if (node.type === 'element' && parentNode != null) {
     if (parentNode.children.includes(node)) {
       for (const child of node.children) {
         visit(child, visitor, node);
@@ -77,7 +81,7 @@ const visit = (node, visitor, parentNode) => {
 exports.visit = visit;
 
 /**
- * @type {(node: XastChild, parentNode: XastParent) => void}
+ * @type {(node: ElementContent|RootContent, parentNode: Parents) => void}
  */
 const detachNodeFromParent = (node, parentNode) => {
   // avoid splice to not break for loops

--- a/lib/xast.test.js
+++ b/lib/xast.test.js
@@ -1,14 +1,14 @@
 'use strict';
 
 /**
- * @typedef {import('./types').XastRoot} XastRoot
- * @typedef {import('./types').XastElement} XastElement
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Root} Root
  */
 
 const { visit, visitSkip, detachNodeFromParent } = require('./xast.js');
 
 /**
- * @type {(children: Array<XastElement>) => XastRoot}
+ * @type {(children: Array<Element>) => Root}
  */
 const root = (children) => {
   return { type: 'root', children };
@@ -18,8 +18,8 @@ const root = (children) => {
  * @type {(
  *   name: string,
  *   attrs?: null | Record<string, string>,
- *   children?: Array<XastElement>
- * ) => XastElement}
+ *   children?: Array<Element>
+ * ) => Element}
  */
 const x = (name, attrs = null, children = []) => {
   return { type: 'element', name, attributes: attrs || {}, children };

--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
     "csso": "^5.0.5",
     "picocolors": "^1.0.0"
   },
+  "optionalDependencies": {
+    "@types/xast": "^2.0.1"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
+ * @typedef {import('xast').Element} Element
  * @typedef {import('../lib/types').PathDataItem} PathDataItem
  */
 
@@ -15,7 +15,7 @@ var prevCtrlPoint;
 /**
  * Convert path string to JS representation.
  *
- * @type {(path: XastElement) => Array<PathDataItem>}
+ * @type {(path: Element) => Array<PathDataItem>}
  */
 const path2js = (path) => {
   // @ts-ignore legacy
@@ -24,6 +24,9 @@ const path2js = (path) => {
    * @type {Array<PathDataItem>}
    */
   const pathData = []; // JS representation of the path data
+  if (!path.attributes.d) {
+    return pathData;
+  }
   const newPathData = parsePathData(path.attributes.d);
   for (const { command, args } of newPathData) {
     pathData.push({ command, args });
@@ -179,7 +182,7 @@ const convertRelativeToAbsolute = (data) => {
 /**
  * Convert path array to string.
  *
- * @type {(path: XastElement, data: Array<PathDataItem>, params: Js2PathParams) => void}
+ * @type {(path: Element, data: Array<PathDataItem>, params: Js2PathParams) => void}
  */
 exports.js2path = function (path, data, params) {
   // @ts-ignore legacy

--- a/plugins/addAttributesToSVGElement.js
+++ b/plugins/addAttributesToSVGElement.js
@@ -62,14 +62,12 @@ exports.fn = (root, params) => {
           for (const attribute of attributes) {
             if (typeof attribute === 'string') {
               if (node.attributes[attribute] == null) {
-                // @ts-ignore disallow explicit nullable attribute value
                 node.attributes[attribute] = undefined;
               }
             }
             if (typeof attribute === 'object') {
               for (const key of Object.keys(attribute)) {
                 if (node.attributes[key] == null) {
-                  // @ts-ignore disallow explicit nullable attribute value
                   node.attributes[key] = attribute[key];
                 }
               }

--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -2,7 +2,6 @@
 
 /**
  * @typedef {import('../lib/types').PathDataItem} PathDataItem
- * @typedef {import('../lib/types').XastElement} XastElement
  */
 
 const { collectStylesheet, computeStyle } = require('../lib/style.js');
@@ -57,7 +56,7 @@ const applyTransforms = (root, params) => {
           node.attributes.style != null ||
           Object.entries(node.attributes).some(
             ([name, value]) =>
-              referencesProps.includes(name) && value.includes('url(')
+              referencesProps.includes(name) && value && value.includes('url(')
           )
         ) {
           return;

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -12,7 +12,6 @@ const regSpaces = /\s{2,}/g;
  * Cleanup attributes values from newlines, trailing and repeating spaces.
  *
  * @author Kir Belevich
- *
  * @type {import('./plugins-types').Plugin<'cleanupAttrs'>}
  */
 exports.fn = (root, params) => {
@@ -21,27 +20,30 @@ exports.fn = (root, params) => {
     element: {
       enter: (node) => {
         for (const name of Object.keys(node.attributes)) {
+          let value = node.attributes[name];
+
+          if (value == null) {
+            delete node.attributes[name];
+            continue;
+          }
+
           if (newlines) {
             // new line which requires a space instead of themselve
-            node.attributes[name] = node.attributes[name].replace(
+            value = value.replace(
               regNewlinesNeedSpace,
               (match, p1, p2) => p1 + ' ' + p2
             );
             // simple new line
-            node.attributes[name] = node.attributes[name].replace(
-              regNewlines,
-              ''
-            );
+            value = value.replace(regNewlines, '');
           }
           if (trim) {
-            node.attributes[name] = node.attributes[name].trim();
+            value = value.trim();
           }
           if (spaces) {
-            node.attributes[name] = node.attributes[name].replace(
-              regSpaces,
-              ' '
-            );
+            value = value.replace(regSpaces, ' ');
           }
+
+          node.attributes[name] = value;
         }
       },
     },

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -51,6 +51,11 @@ exports.fn = (_root, params) => {
         }
 
         for (const [name, value] of Object.entries(node.attributes)) {
+          if (value == null) {
+            delete node.attributes[name];
+            continue;
+          }
+
           // The `version` attribute is a text string and cannot be rounded
           if (name === 'version') {
             continue;

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastNode} XastNode
+ * @typedef {import('xast').ElementContent} ElementContent
  */
 
 const { inheritableAttrs, elemsGroups } = require('./_collections.js');
@@ -10,7 +10,9 @@ exports.name = 'collapseGroups';
 exports.description = 'collapses useless groups';
 
 /**
- * @type {(node: XastNode, name: string) => boolean}
+ * @param {ElementContent} node
+ * @param {string} name
+ * @returns {boolean}
  */
 const hasAnimatedAttr = (node, name) => {
   if (node.type === 'element') {

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -77,6 +77,11 @@ exports.fn = (_root, params) => {
       enter: (node) => {
         for (const [name, value] of Object.entries(node.attributes)) {
           if (collections.colorsProps.includes(name)) {
+            if (value == null) {
+              delete node.attributes[name];
+              continue;
+            }
+
             let val = value;
 
             // convert colors to currentColor

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -1,9 +1,9 @@
 'use strict';
 
 /**
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Parents} Parents
  * @typedef {import('../lib/types').Specificity} Specificity
- * @typedef {import('../lib/types').XastElement} XastElement
- * @typedef {import('../lib/types').XastParent} XastParent
  */
 
 const csstree = require('css-tree');
@@ -69,7 +69,7 @@ exports.fn = (root, params) => {
   } = params;
 
   /**
-   * @type {Array<{ node: XastElement, parentNode: XastParent, cssAst: csstree.StyleSheet }>}
+   * @type {Array<{ node: Element, parentNode: Parents, cssAst: csstree.StyleSheet }>}
    */
   const styles = [];
   /**
@@ -77,7 +77,7 @@ exports.fn = (root, params) => {
    *   node: csstree.Selector,
    *   item: csstree.ListItem<csstree.CssNode>,
    *   rule: csstree.Rule,
-   *   matchedElements?: Array<XastElement>
+   *   matchedElements?: Array<Element>
    * }>}
    */
   let selectors = [];
@@ -206,7 +206,7 @@ exports.fn = (root, params) => {
           // match selectors
           const selectorText = csstree.generate(selector.item.data);
           /**
-           * @type {Array<XastElement>}
+           * @type {Array<Element>}
            */
           const matchedElements = [];
           try {

--- a/plugins/mergeStyles.js
+++ b/plugins/mergeStyles.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
- * @typedef {import('../lib/types').XastChild} XastChild
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').ElementContent} ElementContent
  */
 
 const { visitSkip, detachNodeFromParent } = require('../lib/xast.js');
@@ -19,7 +19,7 @@ exports.description = 'merge multiple style elements into one';
  */
 exports.fn = () => {
   /**
-   * @type {null | XastElement}
+   * @type {Element | null}
    */
   let firstStyleElement = null;
   let collectedStyles = '';
@@ -82,7 +82,7 @@ exports.fn = () => {
         } else {
           detachNodeFromParent(node, parentNode);
           /**
-           * @type {XastChild}
+           * @type {ElementContent}
            */
           const child = { type: styleContentType, value: collectedStyles };
           // TODO remove legacy parentNode in v4

--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
- * @typedef {import('../lib/types').XastParent} XastParent
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Parents} Parents
  */
 
 const csso = require('csso');
@@ -18,10 +18,10 @@ exports.description = 'minifies styles and removes unused styles';
  * @type {import('./plugins-types').Plugin<'minifyStyles'>}
  */
 exports.fn = (_root, { usage, ...params }) => {
-  /** @type {Map<XastElement, XastParent>} */
+  /** @type {Map<Element, Parents>} */
   const styleElements = new Map();
 
-  /** @type {Array<XastElement>} */
+  /** @type {Array<Element>} */
   const elementsWithStyleAttributes = [];
 
   /** @type {Set<string>} */
@@ -133,6 +133,12 @@ exports.fn = (_root, { usage, ...params }) => {
         for (const node of elementsWithStyleAttributes) {
           // style attribute
           const elemStyle = node.attributes.style;
+
+          if (elemStyle == null) {
+            delete node.attributes.style;
+            continue;
+          }
+
           node.attributes.style = csso.minifyBlock(elemStyle, {
             ...params,
           }).css;

--- a/plugins/moveElemsAttrsToGroup.js
+++ b/plugins/moveElemsAttrsToGroup.js
@@ -71,6 +71,11 @@ exports.fn = (root) => {
               initial = false;
               // collect all inheritable attributes from first child element
               for (const [name, value] of Object.entries(child.attributes)) {
+                if (value == null) {
+                  delete node.attributes[name];
+                  continue;
+                }
+
                 // consider only inheritable attributes
                 if (inheritableAttrs.includes(name)) {
                   commonAttributes.set(name, value);

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -36,7 +36,7 @@ exports.fn = () => {
           node.attributes.transform != null &&
           Object.entries(node.attributes).some(
             ([name, value]) =>
-              referencesProps.includes(name) && value.includes('url(')
+              referencesProps.includes(name) && value && value.includes('url(')
           ) === false &&
           node.children.every(
             (child) =>

--- a/plugins/plugins-types.ts
+++ b/plugins/plugins-types.ts
@@ -1,7 +1,8 @@
+import type { Element } from 'xast';
+
 import type {
   Plugin as PluginDef,
   PluginInfo,
-  XastElement,
 } from '../lib/types';
 
 type DefaultPlugins = {
@@ -209,7 +210,7 @@ export type BuiltinsWithOptionalParams = DefaultPlugins & {
     prefix?:
       | boolean
       | string
-      | ((node: XastElement, info: PluginInfo) => string);
+      | ((node: Element, info: PluginInfo) => string);
     delim?: string;
     prefixIds?: boolean;
     prefixClassNames?: boolean;

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -177,11 +177,10 @@ exports.fn = (_root, params, info) => {
         // prefix a href attribute value
         // xlink:href is deprecated, must be still supported
         for (const name of ['href', 'xlink:href']) {
-          if (
-            node.attributes[name] != null &&
-            node.attributes[name].length !== 0
-          ) {
-            const prefixed = prefixReference(prefix, node.attributes[name]);
+          const value = node.attributes[name];
+
+          if (value != null && value.length !== 0) {
+            const prefixed = prefixReference(prefix, value);
             if (prefixed != null) {
               node.attributes[name] = prefixed;
             }
@@ -190,11 +189,10 @@ exports.fn = (_root, params, info) => {
 
         // prefix an URL attribute value
         for (const name of referencesProps) {
-          if (
-            node.attributes[name] != null &&
-            node.attributes[name].length !== 0
-          ) {
-            node.attributes[name] = node.attributes[name].replace(
+          const value = node.attributes[name];
+
+          if (value != null && value.length !== 0) {
+            node.attributes[name] = value.replace(
               /url\((.*?)\)/gi,
               (match, url) => {
                 const prefixed = prefixReference(prefix, url);
@@ -209,11 +207,10 @@ exports.fn = (_root, params, info) => {
 
         // prefix begin/end attribute value
         for (const name of ['begin', 'end']) {
-          if (
-            node.attributes[name] != null &&
-            node.attributes[name].length !== 0
-          ) {
-            const parts = node.attributes[name].split(/\s*;\s+/).map((val) => {
+          const value = node.attributes[name];
+
+          if (value != null && value.length !== 0) {
+            const parts = value.split(/\s*;\s+/).map((val) => {
               if (val.endsWith('.end') || val.endsWith('.start')) {
                 const [id, postfix] = val.split('.');
                 return `${prefixId(prefix, id)}.${postfix}`;

--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -126,6 +126,11 @@ exports.fn = (root, params) => {
           if (list[0].test(node.name)) {
             // loop attributes
             for (const [name, value] of Object.entries(node.attributes)) {
+              if (value == null) {
+                delete node.attributes[name];
+                continue;
+              }
+
               const isFillCurrentColor =
                 preserveCurrentColor &&
                 name == 'fill' &&

--- a/plugins/removeEditorsNSData.js
+++ b/plugins/removeEditorsNSData.js
@@ -33,6 +33,11 @@ exports.fn = (_root, params) => {
         // collect namespace aliases from svg element
         if (node.name === 'svg') {
           for (const [name, value] of Object.entries(node.attributes)) {
+            if (value == null) {
+              delete node.attributes[name];
+              continue;
+            }
+
             if (name.startsWith('xmlns:') && namespaces.includes(value)) {
               prefixes.push(name.slice('xmlns:'.length));
               // <svg xmlns:sodipodi="">

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
- * @typedef {import('../lib/types').XastParent} XastParent
+ * @typedef {import('xast').Element} Element
+ * @typedef {import('xast').Parents} Parents
  */
 
 const { elemsGroups, referencesProps } = require('./_collections.js');
@@ -62,7 +62,7 @@ exports.fn = (root, params) => {
    * Skip non-rendered nodes initially, and only detach if they have no ID, or
    * their ID is not referenced by another node.
    *
-   * @type {Map<XastElement, XastParent>}
+   * @type {Map<Element, Parents>}
    */
   const nonRenderedNodes = new Map();
 

--- a/plugins/removeUselessDefs.js
+++ b/plugins/removeUselessDefs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
+ * @typedef {import('xast').Element} Element
  */
 
 const { detachNodeFromParent } = require('../lib/xast.js');
@@ -23,7 +23,7 @@ exports.fn = () => {
       enter: (node, parentNode) => {
         if (node.name === 'defs') {
           /**
-           * @type {Array<XastElement>}
+           * @type {Array<Element>}
            */
           const usefulNodes = [];
           collectUsefulNodes(node, usefulNodes);
@@ -50,7 +50,7 @@ exports.fn = () => {
 };
 
 /**
- * @type {(node: XastElement, usefulNodes: Array<XastElement>) => void}
+ * @type {(node: Element, usefulNodes: Array<Element>) => void}
  */
 const collectUsefulNodes = (node, usefulNodes) => {
   for (const child of node.children) {

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -4,9 +4,7 @@ const { collectStylesheet } = require('../lib/style');
 const { detachNodeFromParent, querySelectorAll } = require('../lib/xast');
 
 /**
- * @typedef {import('../lib/types').XastElement} XastElement
- * @typedef {import('../lib/types').XastParent} XastParent
- * @typedef {import('../lib/types').XastNode} XastNode
+ * @typedef {import('xast').Element} Element
  */
 
 exports.name = 'reusePaths';
@@ -27,7 +25,7 @@ exports.fn = (root) => {
   const stylesheet = collectStylesheet(root);
 
   /**
-   * @type {Map<string, Array<XastElement>>}
+   * @type {Map<string, Array<Element>>}
    */
   const paths = new Map();
 
@@ -35,7 +33,7 @@ exports.fn = (root) => {
    * Reference to the first defs element that is a direct child of the svg
    * element if one exists.
    *
-   * @type {XastElement}
+   * @type {Element}
    * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
    */
   let svgDefs;
@@ -104,7 +102,7 @@ exports.fn = (root) => {
           let index = 0;
           for (const list of paths.values()) {
             if (list.length > 1) {
-              /** @type {XastElement} */
+              /** @type {Element} */
               const reusablePath = {
                 type: 'element',
                 name: 'path',

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * @typedef {import('xast').Attributes} Attributes
+ */
+
 exports.name = 'sortAttrs';
 exports.description = 'Sort element attributes for better compression';
 
@@ -57,7 +61,9 @@ exports.fn = (_root, params) => {
   };
 
   /**
-   * @type {(a: [string, string], b: [string, string]) => number}
+   * @param {[string, unknown]} param0
+   * @param {[string, unknown]} param1
+   * @returns {number}
    */
   const compareAttrs = ([aName], [bName]) => {
     // sort namespaces
@@ -94,9 +100,7 @@ exports.fn = (_root, params) => {
       enter: (node) => {
         const attrs = Object.entries(node.attributes);
         attrs.sort(compareAttrs);
-        /**
-         * @type {Record<string, string>}
-         */
+        /** @type {Attributes} */
         const sortedAttributes = {};
         for (const [name, value] of attrs) {
           sortedAttributes[name] = value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,6 +1039,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/unist@npm:*":
+  version: 3.0.0
+  resolution: "@types/unist@npm:3.0.0"
+  checksum: e9d21a8fb5e332be0acef29192d82632875b2ef3e700f1bc64fdfc1520189542de85c3d4f3bcfbc2f4afdb210f4c23f68061f3fbf10744e920d4f18430d19f49
+  languageName: node
+  linkType: hard
+
+"@types/xast@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@types/xast@npm:2.0.1"
+  dependencies:
+    "@types/unist": "*"
+  checksum: bad184f0a8ffaf574e1e00d8f9a6abfb8cea8384b5575a28a203d2992a58a8eb11857e4a015bd29274a36f34529a3ae1a56534dc499612be6e979afe298bd61c
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 20.2.1
   resolution: "@types/yargs-parser@npm:20.2.1"
@@ -4563,6 +4579,7 @@ __metadata:
     "@types/css-tree": ^2.0.0
     "@types/csso": ^5.0.1
     "@types/jest": ^29.5.5
+    "@types/xast": ^2.0.1
     commander: ^7.2.0
     css-select: ^5.1.0
     css-tree: ^2.2.1
@@ -4580,6 +4597,9 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     tar-stream: ^3.1.6
     typescript: ^4.8.4
+  dependenciesMeta:
+    "@types/xast":
+      optional: true
   bin:
     svgo: ./bin/svgo
   languageName: unknown


### PR DESCRIPTION
Removes our custom type declarations for Xast in favor of the ones suggested by [xast](https://github.com/syntax-tree/xast).

> If you are using TypeScript, you can use the xast types by installing them with npm:
> 
> ```sh
> npm install @types/xast
> ```
> 
> — https://github.com/syntax-tree/xast#types

## Motivation

While it makes sense to declare types of Xast for our plugin API, I think it'd be better to avoid maintaining them as part of this library/application if there are conventional solutions available already.

* Imo it's better to leave maintaining/redistributing them to @DefinitelyTyped, which [Titus Wormer](https://github.com/wooorm) and [Christian Murphy](https://github.com/ChristianMurphy) from syntax/xast helped define.
* The new types more strictly adhere to the Xast spec, which should simplify integrating with Xast libraries in future.

My hope was actually to explore some libraries surrounding Xast, in particular, [xast-util-from-xml](https://github.com/syntax-tree/xast-util-from-xml) and [xast-util-select](https://github.com/TrialAndErrorOrg/xast-util-select). Unfortunately, neither of these meet fulfil our needs atm.

---

Not 100% sure if this is a worthwhile change, so feedback welcome.