### PR TITLE
feat: Improve loadConfig types

### DIFF
--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -63,4 +63,7 @@ export declare function loadConfig(
   configFile: string,
   cwd?: string
 ): Promise<Config>;
-export declare function loadConfig(): Promise<Config | null>;
+export declare function loadConfig(
+  configFile?: null,
+  cwd?: string
+): Promise<Config | null>;


### PR DESCRIPTION
Improve loadConfig types, fixed like:

```ts

await loadConfig(null, 'webpack context');
await loadConfig(undefined, 'webpack context');
```