### PR TITLE
fix(convertPathData): skip if transform overridden in styles

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -33,9 +33,7 @@ const encodeEntity = (char) => {
   return entities[char];
 };
 
-/**
- * @type {Options}
- */
+/** @type {Options} */
 const defaults = {
   doctypeStart: '<!DOCTYPE',
   doctypeEnd: '>',
@@ -58,16 +56,14 @@ const defaults = {
   indent: 4,
   regEntities: /[&'"<>]/g,
   regValEntities: /[&"<>]/g,
-  encodeEntity: encodeEntity,
+  encodeEntity,
   pretty: false,
   useShortTags: true,
   eol: 'lf',
   finalNewline: false,
 };
 
-/**
- * @type {Record<string, string>}
- */
+/** @type {Record<string, string>} */
 const entities = {
   '&': '&amp;',
   "'": '&apos;',
@@ -113,7 +109,7 @@ const stringifySvg = (data, userOptions = {}) => {
     config.textEnd += eol;
   }
   let svg = stringifyNode(data, config, state);
-  if (config.finalNewline && svg.length > 0 && svg[svg.length - 1] !== '\n') {
+  if (config.finalNewline && svg.length > 0 && !svg.endsWith('\n')) {
     svg += eol;
   }
   return svg;

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -176,3 +176,18 @@ const hasScripts = (node) => {
   return eventAttrs.some((attr) => node.attributes[attr] != null);
 };
 exports.hasScripts = hasScripts;
+
+/**
+ * For example, a string that contains one or more of following would match and
+ * return true:
+ *
+ * * `url(#gradient001)`
+ * * `url('#gradient001')`
+ *
+ * @param {string} body
+ * @returns {boolean} If the given string includes a URL reference.
+ */
+const includesUrlReference = (body) => {
+  return /\burl\((["'])?#(.+?)\1\)/g.test(body);
+};
+exports.includesUrlReference = includesUrlReference;

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { pathElems, referencesProps } = require('./_collections.js');
+const { includesUrlReference } = require('../lib/svgo/tools.js');
 
 exports.name = 'moveGroupAttrsToElems';
 exports.description = 'moves some group attributes to the content elements';
@@ -36,7 +37,7 @@ exports.fn = () => {
           node.attributes.transform != null &&
           Object.entries(node.attributes).some(
             ([name, value]) =>
-              referencesProps.includes(name) && value.includes('url(')
+              referencesProps.includes(name) && includesUrlReference(value)
           ) === false &&
           node.children.every(
             (child) =>


### PR DESCRIPTION
If a node has transforms applied via both the SVG `transform` attribute and the CSS `transform` property in a `<style>` node, then skip it.

The current implementation doesn't handle this correctly and breaks SVGs. Until we have a solution for this, we should drop the logic in this scenario.

## Chores

* Fixed a typo in a comment, `graniends` → `gradients`
* Created a `includesUrlReference` utility that we can use across plugins.
* Makes `moveGroupAttrsToElems` and `applyTransforms` use `includesUrlReference` which is more robust.

## Related

* Problem found in https://github.com/gregberge/svgr/issues/768