### PR TITLE
test failed on Windows

### DIFF
--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -120,7 +120,7 @@ describeCRLF('with CRLF line-endings', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle fill="red" cx="60" cy="60" r="50"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
     );
   });
 });


### PR DESCRIPTION
'should respect line-ending config' failed because parameters were out of order on expected result. CRLF version of the tests was out of sync with LF version.

Fixes #1849 