### PR TITLE
ci: run tests on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,7 @@ jobs:
       - run: yarn install
       - run: yarn test-regression
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} Node.js ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +47,10 @@ jobs:
           - 18
           - 16
           - 14
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
We had an issue where platform-specific tests weren't kept up-to-date since they don't all run in CI, and active maintainers only use Linux/macOS.

This adds windows-latest in the test runners.

Running tests 8 times seems a bit much (build minutes + carbon footprint) but I'm also reluctant to drop Node v14 support until SVGO v4 is released. I'm thinking for now we go with this, but if we run into any problems, I can drop Node v14 support in a minor update instead. (i.e. SVGO v3.1.0)

Both Node v14 and Node v16 are no longer supported, so I think it's sensible to drop them soon. I'd like to take this one at a time though, so starting with Node v14. Node v16 only came out of its support window recently anyway.



## Related

* Found in https://github.com/svg/svgo/pull/1850 and https://github.com/svg/svgo/issues/1849
* Dropping support for Node v14 commented on in https://github.com/svg/svgo/pull/1827