### PR TITLE
chore: fix npm warnings for bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "url": "https://opencollective.com/svgo"
   },
   "main": "./lib/svgo-node.js",
-  "bin": "./bin/svgo",
+  "bin": {
+    "svgo": "bin/svgo"
+  },
   "types": "./lib/svgo.d.ts",
   "files": [
     "bin",


### PR DESCRIPTION
{{ redacted: ignore this, didn't realize this is one of the differences between yarn and npm. }}