### PR TITLE
fix(removeDesc): removeAny should be disabled by default

### DIFF
--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -17,7 +17,7 @@ describeLF('with LF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -34,7 +34,7 @@ describeLF('with LF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -53,7 +53,7 @@ describeLF('with LF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -74,7 +74,7 @@ describeCRLF('with CRLF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -91,7 +91,7 @@ describeCRLF('with CRLF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -110,7 +110,7 @@ describeCRLF('with CRLF line-endings', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -11,7 +11,7 @@ test('allow to setup default preset', () => {
     <?xml version="1.0" encoding="utf-8"?>
     <svg viewBox="0 0 120 120">
       <desc>
-        Not standard description
+        Created with love
       </desc>
       <circle fill="#ff0000" cx="60" cy="60" r="50"/>
     </svg>
@@ -46,7 +46,7 @@ test('allow to disable and customize plugins in preset', () => {
           overrides: {
             removeXMLProcInst: false,
             removeDesc: {
-              removeAny: false,
+              removeAny: true,
             },
           },
         },
@@ -57,9 +57,6 @@ test('allow to disable and customize plugins in preset', () => {
   expect(data).toMatchInlineSnapshot(`
     "<?xml version="1.0" encoding="utf-8"?>
     <svg viewBox="0 0 120 120">
-      <desc>
-        Not standard description
-      </desc>
       <circle cx="60" cy="60" r="50" fill="red"/>
     </svg>
     "
@@ -104,7 +101,7 @@ describe('allow to configure EOL', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -123,7 +120,7 @@ describe('allow to configure EOL', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -142,7 +139,7 @@ describe('allow to configure EOL', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle cx="60" cy="60" fill="#ff0000" r="50"/>
       </svg>
@@ -163,7 +160,7 @@ describe('allow to configure final newline', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle cx="60" cy="60" r="50" fill="#ff0000"/>
       </svg>
@@ -180,7 +177,7 @@ describe('allow to configure final newline', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>
@@ -199,7 +196,7 @@ describe('allow to configure final newline', () => {
       <?xml version="1.0" encoding="utf-8"?>
       <svg viewBox="0 0 120 120">
         <desc>
-          Not standard description
+          Created with love
         </desc>
         <circle fill="#ff0000" cx="60" cy="60" r="50"/>
       </svg>

--- a/plugins/removeDesc.js
+++ b/plugins/removeDesc.js
@@ -19,7 +19,7 @@ const standardDescs = /^(Created with|Created using)/;
  * @type {import('./plugins-types').Plugin<'removeDesc'>}
  */
 exports.fn = (root, params) => {
-  const { removeAny = true } = params;
+  const { removeAny = false } = params;
   return {
     element: {
       enter: (node, parentNode) => {


### PR DESCRIPTION
As the description of the plugin states, it should only remove the description if we can see it's just editor attribution, since this element is used for accessibility.

This behavior was silently changed in the following commit, with no public discussion:

* https://github.com/svg/svgo/commit/055e303607d53a3d539761d8727d86c03b2e88c1#diff-a49dddaf43efeb074adb9f9911b934cc9b359d34c11303c1210929c90284e44bR8

That commit also makes quite a few other controversial changes, including enabling `removeViewBox` by default, which was explicitly disabled a few years prior because it was causing issues for users.

I elaborate on this here:

* https://github.com/svg/svgo/issues/1786#issuecomment-1732401612

In general, accessibility is more important than optimizations, so while I could update the documentation to reflect this behavior, I believe the default should be changed back.