### PR TITLE
fix(inlineStyles): dont remove id if traversed in another selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ svgo one.svg two.svg -o one.min.svg two.min.svg
 Process a directory of files recursively with `-f`/`--folder`:
 
 ```sh
-svgo -f ./path/to/folder/with/svg/files -o ./path/to/folder/with/svg/output
+svgo -f path/to/directory_with_svgs -o path/to/output_directory
 ```
 
 Help for advanced usage:
@@ -48,7 +48,7 @@ svgo --help
 
 SVGO has a plugin architecture. You can read more about all plugins in [Plugins | SVGO Documentation](https://svgo.dev/docs/plugins/), and the default plugins in [Preset Default | SVGO Documentation](https://svgo.dev/docs/preset-default/).
 
-SVGO reads the configuration from `svgo.config.js` or the `--config {{path/to/config.js}}` command-line option. Some other parameters can be configured though command-line options too.
+SVGO reads the configuration from `svgo.config.js` or the `--config path/to/config.js` command-line option. Some other parameters can be configured though command-line options too.
 
 **`svgo.config.js`**
 ```js
@@ -88,7 +88,7 @@ module.exports = {
           // disable a default plugin
           removeViewBox: false,
 
-          // customize the options of a default plugin
+          // customize the params of a default plugin
           inlineStyles: {
             onlyMatchedOnce: false,
           }

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -318,9 +318,16 @@ exports.fn = (root, params) => {
             // ID
             const firstSubSelector = selector.node.children.first;
             if (
-              firstSubSelector != null &&
-              firstSubSelector.type === 'IdSelector' &&
-              selectedEl.attributes.id === firstSubSelector.name
+              firstSubSelector?.type === 'IdSelector' &&
+              selectedEl.attributes.id === firstSubSelector.name &&
+              !selectors.some((selector) =>
+                includesAttrSelector(
+                  selector.item,
+                  'id',
+                  firstSubSelector.name,
+                  true
+                )
+              )
             ) {
               delete selectedEl.attributes.id;
             }


### PR DESCRIPTION
This PR is similar to https://github.com/svg/svgo/pull/1832, but for IDs rather than classes. We shouldn't remove the ID of the node if the ID is traversed in another CSS selector.

## Chores

Includes minor rewording to the README, this is an extension to https://github.com/svg/svgo/pull/1835.

## Related

* Closes https://github.com/svg/svgo/issues/952