### PR TITLE
fix: skip keyframes with webkit prefix

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -88,7 +88,10 @@ const parseStylesheet = (css, dynamic) => {
       return csstreeWalkSkip;
     }
     if (cssNode.type === 'Atrule') {
-      if (cssNode.name === 'keyframes') {
+      if (
+        cssNode.name === 'keyframes' ||
+        cssNode.name === '-webkit-keyframes'
+      ) {
         return csstreeWalkSkip;
       }
       csstree.walk(cssNode, (ruleNode) => {


### PR DESCRIPTION
This resolves the error a user of SVGR ran into.

If an SVG features `keyframes` with the `-webkit` prefix, it would throw an error before. This will treat them the same as regular `keyframes`.

You can see a dated article that explains the use of `@-webkit-keyframes` at the following:
https://webkit.org/blog/324/css-animation-2/

As SVGs/styles still use this property in the wild, it makes sense that we at least not crash when it pops up.

## Related

* Reported in https://github.com/gregberge/svgr/issues/768