### PR TITLE
feat(inlineStyles): remove redundant presentation attrs

### DIFF
--- a/docs/03-plugins/inline-styles.mdx
+++ b/docs/03-plugins/inline-styles.mdx
@@ -16,7 +16,7 @@ svgo:
       description: What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo-classes and non-pseudo-elements. 
 ---
 
-Move and merge styles from `<style>` elements to a respective elements `style` attributes.
+Merges styles from `<style>` elements to the `style` attribute of matching elements.
 
 ## Usage
 

--- a/docs/03-plugins/remove-attributes-by-selector.mdx
+++ b/docs/03-plugins/remove-attributes-by-selector.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: removeAttributesBySelector
   parameters:
     selectors:
-      description: This is an array of objects with two properties, <code>selector</code>, and <code>attributes</code>, which represent a CSS selector and the attributes to remove respectively.
+      description: An array of objects with two properties, <code>selector</code>, and <code>attributes</code>, which represent a CSS selector and the attributes to remove respectively.
       default: null
 ---
 

--- a/docs/03-plugins/remove-comments.mdx
+++ b/docs/03-plugins/remove-comments.mdx
@@ -28,6 +28,10 @@ Removing a comment like this may be considered a breach of the license terms, as
 
 <PluginUsage/>
 
+### Parameters
+
+<PluginParams/>
+
 ## Demo
 
 <PluginDemo/>

--- a/docs/03-plugins/remove-empty-text.mdx
+++ b/docs/03-plugins/remove-empty-text.mdx
@@ -5,13 +5,13 @@ svgo:
   defaultPlugin: true
   parameters:
     text:
-      description: Removes empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/text" target="_blank"><code>&lt;text&gt;</code></a> elements.
+      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/text" target="_blank"><code>&lt;text&gt;</code></a> elements.
       default: true
     tspan:
-      description: Removes empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tspan" target="_blank"><code>&lt;tspan&gt;</code></a> elements.
+      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tspan" target="_blank"><code>&lt;tspan&gt;</code></a> elements.
       default: true
     tref:
-      description: Removes empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tref" target="_blank"><code>&lt;tref&gt;</code></a> elements.
+      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tref" target="_blank"><code>&lt;tref&gt;</code></a> elements.
       default: true
 ---
 

--- a/docs/03-plugins/remove-hidden-elems.mdx
+++ b/docs/03-plugins/remove-hidden-elems.mdx
@@ -55,7 +55,7 @@ Remove hidden or invisible elements from the document. This can be elements with
 
 This plugin ignores non-rendering elements, such as [`<clipPath>`](https://developer.mozilla.org/docs/Web/SVG/Element/clipPath) and [`<linearGradient>`](https://developer.mozilla.org/docs/Web/SVG/Element/linearGradient), which still apply regardless of styles, unless they are unused.
 
-Refer to the paremeters for the conditions this plugin looks for. All checks enabled by default.
+Refer to the parameters for the conditions this plugin looks for. All checks enabled by default.
 
 ## Usage
 

--- a/docs/03-plugins/remove-useless-stroke-and-fill.mdx
+++ b/docs/03-plugins/remove-useless-stroke-and-fill.mdx
@@ -17,7 +17,7 @@ svgo:
 
 Removes useless `stroke` and `fill` attributes.
 
-Assigning these attributes can sometimes change nothing in the document. For example, in most cases assigning a `stoke` color is redundant if the elements [`stroke-width`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-width) or [`stroke-opacity`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-opacity) is `0`.
+Assigning these attributes can sometimes change nothing in the document. For example, in most cases assigning a `stroke` color is redundant if the elements [`stroke-width`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-width) or [`stroke-opacity`](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-opacity) is `0`.
 
 ## Usage
 

--- a/lib/style.js
+++ b/lib/style.js
@@ -276,3 +276,19 @@ const computeStyle = (stylesheet, node) => {
   return computedStyles;
 };
 exports.computeStyle = computeStyle;
+
+/**
+ * Determines if the given CSS selector references the given attribute.
+ *
+ * @param {csstree.ListItem<csstree.CssNode>|string} selector
+ * @param {string} attr
+ * @returns {boolean}
+ * @see https://developer.mozilla.org/docs/Web/CSS/Attribute_selectors
+ */
+const containsAttrSelector = (selector, attr) => {
+  const body =
+    typeof selector === 'string' ? selector : csstree.generate(selector.data);
+
+  return new RegExp(`\\[\\s*${attr}`).test(body);
+};
+exports.containsAttrSelector = containsAttrSelector;

--- a/lib/style.js
+++ b/lib/style.js
@@ -278,17 +278,20 @@ const computeStyle = (stylesheet, node) => {
 exports.computeStyle = computeStyle;
 
 /**
- * Determines if the given CSS selector references the given attribute.
+ * Determines if the CSS selector references the given attribute.
  *
  * @param {csstree.ListItem<csstree.CssNode>|string} selector
  * @param {string} attr
  * @returns {boolean}
  * @see https://developer.mozilla.org/docs/Web/CSS/Attribute_selectors
  */
-const containsAttrSelector = (selector, attr) => {
-  const body =
-    typeof selector === 'string' ? selector : csstree.generate(selector.data);
+const includesAttrSelector = (selector, attr) => {
+  const attrSelectorPattern = new RegExp(`\\[\\s*${attr}\\s*[\\]=~|^$*]`, 'i');
 
-  return new RegExp(`\\[\\s*${attr}`).test(body);
+  if (typeof selector === 'string') {
+    return attrSelectorPattern.test(attr);
+  }
+
+  return attrSelectorPattern.test(csstree.generate(selector.data));
 };
-exports.containsAttrSelector = containsAttrSelector;
+exports.includesAttrSelector = includesAttrSelector;

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -306,3 +306,32 @@ it('ignores keyframes atrule', () => {
     },
   });
 });
+
+it('ignores @-webkit-keyframes atrule', () => {
+  const root = parseSvg(`
+      <svg>
+        <style>
+          .a {
+            animation: loading 4s linear infinite;
+          }
+          @-webkit-keyframes loading {
+            0% {
+              stroke-dashoffset: 440;
+            }
+            50% {
+              stroke-dashoffset: 0;
+            }
+          }
+        </style>
+        <rect id="element" class="a" />
+      </svg>
+    `);
+  const stylesheet = collectStylesheet(root);
+  expect(computeStyle(stylesheet, getElementById(root, 'element'))).toEqual({
+    animation: {
+      type: 'static',
+      inherited: false,
+      value: 'loading 4s linear infinite',
+    },
+  });
+});

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -15,7 +15,7 @@ const {
   querySelectorAll,
   detachNodeFromParent,
 } = require('../lib/xast.js');
-const { compareSpecificity, containsAttrSelector } = require('../lib/style');
+const { compareSpecificity, includesAttrSelector } = require('../lib/style');
 const { attrsGroups } = require('./_collections');
 
 exports.name = 'inlineStyles';
@@ -222,7 +222,7 @@ exports.fn = (root, params) => {
                 if (
                   attrsGroups.presentation.includes(property) &&
                   !selectors.some((selector) =>
-                    containsAttrSelector(selector.item, property)
+                    includesAttrSelector(selector.item, property)
                   )
                 ) {
                   delete selectedEl.attributes[property];

--- a/test/plugins/inlineStyles.24.svg
+++ b/test/plugins/inlineStyles.24.svg
@@ -1,0 +1,21 @@
+If we're going to inline styles for property that is also a presentation
+attribute, and that presentation attribute was already defined in the node, we
+can just drop the presentation attribute as it would be overridden by the style
+anyway.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 269 349">
+  <style type="text/css">
+    .a {
+      fill: #059669;
+    }
+  </style>
+  <path class="a" d="M191.5,324.1V355l9.6-31.6A77.49,77.49,0,0,1,191.5,324.1Z" fill="#059669" transform="translate(-57.17 -13.4)"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 269 349">
+    <path d="M191.5,324.1V355l9.6-31.6A77.49,77.49,0,0,1,191.5,324.1Z" transform="translate(-57.17 -13.4)" style="fill:#059669"/>
+</svg>

--- a/test/plugins/inlineStyles.25.svg
+++ b/test/plugins/inlineStyles.25.svg
@@ -1,0 +1,32 @@
+Don't remove the redundant presentation attribute if it's used in a CSS
+selector in a `<style> tag.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+  <style>
+    .a {
+      stroke: red;
+    }
+
+    [stroke] + path {
+      stroke: purple;
+    }
+  </style>
+  <path class="a" d="M10 10h20" stroke="red"/>
+  <path d="M10 20h20"/>
+  <path d="M10 30h20" stroke="yellow"/>
+  <path d="M10 40h20"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+    <style>
+        [stroke]+path{stroke:purple}
+    </style>
+    <path d="M10 10h20" stroke="red" style="stroke:red"/>
+    <path d="M10 20h20"/>
+    <path d="M10 30h20" stroke="yellow"/>
+    <path d="M10 40h20"/>
+</svg>


### PR DESCRIPTION
SVGs can have the same presentation attribute declared redundantly in both the node attributes and `<style>` tag.

This wouldn't break anything, but we can shave off a few more bytes by dropping the attribute in this case. 

We drop the attribute instead of the style because the style has more priority. If we dropped the style, it could be the style of another selector with a lower specificity would be used instead, affecting rendering.

## Chores

* Refactors parts of the `inlineStyles` plugin.
* Creates the `includesAttrSelector` utility, so we don't remove an attribute if that's used as part of a CSS selector elsewhere.
* Adds a test for `@-webkit-keyframes` which was missed on a previous PR.
* Revise some of the documentation.