### PR TITLE
Added collapseText plugin.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/docs/03-plugins/collapse-text.mdx
+++ b/docs/03-plugins/collapse-text.mdx
@@ -1,0 +1,23 @@
+---
+title: Collapse Text
+svgo:
+  pluginId: collapseText
+  defaultPlugin: false
+---
+
+Finds `<text>` elements which contain a single child, of type `<tspan>` and collapses them by:
+- removing the `<tspan>` element
+- making all children of the `<tspan>` element children of the `<text>` element
+- copying all attributes of the `<tspan>` element to the `<text>` element
+
+The elements are not collapsed if any of the following are true:
+- The document contains a `<style>` element
+- Either the `<text>` or `<tspan>` element contains a style attribute
+
+## Usage
+
+<PluginUsage/>
+
+## Implementation
+
+* https://github.com/svg/svgo/blob/main/plugins/collapseText.js

--- a/lib/builtin.js
+++ b/lib/builtin.js
@@ -10,6 +10,7 @@ exports.builtin = [
   require('../plugins/cleanupListOfValues.js'),
   require('../plugins/cleanupNumericValues.js'),
   require('../plugins/collapseGroups.js'),
+  require('../plugins/collapseText.js'),
   require('../plugins/convertColors.js'),
   require('../plugins/convertEllipseToCircle.js'),
   require('../plugins/convertOneStopGradients.js'),

--- a/plugins/collapseText.js
+++ b/plugins/collapseText.js
@@ -10,12 +10,6 @@ exports.name = 'collapseText';
 exports.description = 'merges tspan into text parent if possible';
 
 /**
- * @type {Map<XastElement, XastElement>}
- */
-let tspansToCollapse;
-let deoptimized = false;
-
-/**
  * If <text> has a single child of type <tspan>, remove the <tspan> element and make it's children
  * children of <text>.
  *
@@ -25,6 +19,12 @@ let deoptimized = false;
  */
 
 exports.fn = () => {
+  /**
+   * @type {Map<XastElement, XastElement>}
+   */
+  let tspansToCollapse = new Map();
+  let deoptimized = false;
+
   return {
     element: {
       enter: (node, parentNode) => {
@@ -56,10 +56,6 @@ exports.fn = () => {
     },
 
     root: {
-      enter: () => {
-        deoptimized = false;
-        tspansToCollapse = new Map();
-      },
       exit: () => {
         if (deoptimized) {
           return;

--- a/plugins/collapseText.js
+++ b/plugins/collapseText.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * @typedef {import('../lib/types').XastElement} XastElement
+ */
+
+const { detachNodeFromParent, visitSkip } = require('../lib/xast.js');
+
+exports.name = 'collapseText';
+exports.description = 'merges tspan into text parent if possible';
+
+/**
+ * @type {Map<XastElement, XastElement>}
+ */
+let tspansToCollapse;
+let deoptimized = false;
+
+/**
+ * If <text> has a single child of type <tspan>, remove the <tspan> element and make it's children
+ * children of <text>.
+ *
+ * @author John Kenny
+ *
+ * @type {import('./plugins-types').Plugin<'collapseText'>}
+ */
+
+exports.fn = () => {
+  return {
+    element: {
+      enter: (node, parentNode) => {
+        // Don't collapse if styles are present.
+        if (node.name === 'style' && node.children.length !== 0) {
+          deoptimized = true;
+        }
+        if (deoptimized) {
+          return visitSkip;
+        }
+
+        // Merge only if <text> contains a single child, of type <tspan>.
+        if (
+          node.name !== 'tspan' ||
+          parentNode.type !== 'element' ||
+          parentNode.name !== 'text' ||
+          parentNode.children.length !== 1
+        ) {
+          return;
+        }
+
+        // If either the <text> or <tspan> has a style attribute, don't collapse.
+        if (node.attributes['style'] || parentNode.attributes['style']) {
+          return;
+        }
+
+        tspansToCollapse.set(node, parentNode);
+      },
+    },
+
+    root: {
+      enter: () => {
+        deoptimized = false;
+        tspansToCollapse = new Map();
+      },
+      exit: () => {
+        if (deoptimized) {
+          return;
+        }
+        for (const [node, parentNode] of tspansToCollapse) {
+          // Move <tspan> children to parent.
+          detachNodeFromParent(node, parentNode);
+          parentNode.children = node.children;
+
+          // Overwrite <text> attributes with <tspan> attributes.
+          for (const [name, value] of Object.entries(node.attributes)) {
+            parentNode.attributes[name] = value;
+          }
+        }
+      },
+    },
+  };
+};

--- a/plugins/plugins-types.ts
+++ b/plugins/plugins-types.ts
@@ -25,6 +25,7 @@ type DefaultPlugins = {
     convertToPx?: boolean;
   };
   collapseGroups: void;
+  collapseText: void;
   convertColors: {
     currentColor?: boolean | string | RegExp;
     names2hex?: boolean;
@@ -127,13 +128,13 @@ type DefaultPlugins = {
      * Advanced optimizations
      */
     usage?:
-      | boolean
-      | {
-          force?: boolean;
-          ids?: boolean;
-          classes?: boolean;
-          tags?: boolean;
-        };
+    | boolean
+    | {
+      force?: boolean;
+      ids?: boolean;
+      classes?: boolean;
+      tags?: boolean;
+    };
   };
 
   moveElemsAttrsToGroup: void;
@@ -229,9 +230,9 @@ export type BuiltinsWithOptionalParams = DefaultPlugins & {
   };
   prefixIds: {
     prefix?:
-      | boolean
-      | string
-      | ((node: XastElement, info: PluginInfo) => string);
+    | boolean
+    | string
+    | ((node: XastElement, info: PluginInfo) => string);
     delim?: string;
     prefixIds?: boolean;
     prefixClassNames?: boolean;

--- a/test/plugins/collapseText.01.svg
+++ b/test/plugins/collapseText.01.svg
@@ -1,0 +1,14 @@
+Collapse single <tspan> child of <text>
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan x="64" y="64">this is a test</tspan></text>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve">this is a test</text>
+</svg>

--- a/test/plugins/collapseText.02.svg
+++ b/test/plugins/collapseText.02.svg
@@ -1,0 +1,13 @@
+Collapse single <tspan> child of <text>, where single <tspan> has multiple children.
+
+===
+
+<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+ <text x="56.571426" y="93.266411" fill="#0000ff" font-size="3.175px" stroke-width=".26458" xml:space="preserve"><tspan x="56.571426" y="93.266411" stroke-width=".26458">This is <tspan font-family="Arial" font-weight="bold">some</tspan> <tspan fill="#ff0000">text</tspan></tspan></text>
+</svg>
+
+@@@
+
+<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+    <text x="56.571426" y="93.266411" fill="#0000ff" font-size="3.175px" stroke-width=".26458" xml:space="preserve">This is <tspan font-family="Arial" font-weight="bold">some</tspan> <tspan fill="#ff0000">text</tspan></text>
+</svg>

--- a/test/plugins/collapseText.03.svg
+++ b/test/plugins/collapseText.03.svg
@@ -1,0 +1,18 @@
+Do not collapse if styles are present.
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan  x="64" y="64">this is a test</tspan></text>
+		<style>tspan { stroke:red;}</style>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve"><tspan x="64" y="64">this is a test</tspan></text>
+    <style>
+        tspan { stroke:red;}
+    </style>
+</svg>

--- a/test/plugins/collapseText.04.svg
+++ b/test/plugins/collapseText.04.svg
@@ -1,0 +1,15 @@
+Move attributes from <tspan> to <text>.
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="32" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan x="64" y="128">this is a test</tspan></text>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve" y="128">this is a test</text>
+</svg>
+

--- a/test/plugins/collapseText.05.svg
+++ b/test/plugins/collapseText.05.svg
@@ -1,0 +1,14 @@
+Collapse single <tspan> child of <text>
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan x="64" y="64" style="stroke:red;">this is a test</tspan></text>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve"><tspan x="64" y="64" style="stroke:red;">this is a test</tspan></text>
+</svg>


### PR DESCRIPTION
Resolves #964

If a `<text>` element has a single child, of type `<tspan>`
- remove the `<tspan>`
- make all children of `<tspan>` children of `<text>`
- move all attributes of `<tspan>` to `<text>`

Exceptions: no changes are made if document contains a style element or either text or tspan has a style attribute.