### PR TITLE
fix(removeScriptElement): collapse a tag propertly

### DIFF
--- a/plugins/removeScriptElement.js
+++ b/plugins/removeScriptElement.js
@@ -49,7 +49,6 @@ exports.fn = () => {
             continue;
           }
 
-          detachNodeFromParent(node, parentNode);
           const index = parentNode.children.indexOf(node);
           parentNode.children.splice(index, 1, ...node.children);
 

--- a/test/plugins/removeScriptElement.04.svg
+++ b/test/plugins/removeScriptElement.04.svg
@@ -1,0 +1,23 @@
+If making different modifications to two different nodes in the same parent,
+drop attributes and collapse nodes approriately without losing elements.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" version="1.1">
+  <script>alert('uwu')</script>
+  <g onclick="alert('uwu')">
+    <text y="10">uwu</text>
+  </g>
+  <a href="javascript:(() => { alert('uwu') })();">
+    <text y="20">uwu</text>
+  </a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" version="1.1">
+    <g>
+        <text y="10">uwu</text>
+    </g>
+    <text y="20">uwu</text>
+</svg>


### PR DESCRIPTION
When making `removeScriptElement` remove attributes and JavaScript URIs as well, I introduced a bug.

When collapsing, a node's children, there's no need to call `detachNodeFromParent`. This led to dropping more elements we should've.