### PR TITLE
fix(inlineStyles): dont remove wrapper class if traversed

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -14,6 +14,7 @@
  */
 
 const csstree = require('css-tree');
+const csswhat = require('css-what');
 const {
   // @ts-ignore internal api
   syntax: { specificity },
@@ -278,20 +279,55 @@ const computeStyle = (stylesheet, node) => {
 exports.computeStyle = computeStyle;
 
 /**
- * Determines if the CSS selector references the given attribute.
+ * Determines if the CSS selector includes or traverses the given attribute.
+ *
+ * Classes and IDs are generated as attribute selectors, so you can check for
+ * if a `.class` or `#id` is included by passing `name=class` or `name=id`
+ * respectively.
  *
  * @param {csstree.ListItem<csstree.CssNode>|string} selector
- * @param {string} attr
+ * @param {string} name
+ * @param {?string} value
+ * @param {boolean} traversed
  * @returns {boolean}
- * @see https://developer.mozilla.org/docs/Web/CSS/Attribute_selectors
  */
-const includesAttrSelector = (selector, attr) => {
-  const attrSelectorPattern = new RegExp(`\\[\\s*${attr}\\s*[\\]=~|^$*]`, 'i');
+const includesAttrSelector = (
+  selector,
+  name,
+  value = null,
+  traversed = false
+) => {
+  const selectors =
+    typeof selector === 'string'
+      ? csswhat.parse(selector)
+      : csswhat.parse(csstree.generate(selector.data));
 
-  if (typeof selector === 'string') {
-    return attrSelectorPattern.test(attr);
+  for (const subselector of selectors) {
+    const hasAttrSelector = subselector.some((segment, index) => {
+      if (traversed) {
+        if (index === subselector.length - 1) {
+          return false;
+        }
+
+        const isNextTraversal = csswhat.isTraversal(subselector[index + 1]);
+
+        if (!isNextTraversal) {
+          return false;
+        }
+      }
+
+      if (segment.type !== 'attribute' || segment.name !== name) {
+        return false;
+      }
+
+      return value == null ? true : segment.value === value;
+    });
+
+    if (hasAttrSelector) {
+      return true;
+    }
   }
 
-  return attrSelectorPattern.test(csstree.generate(selector.data));
+  return false;
 };
 exports.includesAttrSelector = includesAttrSelector;

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "commander": "^7.2.0",
     "css-select": "^5.1.0",
     "css-tree": "^2.2.1",
+    "css-what": "^6.1.0",
     "csso": "5.0.5",
     "picocolors": "^1.0.0"
   },

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -299,7 +299,12 @@ exports.fn = (root, params) => {
             );
 
             for (const child of selector.node.children) {
-              if (child.type === 'ClassSelector') {
+              if (
+                child.type === 'ClassSelector' &&
+                !selectors.some((selector) =>
+                  includesAttrSelector(selector.item, 'class', child.name, true)
+                )
+              ) {
                 classList.delete(child.name);
               }
             }

--- a/test/plugins/inlineStyles.26.svg
+++ b/test/plugins/inlineStyles.26.svg
@@ -1,0 +1,32 @@
+Don't remove the class from a wrapper element if it's traversed in another
+selector.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 35">
+  <style>
+    .a {}
+
+    .a .b {
+      fill: none;
+      stroke: #000;
+    }
+  </style>
+  <g class="a">
+    <circle class="b" cx="42.97" cy="24.92" r="1.14"/>
+    <path class="b" d="M26,31s11.91-1.31,15.86-5.64"/>
+  </g>
+</svg>
+
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 35">
+    <style>
+        .a .b{fill:none;stroke:#000}
+    </style>
+    <g class="a">
+        <circle class="b" cx="42.97" cy="24.92" r="1.14"/>
+        <path class="b" d="M26,31s11.91-1.31,15.86-5.64"/>
+    </g>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,7 @@ __metadata:
     commander: ^7.2.0
     css-select: ^5.1.0
     css-tree: ^2.2.1
+    css-what: ^6.1.0
     csso: 5.0.5
     del: ^6.0.0
     eslint: ^8.24.0


### PR DESCRIPTION
Inline Styles would remove the class from a node after inlining the styles. However, this would break vectors if that class was still needed by another vector though traversal.

For example:

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 35">
  <style>
    .a {}

    .c {}

    .a .b {
      fill: none;
      stroke: #000;
    }
  </style>
  <g class="a c">
    <circle class="b" cx="42.97" cy="24.92" r="1.14"/>
    <path class="b" d="M26,31s11.91-1.31,15.86-5.64"/>
  </g>
</svg>
```

We can inline `.a`, however, by removing the `class="a"` on the group, `.a .b` no longer selects the `circle` and `path` nodes.

This preserves that class if it's traversed in another selector. The class `c` is still removed.

## Notes

* Despite adding a dependency on `css-what`, it's worth noting we already depend on it, as it's a dependency of `css-select`. This has no impact on the package/bundle size.

## Metrics

Tested using `preset-default` of each respective version.

| [SVG](https://github.com/svg/svgo/issues/1077#issue-401094272) | time | % reduced | final size | borked |
|---|---|---|---|---|
| Original | | | 3.395 KiB |
| v3.0.3 | 38 ms | 47.1% | 1.797 KiB | borked | 
| main (7e25b62fa7b4295f592fb1301392f28fbbb7dcd9) | 47 ms | 47.6% | 1.777 KiB | borked | 
| this branch | 50 ms | 40.4% | 2.021 KiB | |

## Related

* Closes https://github.com/svg/svgo/issues/1077