### PR TITLE
docs: add params section to remove xlink docs

### DIFF
--- a/docs/03-plugins/remove-xlink.mdx
+++ b/docs/03-plugins/remove-xlink.mdx
@@ -38,6 +38,10 @@ This replaces XLink with features that are only supported in the SVGO 2 spec, an
 
 <PluginUsage/>
 
+### Parameters
+
+<PluginParams/>
+
 ## Demo
 
 <PluginDemo/>


### PR DESCRIPTION
Minor change to show the params heading in the new Remove XLink plugin. I forgot to add it when introducing the param in the Remove XLink plugin.

The way we do it now is a bit messy and error-prone, so I'll look more into if we can safely detect and add the header while automatically updating the ToC.