### PR TITLE
fix(convertPathData): handle setting prev properly to fix path joining and #1855

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -828,15 +828,12 @@ function filters(
 
       item.command = command;
       item.args = data;
-
-      prev = item;
     } else {
       // z resets coordinates
       relSubpoint[0] = pathBase[0];
       relSubpoint[1] = pathBase[1];
       // @ts-ignore
       if (prev.command === 'Z' || prev.command === 'z') return false;
-      prev = item;
     }
     if (
       (command === 'Z' || command === 'z') &&
@@ -849,6 +846,7 @@ function filters(
     )
       return false;
 
+    prev = item;
     return true;
   });
 

--- a/test/plugins/convertPathData.29.svg
+++ b/test/plugins/convertPathData.29.svg
@@ -1,0 +1,15 @@
+Should merge M and m, even when Z command is used between.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M1 1m1 1"/>
+  <path fill="black" d="M8.5 12Zm0 8q3.35 0 5.675-2.325"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M2 2"/>
+    <path fill="black" d="M8.5 20q3.35 0 5.675-2.325"/>
+</svg>


### PR DESCRIPTION
I think the issue there is caused by the path joining acting weird because `prev` is set to a nonexistent (filtered out) command. This PR moves where `prev` is set to fix.
Fix #1855