### PR TITLE
ci: use and run tests for node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 env:
   FORCE_COLOR: 2
-  NODE: 18
+  NODE: 20
 on:
   push:
     branches:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE }}
           cache: yarn
@@ -44,12 +44,13 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 20
           - 18
           - 16
           - 14
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn


### PR DESCRIPTION
Now that Node v20 is LTS, we should use Node 20 for CI and run tests on a Node v20 environment as well.

I will not remove any of the others yet, but it's worth noting that the following are no longer supported, including security updates:

* Node v14 since April 2023
* Node v16 since September 2023