### PR TITLE
fix(removeComments): make preserving comments a param

### DIFF
--- a/plugins/plugins-types.ts
+++ b/plugins/plugins-types.ts
@@ -119,7 +119,9 @@ type DefaultPlugins = {
 
   moveElemsAttrsToGroup: void;
   moveGroupAttrsToElems: void;
-  removeComments: void;
+  removeComments: {
+    preservePatterns: Array<RegExp|string> | false
+  };
   removeDesc: {
     removeAny?: boolean;
   };

--- a/plugins/removeComments.js
+++ b/plugins/removeComments.js
@@ -6,6 +6,12 @@ exports.name = 'removeComments';
 exports.description = 'removes comments';
 
 /**
+ * If a comment matches one of the following patterns, it will be
+ * preserved by default. Particularly for copyright/license information.
+ */
+const DEFAULT_PRESERVE_PATTERNS = [/^!/];
+
+/**
  * Remove comments.
  *
  * @example
@@ -16,13 +22,29 @@ exports.description = 'removes comments';
  *
  * @type {import('./plugins-types').Plugin<'removeComments'>}
  */
-exports.fn = () => {
+exports.fn = (_root, params) => {
+  const { preservePatterns = DEFAULT_PRESERVE_PATTERNS } = params;
+
   return {
     comment: {
       enter: (node, parentNode) => {
-        if (node.value.charAt(0) !== '!') {
-          detachNodeFromParent(node, parentNode);
+        if (preservePatterns) {
+          if (!Array.isArray(preservePatterns)) {
+            throw Error(
+              `Expected array in removeComments preservePatterns parameter but received ${preservePatterns}`
+            );
+          }
+
+          const matches = preservePatterns.some((pattern) => {
+            return new RegExp(pattern).test(node.value);
+          });
+
+          if (matches) {
+            return;
+          }
         }
+
+        detachNodeFromParent(node, parentNode);
       },
     },
   };

--- a/test/plugins/removeComments.03.svg
+++ b/test/plugins/removeComments.03.svg
@@ -5,7 +5,10 @@
 
 @@@
 
-<!--!Icon Font v1 by @iconfont - Copyright 2023 Icon Font CIC.-->
 <svg xmlns="http://www.w3.org/2000/svg">
     test
 </svg>
+
+@@@
+
+{"preservePatterns":false}


### PR DESCRIPTION
Converts the hard-coded exception to a param so users can override this behavior to preserve custom patterns or drop the logic altogether.

We retain the existing exception as the default value, as this convention is interpreted across minifiers as important. For example, Font Awesome prefixes their comment with a `!`.

```
<!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
```

However, we also allow users to pass custom patterns, or either `preservePatterns: []` or `preservePatterns: false` to indiscriminately remove comments.

This is completely backward compatible.

I also replaced the `ignored comment` in the tests with something that matches the kind of comment we're expecting to encounter with this prefix.

## Related

* Closes https://github.com/svg/svgo/issues/1811