### PR TITLE
fix: remove hrefs for unconventional namespaces

### DIFF
--- a/plugins/removeScriptElement.js
+++ b/plugins/removeScriptElement.js
@@ -43,23 +43,25 @@ exports.fn = () => {
           return;
         }
 
-        for (const attr of ['href', 'xlink:href']) {
-          if (
-            node.attributes[attr] == null ||
-            !node.attributes[attr].trimStart().startsWith('javascript:')
-          ) {
-            continue;
-          }
+        for (const attr of Object.keys(node.attributes)) {
+          if (attr === 'href' || attr.endsWith(':href')) {
+            if (
+              node.attributes[attr] == null ||
+              !node.attributes[attr].trimStart().startsWith('javascript:')
+            ) {
+              continue;
+            }
 
-          const index = parentNode.children.indexOf(node);
-          parentNode.children.splice(index, 1, ...node.children);
+            const index = parentNode.children.indexOf(node);
+            parentNode.children.splice(index, 1, ...node.children);
 
-          // TODO remove legacy parentNode in v4
-          for (const child of node.children) {
-            Object.defineProperty(child, 'parentNode', {
-              writable: true,
-              value: parentNode,
-            });
+            // TODO remove legacy parentNode in v4
+            for (const child of node.children) {
+              Object.defineProperty(child, 'parentNode', {
+                writable: true,
+                value: parentNode,
+              });
+            }
           }
         }
       },

--- a/test/plugins/removeScriptElement.05.svg
+++ b/test/plugins/removeScriptElement.05.svg
@@ -1,0 +1,19 @@
+Removes hrefs to JavaScript URIs, including unconventional namespaces.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" version="1.1">
+  <a href="javascript:(() => { alert('uwu') })();">
+    <text y="20">uwu</text>
+  </a>
+  <a uwu:href="javascript:(() => { alert('uwu') })();">
+    <text y="30">uwu</text>
+  </a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" version="1.1">
+    <text y="20">uwu</text>
+    <text y="30">uwu</text>
+</svg>


### PR DESCRIPTION
This was hardcoded to use `href` and `xlink:href` before. Now it checks for attributes ending with `:href` in case the xlink namespace is added with a non-standard name.

I was testing in the browser, and it was possible to bypass the plugin before by adding `xlink` with `xmlns:uwu="http://www.w3.org/1999/xlink"`.