### PR TITLE
chore: apply prettier to all supported file types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,9 +24,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - SVGO Version [e.g. 2.0.3]
- - NodeJs Version [e.g 14.0.4]
- - OS: [e.g. iOS]
- 
+
+- SVGO Version [e.g. 2.0.3]
+- NodeJs Version [e.g 14.0.4]
+- OS: [e.g. iOS]
+
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/plugin_request.md
+++ b/.github/ISSUE_TEMPLATE/plugin_request.md
@@ -4,7 +4,6 @@ about: Suggest a plugin for this project
 title: ''
 labels: 'New plugin'
 assignees: ''
-
 ---
 
 **Is your plugin request related to a problem? Please describe.**
@@ -19,4 +18,5 @@ A clear and concise description of what you want to happen.
 Include any links pointing to relevant specs or general knowledge that may validate your plugin idea.
 
 **Implementation**
+
 - [ ] Are you volunteering to work on this plugin?

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,6 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.3.cjs

--- a/CHANGELOG-old.md
+++ b/CHANGELOG-old.md
@@ -1,533 +1,601 @@
 ### [ [>](https://github.com/svg/svgo/tree/v1.3.2) ] 1.3.2 / 30.10.2019
-* Fixed TypeError: Cannot set property 'multipassCount' of undefined
+
+- Fixed TypeError: Cannot set property 'multipassCount' of undefined
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.3.1) ] 1.3.1 / 29.10.2019
-* Updated CSSO version to 4.0.2 fixing the issue with empty semicolons ";;" in styles (thanks to @strarsis and @lahmatiy).
-* `prefixIds` plugin now runs only once with `--multipass` option (by @strarsis).
-* `cleanupIDs` plugin is prevented from producing a preserved ID, including one which matches a preserved prefix, when minifying (by @thomsj).
+
+- Updated CSSO version to 4.0.2 fixing the issue with empty semicolons ";;" in styles (thanks to @strarsis and @lahmatiy).
+- `prefixIds` plugin now runs only once with `--multipass` option (by @strarsis).
+- `cleanupIDs` plugin is prevented from producing a preserved ID, including one which matches a preserved prefix, when minifying (by @thomsj).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.3.0) ] 1.3.0 / 14.07.2019
-* Custom plugins now can be loaded from external js through `path` plugin param.
-* New plugin `convertEllipseToCircle` to convert ellipse with equal radius measures to circle (by @tigt).
-* New plugin `sortDefsChildren` for improved compression (by @davidleston).
-* SVGO now removes unnecessary spaces after `arcto` path command flags.
-* `removeDimensions` plugin now adds `viewBox` if it's missing (by @adipascu).
-* Fixed `removeUnusedNS` not counting attributes in `<svg>` tag itself.
-* Fixed an issue with incorrect processing multiple images (by @cyberalien).
-* Fixed an error with incorrect converting multiple segmented curve to an arc.
-* Fixed an error with matrix decomposition in `convertTransform` due to rounding error leading to illegal value.
-* Added `force` option for `mergePaths` plugin (by @goyney).
-* Added options to `prefixIds` plugin for selectively prefixing IDs and/or classes (by @strarsis).
-* Exported config function (by @1000ch).
+
+- Custom plugins now can be loaded from external js through `path` plugin param.
+- New plugin `convertEllipseToCircle` to convert ellipse with equal radius measures to circle (by @tigt).
+- New plugin `sortDefsChildren` for improved compression (by @davidleston).
+- SVGO now removes unnecessary spaces after `arcto` path command flags.
+- `removeDimensions` plugin now adds `viewBox` if it's missing (by @adipascu).
+- Fixed `removeUnusedNS` not counting attributes in `<svg>` tag itself.
+- Fixed an issue with incorrect processing multiple images (by @cyberalien).
+- Fixed an error with incorrect converting multiple segmented curve to an arc.
+- Fixed an error with matrix decomposition in `convertTransform` due to rounding error leading to illegal value.
+- Added `force` option for `mergePaths` plugin (by @goyney).
+- Added options to `prefixIds` plugin for selectively prefixing IDs and/or classes (by @strarsis).
+- Exported config function (by @1000ch).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.2.2) ] 1.2.2 / 16.04.2019
-* Update js-yaml for Code Injection warning (by @kaungst).
+
+- Update js-yaml for Code Injection warning (by @kaungst).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.2.1) ] 1.2.1 / 04.04.2019
+
 Some goodness from pull-requests.
-* Bump up js-yaml version to fix DoS vulnerability (by @eugestarr).
+
+- Bump up js-yaml version to fix DoS vulnerability (by @eugestarr).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.2.0) ] 1.2.0 / 24.02.2019
+
 Some goodness from pull-requests.
-* Fixed extra blank lines when processing many files (by @panczarny).
-* Added `--recursive` option to process folders recursively with option `-f` (by @dartess).
-* Added `removeAttributesBySelector` plugin to remove elements matching a css selector (by @bmease).
-* Added `removeOffCanvasPaths` plugin to remove elements outside of the viewbox (by @JoshyPHP).
-* `removeAttrs` plugin: added `preserveCurrentColor` color (by @roblevintennis) and 3rd optional filter for a value (by @Herman-Freund).
-* Added `reusePaths` plugin to replace duplicated elements with link (by @jhowcrof).
-* Added support of comma-separated plugins list in `--disable` and `--enable` options (by @jmwebservices).
-* Added option to preserve IDs based on prefix in `cleanupIDs` plugin (by @bkotzz).
-* Replaced `colors` dependency with `chalk` (by @xPaw).
+
+- Fixed extra blank lines when processing many files (by @panczarny).
+- Added `--recursive` option to process folders recursively with option `-f` (by @dartess).
+- Added `removeAttributesBySelector` plugin to remove elements matching a css selector (by @bmease).
+- Added `removeOffCanvasPaths` plugin to remove elements outside of the viewbox (by @JoshyPHP).
+- `removeAttrs` plugin: added `preserveCurrentColor` color (by @roblevintennis) and 3rd optional filter for a value (by @Herman-Freund).
+- Added `reusePaths` plugin to replace duplicated elements with link (by @jhowcrof).
+- Added support of comma-separated plugins list in `--disable` and `--enable` options (by @jmwebservices).
+- Added option to preserve IDs based on prefix in `cleanupIDs` plugin (by @bkotzz).
+- Replaced `colors` dependency with `chalk` (by @xPaw).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.1.1) ] 1.1.1 / 17.09.2018
-* Fixed crash in `SVGO.optimize()` when ‘info’ is absent.
-* Removed extra space after `cleanupListOfValues` plugin.
+
+- Fixed crash in `SVGO.optimize()` when ‘info’ is absent.
+- Removed extra space after `cleanupListOfValues` plugin.
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.1.0) ] 1.1.0 / 16.09.2018
-* Fixed `collapseGroups` plugin removing property with a child having `inherit` value.
-* `version` attribute value is not more being rounded.
-* Fixed jsAPI `clone` method with respect to the introduced CSS classes.
-* Fixed scaling strokes with `vector-effect="non-scaling-stroke"` (by @alexjlockwood).
-* Fixed passing properties from groups in `collapseGroups` plugin if child have a filter (by @stristr).
-* Fixed arc path commands parsing without separators after flags, effectively producing a JS error.
-* Fixed `viewBox` separators parsing.
-* Fixed `removeNonInheritableGroupAttrs` plugin to work as intended.
-* Fixed removing path segments without length in presence of `stroke-linecap`.
-* Fixed `removeUnknownsAndDefaults` plugin removing attributes from elements with `id`.
-* Fixed converting to large arcs from nearly straight lines curves.
-* Fixed `collapseGroups` plugin affecting `<switch>` and its subgroups.
-* Fixed `convertTransform` plugin converting to `rotate()` with wrong sign in some case.
-* Fixed `cleanupListOfValues` plugin not preserving non-numeric values.
-* Fixed `!important` being passed to attributes in `convertStyleToAttrs` plugin.
-* Added option `keepImportant` to `convertStyleToAttrs` plugin to preserve styles with `!important`.
-* `removeHiddenElems` plugin now also removes elements with `visibility="hidden"` attribute (by @mikolaj92).
-* Added `forceAbsolutePath` option to `convertPathData` plugin to always use absolute coordinates (by @cool).
-* Added `keepRoleAttr` for `removeUnknownsAndDefaults` plugin to preserve `role-` attributes (by @himedlooff).
-* Added `xmlns` order option in `sortAttrs` plugin (by @hellatan).
-* Added an option to `prefixIds` plugin to pass prefix as false or as a function that returns false (by @vzaidman).
-* `prefixIds` plugin now adds prefix to every class (by @vzaidman).
-* Updated and improved docs a bit (multiple authors).
+
+- Fixed `collapseGroups` plugin removing property with a child having `inherit` value.
+- `version` attribute value is not more being rounded.
+- Fixed jsAPI `clone` method with respect to the introduced CSS classes.
+- Fixed scaling strokes with `vector-effect="non-scaling-stroke"` (by @alexjlockwood).
+- Fixed passing properties from groups in `collapseGroups` plugin if child have a filter (by @stristr).
+- Fixed arc path commands parsing without separators after flags, effectively producing a JS error.
+- Fixed `viewBox` separators parsing.
+- Fixed `removeNonInheritableGroupAttrs` plugin to work as intended.
+- Fixed removing path segments without length in presence of `stroke-linecap`.
+- Fixed `removeUnknownsAndDefaults` plugin removing attributes from elements with `id`.
+- Fixed converting to large arcs from nearly straight lines curves.
+- Fixed `collapseGroups` plugin affecting `<switch>` and its subgroups.
+- Fixed `convertTransform` plugin converting to `rotate()` with wrong sign in some case.
+- Fixed `cleanupListOfValues` plugin not preserving non-numeric values.
+- Fixed `!important` being passed to attributes in `convertStyleToAttrs` plugin.
+- Added option `keepImportant` to `convertStyleToAttrs` plugin to preserve styles with `!important`.
+- `removeHiddenElems` plugin now also removes elements with `visibility="hidden"` attribute (by @mikolaj92).
+- Added `forceAbsolutePath` option to `convertPathData` plugin to always use absolute coordinates (by @cool).
+- Added `keepRoleAttr` for `removeUnknownsAndDefaults` plugin to preserve `role-` attributes (by @himedlooff).
+- Added `xmlns` order option in `sortAttrs` plugin (by @hellatan).
+- Added an option to `prefixIds` plugin to pass prefix as false or as a function that returns false (by @vzaidman).
+- `prefixIds` plugin now adds prefix to every class (by @vzaidman).
+- Updated and improved docs a bit (multiple authors).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.5) ] 1.0.5 / 26.02.2018
-* Fixed issue with prefixIDs plugin not replacing url() values correctly (by @harrisjose).
+
+- Fixed issue with prefixIDs plugin not replacing url() values correctly (by @harrisjose).
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.4) ] 1.0.4 / 30.01.2018
-* Fixed bug with removing groups that are direct child of "<switch>".
-* Fixed bug with shorthand path points counting (thanks @alexjlockwood for noticing).
-* Fixed crash on parsing invalid transform, e.g. without close parenthesis.
+
+- Fixed bug with removing groups that are direct child of "<switch>".
+- Fixed bug with shorthand path points counting (thanks @alexjlockwood for noticing).
+- Fixed crash on parsing invalid transform, e.g. without close parenthesis.
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.3) ] 1.0.3 / 08.11.2017
-* Fixed `removeViewBox` plugin to check for zero start coordinates.
-* Removed extra info from STDOUT when it set to output.
+
+- Fixed `removeViewBox` plugin to check for zero start coordinates.
+- Removed extra info from STDOUT when it set to output.
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.2) ] 1.0.2 / 03.11.2017
-* Fixed a couple of errors related to `inlineStyles` plugin.
-* Updated some lost details in documentation to reflect v1.0 changes.
+
+- Fixed a couple of errors related to `inlineStyles` plugin.
+- Updated some lost details in documentation to reflect v1.0 changes.
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.1) ] 1.0.1 / 31.10.2017
-* Fixed error “Object.defineProperty called on non-object” in images with `<foreignObject/>`.
+
+- Fixed error “Object.defineProperty called on non-object” in images with `<foreignObject/>`.
 
 ### [ [>](https://github.com/svg/svgo/tree/v1.0.0) ] 1.0.0 / 30.10.2017
-* SVGO now requires Node 4 or higher.
-* Changed CLI syntax to treat filenames as input, thus allowing `svgo *.svg` syntax.
-* `SVGO.optimize()` now returns `Promise`.
-* Added `datauri` option to JS API.
-* Added support for SVG 2 `href` attribute.
-* `cleanupIDs` now don't removes IDs if an image consists only of `defs`.
-* New plugin `inlineStyles` for converting styles from `<style>` element to attributes if possible (by @strarsis).
-* `cleanupNumericValues` now rounds values in `viewBox` (by @caub).
-* New plugin: `removeScriptElement` (disabled by default) to align with `removeStyleElement` (by @pklingem).
-* `minifyStyles` now removes styles based on usage with controlling options (by @lahmatiy).
-* New option `except` in `cleanupIDs` to keep IDs (by @Velenir).
-* New option `force` in `cleanupIDs` to work even if SVG contains `style` or `script` elements (by @Velenir).
-* Fixed arcs transforming with different signed `scale` parameters (by @JoshyPHP).
-* Fixed `removeUselessStrokeAndFill` to check for `style` or `script` elements per file (by @caub).
-* New option `keepAriaAttrs` in `removeUnknownsAndDefaults` (by @davidtheclark).
-* Corrected parsing in `cleanupIDs` to account animation syntax (by @caub).
-* `#ff0000` now converts to `red` as well as `#f00` (by @davidleston).
-* Added “gray” variation to colors list per CSS Color Module Level 4 (by @ydaniv).
-* Fixed error on empty files.
-* A separator character in `removeAttrs` now can be changed per `elemSeparator` option (by @mikestreety).
-* `addAttributesToSVGElement` now can add values to attributes.
+
+- SVGO now requires Node 4 or higher.
+- Changed CLI syntax to treat filenames as input, thus allowing `svgo *.svg` syntax.
+- `SVGO.optimize()` now returns `Promise`.
+- Added `datauri` option to JS API.
+- Added support for SVG 2 `href` attribute.
+- `cleanupIDs` now don't removes IDs if an image consists only of `defs`.
+- New plugin `inlineStyles` for converting styles from `<style>` element to attributes if possible (by @strarsis).
+- `cleanupNumericValues` now rounds values in `viewBox` (by @caub).
+- New plugin: `removeScriptElement` (disabled by default) to align with `removeStyleElement` (by @pklingem).
+- `minifyStyles` now removes styles based on usage with controlling options (by @lahmatiy).
+- New option `except` in `cleanupIDs` to keep IDs (by @Velenir).
+- New option `force` in `cleanupIDs` to work even if SVG contains `style` or `script` elements (by @Velenir).
+- Fixed arcs transforming with different signed `scale` parameters (by @JoshyPHP).
+- Fixed `removeUselessStrokeAndFill` to check for `style` or `script` elements per file (by @caub).
+- New option `keepAriaAttrs` in `removeUnknownsAndDefaults` (by @davidtheclark).
+- Corrected parsing in `cleanupIDs` to account animation syntax (by @caub).
+- `#ff0000` now converts to `red` as well as `#f00` (by @davidleston).
+- Added “gray” variation to colors list per CSS Color Module Level 4 (by @ydaniv).
+- Fixed error on empty files.
+- A separator character in `removeAttrs` now can be changed per `elemSeparator` option (by @mikestreety).
+- `addAttributesToSVGElement` now can add values to attributes.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.7.2) ] 0.7.2 / 29.01.2017
-* Extended `currentColor` match conditions (string, rx, bool) (by @AlimovSV)
-* Fixed removing `<animate>` in `<stop>`.
-* Fixed removing same transform in inner element in `removeUnknownsAndDefaults`.
-* Fixed collapsing groups with same non-inheritable attribute.
-* Corrected removing of leading zero in case of exponential notation.
+
+- Extended `currentColor` match conditions (string, rx, bool) (by @AlimovSV)
+- Fixed removing `<animate>` in `<stop>`.
+- Fixed removing same transform in inner element in `removeUnknownsAndDefaults`.
+- Fixed collapsing groups with same non-inheritable attribute.
+- Corrected removing of leading zero in case of exponential notation.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.7.1) ] 0.7.1 / 27.09.2016
-* Reverted the requirement of Node.js to version 0.10.
-* Added `addAttributesToSVGElement` to the default config to allow using it with `--enable` option.
-* Added korean translation of “How it works” doc (by @primeiros).
+
+- Reverted the requirement of Node.js to version 0.10.
+- Added `addAttributesToSVGElement` to the default config to allow using it with `--enable` option.
+- Added korean translation of “How it works” doc (by @primeiros).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.7.0) ] 0.7.0 / 25.08.2016
-* Required Node.js version has increased to 0.12.
-* New plugins: `removeElementsByAttr` (by IDs or classes) by @elidupuis,
+
+- Required Node.js version has increased to 0.12.
+- New plugins: `removeElementsByAttr` (by IDs or classes) by @elidupuis,
   `addAttributesToSVGElement` by @gjjones,
   `removeXMLNS` (for SVG inlining) by @ricardobeat.
-* Tests now correctly pass in Windows with CRLF line endings. Pretty print now accounts system line endings.
-* Fixed bugs with collapsing groups with masks and transforms in `collapseGroups`.
-* Fixed bugs with erroneous removing IDs in `cleanupIDs`.
-* Improved attributes sorting in `sortAttrs` by @darktrojan.
-* `addClassesToSVGElement` no more repeats classes (by @ricardobeat).
+- Tests now correctly pass in Windows with CRLF line endings. Pretty print now accounts system line endings.
+- Fixed bugs with collapsing groups with masks and transforms in `collapseGroups`.
+- Fixed bugs with erroneous removing IDs in `cleanupIDs`.
+- Improved attributes sorting in `sortAttrs` by @darktrojan.
+- `addClassesToSVGElement` no more repeats classes (by @ricardobeat).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.6) ] 0.6.6 / 25.04.2016
-* Corrected CSSO API usage
+
+- Corrected CSSO API usage
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.5) ] 0.6.5 / 25.04.2016
-* Extra content inserted by editors are now being removed within `<foreignObject>` as well thus fixing bug “Namespace prefix … is not defined“ after applying SVGO.
-* Doctype with entities declaration is now also being removed since svgo correctly parses them starting from the version [0.6.2](https://github.com/svg/svgo/tree/v0.6.2).
-* Corrected `moveGroupAttrsToElems` not to move attributes to `g` content if it's referenced (has an `id`).
-* `collapseGroups` now don't collapse a group if it has an animated attribute (SMIL).
+
+- Extra content inserted by editors are now being removed within `<foreignObject>` as well thus fixing bug “Namespace prefix … is not defined“ after applying SVGO.
+- Doctype with entities declaration is now also being removed since svgo correctly parses them starting from the version [0.6.2](https://github.com/svg/svgo/tree/v0.6.2).
+- Corrected `moveGroupAttrsToElems` not to move attributes to `g` content if it's referenced (has an `id`).
+- `collapseGroups` now don't collapse a group if it has an animated attribute (SMIL).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.4) ] 0.6.4 / 05.04.2016
-* Fixed bug in “[convertStyleToAttrs](https://github.com/svg/svgo/blob/master/plugins/convertStyleToAttrs.js)” plugin with converting styling properties to non-existent attributes (which are normally removed later by `removeUnknownsAndDefaults`).
-* Added `--indent` option to style pretty-printed SVG. (e.g. `--indent 2`) (by @scurker).
-* Added `currentColor` param to `convertColors` plugin for converting values like `fill` and `stroke` to `currentColor` (by @scurker).
-* Bumped CSSO to the current version and used [its new shiny API](https://github.com/css/csso#api) (thanks to @lahmatiy).
+
+- Fixed bug in “[convertStyleToAttrs](https://github.com/svg/svgo/blob/master/plugins/convertStyleToAttrs.js)” plugin with converting styling properties to non-existent attributes (which are normally removed later by `removeUnknownsAndDefaults`).
+- Added `--indent` option to style pretty-printed SVG. (e.g. `--indent 2`) (by @scurker).
+- Added `currentColor` param to `convertColors` plugin for converting values like `fill` and `stroke` to `currentColor` (by @scurker).
+- Bumped CSSO to the current version and used [its new shiny API](https://github.com/css/csso#api) (thanks to @lahmatiy).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.3) ] 0.6.3 / 20.03.2016
-* Smart rounding (introduced in 0.4.5) now applies only when rounding is needed, thus making subsequent passes more stable.
-* Fixed regression in converting curves to arcs.
-* `xlink:href` references are now being checked by local name `href`, thus correctly working with another namespace prefix.
-* Fixed `id` removing with disabled `plugins/convertStyleToAttrs.js`.
+
+- Smart rounding (introduced in 0.4.5) now applies only when rounding is needed, thus making subsequent passes more stable.
+- Fixed regression in converting curves to arcs.
+- `xlink:href` references are now being checked by local name `href`, thus correctly working with another namespace prefix.
+- Fixed `id` removing with disabled `plugins/convertStyleToAttrs.js`.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.2) ] 0.6.2 / 08.03.2016
-* Better error handling and messaging improvements.
-* SVG files with XML entities (e.g. from Adobe Illustrator) are now correctly being parsed.
-* Fixed error on converting curves to arcs.
-* Corrected rounding in subsequent passes with `--multipass` option.
-* Data URI option now handles charset (by @holymonson)
-* Transformations are no longer moved to group if there is a mask (`plugins/moveElemsAttrsToGroup.js`).
-* Fixed matrix decomposition losing sign in case like `[1, 0, 0, -1, 0, 0]` (`scale(1 -1)`).
-* Fixed crash on uppercased color name.
-* Paths with `id` and without `stroke-width` aren't being transformed now since `stroke-width` may be applied later.
+
+- Better error handling and messaging improvements.
+- SVG files with XML entities (e.g. from Adobe Illustrator) are now correctly being parsed.
+- Fixed error on converting curves to arcs.
+- Corrected rounding in subsequent passes with `--multipass` option.
+- Data URI option now handles charset (by @holymonson)
+- Transformations are no longer moved to group if there is a mask (`plugins/moveElemsAttrsToGroup.js`).
+- Fixed matrix decomposition losing sign in case like `[1, 0, 0, -1, 0, 0]` (`scale(1 -1)`).
+- Fixed crash on uppercased color name.
+- Paths with `id` and without `stroke-width` aren't being transformed now since `stroke-width` may be applied later.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.1) ] 0.6.1 / 21.11.2015
-* Added option `--quiet` to suppress output (by @phihag).
-* Removed `lib-cov` folder from the package, which was erroneously included before.
-* Fixed errors in “[minifyStyles](https://github.com/svg/svgo/blob/master/plugins/minifyStyles.js)” when there are `<style>` elements with `CDATA` content or without content at all.
-* Amended transform functions parsing to prevent errors when there are no separators between numbers (which isn't allowed by syntax, but understood by browsers).
+
+- Added option `--quiet` to suppress output (by @phihag).
+- Removed `lib-cov` folder from the package, which was erroneously included before.
+- Fixed errors in “[minifyStyles](https://github.com/svg/svgo/blob/master/plugins/minifyStyles.js)” when there are `<style>` elements with `CDATA` content or without content at all.
+- Amended transform functions parsing to prevent errors when there are no separators between numbers (which isn't allowed by syntax, but understood by browsers).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.6.0) ] 0.6.0 / 08.11.2015
-* New optimization: circular curves now being converted to arcs. A notable improvement for circles within paths.
-* New plugin “[minifyStyles](https://github.com/svg/svgo/blob/master/plugins/minifyStyles.js)” which minifies `<style>` elements content with CSSO by @strarsis (svgo still doesn't understand its content)
-* New plugin “[removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js)” (disabled by default) by @betsydupuis.
-* Fixed issues with parsing numbers with exponent fraction (could happen with high precision >= 7).
-* Fixed rounding error due to incorrect preserving of precision in transformations.
-* Fixed shorthand curve distortion due to converted previous curve to not a curve.
-* Fixed interoperability issue with `precision` cli-option and `full` config.
-* Fixed an error produced by “[removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)” by @thiakil
-* Another Inkscape prefix namespace is being removed.
-* Fixed an issue in [moveElemsAttrsToGroup“](https://github.com/svg/svgo/blob/master/plugins/moveElemsAttrsToGroup“.js)” with transforms moved around `clip-path`.
+
+- New optimization: circular curves now being converted to arcs. A notable improvement for circles within paths.
+- New plugin “[minifyStyles](https://github.com/svg/svgo/blob/master/plugins/minifyStyles.js)” which minifies `<style>` elements content with CSSO by @strarsis (svgo still doesn't understand its content)
+- New plugin “[removeStyleElement](https://github.com/svg/svgo/blob/master/plugins/removeStyleElement.js)” (disabled by default) by @betsydupuis.
+- Fixed issues with parsing numbers with exponent fraction (could happen with high precision >= 7).
+- Fixed rounding error due to incorrect preserving of precision in transformations.
+- Fixed shorthand curve distortion due to converted previous curve to not a curve.
+- Fixed interoperability issue with `precision` cli-option and `full` config.
+- Fixed an error produced by “[removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)” by @thiakil
+- Another Inkscape prefix namespace is being removed.
+- Fixed an issue in [moveElemsAttrsToGroup“](https://github.com/svg/svgo/blob/master/plugins/moveElemsAttrsToGroup“.js)” with transforms moved around `clip-path`.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.6) ] 0.5.6 / 13.08.2015
-* Fixed paths removing.
+
+- Fixed paths removing.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.5) ] 0.5.5 / 05.08.2015
-* Reverted debugging changes.
+
+- Reverted debugging changes.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.4) ] 0.5.4 / 05.08.2015
-* New parameter `useShortTags` by @bradbarrow. Now svgo can produce correct non-selfclosing tags (useful in HTML in old browsers).
-* Fixed failing on empty transformation (which could be produced by two opposite).
-* Fixed removing paths which have numbers with exponent notation.
-* Fixed a bug with arc transformation.
-* Some typo fixes.
+
+- New parameter `useShortTags` by @bradbarrow. Now svgo can produce correct non-selfclosing tags (useful in HTML in old browsers).
+- Fixed failing on empty transformation (which could be produced by two opposite).
+- Fixed removing paths which have numbers with exponent notation.
+- Fixed a bug with arc transformation.
+- Some typo fixes.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.3) ] 0.5.3 / 21.06.2015
-* Fixed breaking related to rounding functions in “[convertTransform](https://github.com/svg/svgo/blob/master/plugins/convertTransform.js)”.
-* Fixed a bug with ID in animations not being worked on by “[cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js)”.
-* Fixed a bug with quoted reference in `url()`.
-* Now, if there are several same IDs in the document, then the first one is used and others are being removed.
-* New command-line option `--show-plugins` displaying list of plugins.
-* Two new optional plugins: “[removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js)” (removes `width` and `height` if there is `viewBox`) and “[removeAttrsPlugin](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js)” (by @bennyschudel).
+
+- Fixed breaking related to rounding functions in “[convertTransform](https://github.com/svg/svgo/blob/master/plugins/convertTransform.js)”.
+- Fixed a bug with ID in animations not being worked on by “[cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js)”.
+- Fixed a bug with quoted reference in `url()`.
+- Now, if there are several same IDs in the document, then the first one is used and others are being removed.
+- New command-line option `--show-plugins` displaying list of plugins.
+- Two new optional plugins: “[removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js)” (removes `width` and `height` if there is `viewBox`) and “[removeAttrsPlugin](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js)” (by @bennyschudel).
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.2) ] 0.5.2 / 24.05.2015
-* Introduced new `transformPrecision` option for better image quality (defaults to 5) in “[convertTransform](https://github.com/svg/svgo/blob/master/plugins/convertTransform.js)” and “[convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js)” (for the purpose of applying transformations) plugins.
-* Matrix transformations now can be decomposed into a combination of few simple transforms like `translate`, `rotate`, `scale`.
-* Arcs (paths `arcto` command) are now correctly being transformed into another arcs without being converting to Bézier curves.
-* Fixed an issue with “[mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js)” failing to detect paths intersection in some cases.
-* Fixed a bug with “[removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)” removing some paths, which was introduced in [v0.5.1](https://github.com/svg/svgo/tree/v0.5.1).
-* Fixed a bug with transformation having `rotate()` with optional parameters.
-* Patterns with inherited attributes are no longer being removed.
-* Styles are no longer being removed from `<desc>` (by @dennari).
-* SVGO no longer breaks during parsing.
-* Added `clone()` method to JSAPI (by @jakearchibald)
+
+- Introduced new `transformPrecision` option for better image quality (defaults to 5) in “[convertTransform](https://github.com/svg/svgo/blob/master/plugins/convertTransform.js)” and “[convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js)” (for the purpose of applying transformations) plugins.
+- Matrix transformations now can be decomposed into a combination of few simple transforms like `translate`, `rotate`, `scale`.
+- Arcs (paths `arcto` command) are now correctly being transformed into another arcs without being converting to Bézier curves.
+- Fixed an issue with “[mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js)” failing to detect paths intersection in some cases.
+- Fixed a bug with “[removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)” removing some paths, which was introduced in [v0.5.1](https://github.com/svg/svgo/tree/v0.5.1).
+- Fixed a bug with transformation having `rotate()` with optional parameters.
+- Patterns with inherited attributes are no longer being removed.
+- Styles are no longer being removed from `<desc>` (by @dennari).
+- SVGO no longer breaks during parsing.
+- Added `clone()` method to JSAPI (by @jakearchibald)
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.1) ] 0.5.1 / 30.03.2015
-* added new command-line option to set precision in floating point numbers.
-* fixed all known image-disruptive bugs
-* Notably [mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js) plugin now checks for possible intersections to avoid side-effects
-* new plugin [removeUselessDefs](https://github.com/svg/svgo/blob/master/plugins/removeUselessDefs.js) to remove elements in ``<defs>`` and similar non-rendering elements without an ``id`` and thus cannot be used
-* fix for ``--multipass`` command line option (by @dfilatov)
-* improved [cleanupEnableBackground](https://github.com/svg/svgo/blob/master/plugins/cleanupEnableBackground.js) and [convertColors](https://github.com/svg/svgo/blob/master/plugins/convertColors.js) plugins (by @YetiOr)
-* new plugin for image manipulation [cleanupListOfValues](https://github.com/svg/svgo/blob/master/plugins/cleanupListOfValues.js) (by @kiyopikko)
-* fixed fail on comments after closing root ``</svg>`` tag
-* updated parsing to account meaningful spaces in ``<text>``
-* ``data-*`` attributes are now preserved in [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)
-* prevented plugins from failing in ``<foreignObject>``
-* [cleanupNumericValues](https://github.com/svg/svgo/blob/master/plugins/cleanupNumericValues.js) plugin now converts other units to pixels (if it's better)
-* [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) plugin is enabled again with correct work in case of inherited attributes
-* fixed fail on images with incorrect paths like ``<path d="z"/>``
-* svgo now understands if an input is a folder (remember, you can set output to folder as well)
-* added support for some properties from SVG 2 like ``vector-effect="non-scaling-stroke"``
-* removed option to remove an ``id`` on root ``<svg>`` tag in [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js) since it's already being done in [cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js)
+
+- added new command-line option to set precision in floating point numbers.
+- fixed all known image-disruptive bugs
+- Notably [mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js) plugin now checks for possible intersections to avoid side-effects
+- new plugin [removeUselessDefs](https://github.com/svg/svgo/blob/master/plugins/removeUselessDefs.js) to remove elements in `<defs>` and similar non-rendering elements without an `id` and thus cannot be used
+- fix for `--multipass` command line option (by @dfilatov)
+- improved [cleanupEnableBackground](https://github.com/svg/svgo/blob/master/plugins/cleanupEnableBackground.js) and [convertColors](https://github.com/svg/svgo/blob/master/plugins/convertColors.js) plugins (by @YetiOr)
+- new plugin for image manipulation [cleanupListOfValues](https://github.com/svg/svgo/blob/master/plugins/cleanupListOfValues.js) (by @kiyopikko)
+- fixed fail on comments after closing root `</svg>` tag
+- updated parsing to account meaningful spaces in `<text>`
+- `data-*` attributes are now preserved in [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js)
+- prevented plugins from failing in `<foreignObject>`
+- [cleanupNumericValues](https://github.com/svg/svgo/blob/master/plugins/cleanupNumericValues.js) plugin now converts other units to pixels (if it's better)
+- [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) plugin is enabled again with correct work in case of inherited attributes
+- fixed fail on images with incorrect paths like `<path d="z"/>`
+- svgo now understands if an input is a folder (remember, you can set output to folder as well)
+- added support for some properties from SVG 2 like `vector-effect="non-scaling-stroke"`
+- removed option to remove an `id` on root `<svg>` tag in [removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js) since it's already being done in [cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js)
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.5.0) ] 0.5.0 / 05.11.2014
-* added ``--multipass`` command line option which repeatedly applies optimizations like collapsing groups (by @dfilatov)
-* exposed JSAPI as a factory method (by @mistakster)
-* added removeDesc plugin (by @dwabyick), disabled by default
-* [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) plugin is disabled by default since it's unable to check inherited properties
-* transformations now apply to paths with arcs in [plugins/convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js)
-* a lot of bug fixes mostly related to transformations
+
+- added `--multipass` command line option which repeatedly applies optimizations like collapsing groups (by @dfilatov)
+- exposed JSAPI as a factory method (by @mistakster)
+- added removeDesc plugin (by @dwabyick), disabled by default
+- [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) plugin is disabled by default since it's unable to check inherited properties
+- transformations now apply to paths with arcs in [plugins/convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js)
+- a lot of bug fixes mostly related to transformations
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.5) ] 0.4.5 / 02.08.2014
-* significantly improved plugin [plugins/convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js):
-  - Now data is being written relative or absolute whichever is shorter. You can turn it off by setting ``utilizeAbsolute`` to ``false``.
+
+- significantly improved plugin [plugins/convertPathData](https://github.com/svg/svgo/blob/master/plugins/convertPathData.js):
+  - Now data is being written relative or absolute whichever is shorter. You can turn it off by setting `utilizeAbsolute` to `false`.
   - Smarter rounding: values like 2.499 now rounds to 2.5. Rounding now takes in account accumulative error meaning that points will not be misplaced due to rounding more than it necessary.
   - Fixed couple bugs.
-* ``--output`` option now can be a folder along with ``--folder``, thanks to @mako-taco.
-* [plugins/cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js) now have ``prefix`` option in case you want to combine multiple svg later (by @DanielMazurkiewicz).
-* Quotes now being escaped in attributes (by @ditesh).
-* Minor bugfixes.
+- `--output` option now can be a folder along with `--folder`, thanks to @mako-taco.
+- [plugins/cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js) now have `prefix` option in case you want to combine multiple svg later (by @DanielMazurkiewicz).
+- Quotes now being escaped in attributes (by @ditesh).
+- Minor bugfixes.
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.4) ] 0.4.4 / 14.01.2014
-* new plugin [plugins/removeTitle](https://github.com/svg/svgo/blob/master/plugins/removeTitle.js) (disabled by default, close [#159](https://github.com/svg/svgo/issues/159))
-* plugins/convertPathData: skip data concatenation for z instruction in collapseRepeated
-* plugins/removeUnknownsAndDefaults: do not remove overridden attributes with default values (fix [#161](https://github.com/svg/svgo/issues/161) and [#168](https://github.com/svg/svgo/issues/168))
-* plugins/removeViewBox: disable by default (fix [#139](https://github.com/svg/svgo/issues/139))
-* update README with [gulp task](https://github.com/ben-eb/gulp-svgmin)
+
+- new plugin [plugins/removeTitle](https://github.com/svg/svgo/blob/master/plugins/removeTitle.js) (disabled by default, close [#159](https://github.com/svg/svgo/issues/159))
+- plugins/convertPathData: skip data concatenation for z instruction in collapseRepeated
+- plugins/removeUnknownsAndDefaults: do not remove overridden attributes with default values (fix [#161](https://github.com/svg/svgo/issues/161) and [#168](https://github.com/svg/svgo/issues/168))
+- plugins/removeViewBox: disable by default (fix [#139](https://github.com/svg/svgo/issues/139))
+- update README with [gulp task](https://github.com/ben-eb/gulp-svgmin)
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.3) ] 0.4.3 / 02.01.2014
-* new plugin [plugins/convertShapeToPath](https://github.com/svg/svgo/blob/master/plugins/convertShapeToPath.js) (close [#96](https://github.com/svg/svgo/issues/96))
-* update sax version to fix [#140](https://github.com/svg/svgo/issues/140)
-* update deps
+
+- new plugin [plugins/convertShapeToPath](https://github.com/svg/svgo/blob/master/plugins/convertShapeToPath.js) (close [#96](https://github.com/svg/svgo/issues/96))
+- update sax version to fix [#140](https://github.com/svg/svgo/issues/140)
+- update deps
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.2) ] 0.4.2 / 19.12.2013
-* add `lcov.info` to npmignore
-* fix `js-yaml` version to suppress deprecation warning in stdout
+
+- add `lcov.info` to npmignore
+- fix `js-yaml` version to suppress deprecation warning in stdout
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.1) ] 0.4.1 / 18.11.2013
-* node >=0.8.0
+
+- node >=0.8.0
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.4.0) ] 0.4.0 / 18.11.2013
-* merge almost all pull-requests
-* update dependencies
+
+- merge almost all pull-requests
+- update dependencies
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.7) ] 0.3.7 / 24.06.2013
-* do not remove `result` attribute from filter primitives (fix [#122](https://github.com/svg/svgo/issues/122))
-* plugins/cleanupAttrs: replace newline with space when needed (fix [#119](https://github.com/svg/svgo/issues/119))
-* lib/coa: look for config file in current folder
-* lib/coa: always traverse all files in the given folder
-* deprecate svgo-grunt in favor of [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
-* re-enable node-coveralls
+
+- do not remove `result` attribute from filter primitives (fix [#122](https://github.com/svg/svgo/issues/122))
+- plugins/cleanupAttrs: replace newline with space when needed (fix [#119](https://github.com/svg/svgo/issues/119))
+- lib/coa: look for config file in current folder
+- lib/coa: always traverse all files in the given folder
+- deprecate svgo-grunt in favor of [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)
+- re-enable node-coveralls
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.6) ] 0.3.6 / 06.06.2013
-* plugins/removeNonInheritableGroupAttrs: more attrs groups to exclude (fix [#116](https://github.com/svg/svgo/issues/116) & [#118](https://github.com/svg/svgo/issues/118))
-* lib/coa: optimize folder file by file (temp fix [#114](https://github.com/svg/svgo/issues/114))
-* `.jshintrc`: JSHint 2.0
-* temporarily disable node-coveralls
+
+- plugins/removeNonInheritableGroupAttrs: more attrs groups to exclude (fix [#116](https://github.com/svg/svgo/issues/116) & [#118](https://github.com/svg/svgo/issues/118))
+- lib/coa: optimize folder file by file (temp fix [#114](https://github.com/svg/svgo/issues/114))
+- `.jshintrc`: JSHint 2.0
+- temporarily disable node-coveralls
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.5) ] 0.3.5 / 07.05.2013
-* plugins/transformsWithOnePath: fix curves bounding box calculation
-* plugins/transformsWithOnePath: fix possible c+t or q+s bug
 
+- plugins/transformsWithOnePath: fix curves bounding box calculation
+- plugins/transformsWithOnePath: fix possible c+t or q+s bug
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.4) ] 0.3.4 / 06.05.2013
-* plugins/convertPathData: fix m->M bug in some cases
-* plugins/transformsWithOnePath: fix last point calculation for C/S/Q/T
-* plugins/mergePaths: add space delimiter between z and m
+
+- plugins/convertPathData: fix m->M bug in some cases
+- plugins/transformsWithOnePath: fix last point calculation for C/S/Q/T
+- plugins/mergePaths: add space delimiter between z and m
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.3) ] 0.3.3 / 05.05.2013
-* plugins/convertPathData: convert very first m to M, fix applyTransforms with translate() (fix [#112](https://github.com/svg/svgo/issues/112))
-* plugins/transformsWithOnePath: fix real width/height rounding; fix scale transform origin; reorder transforms
-* plugins/transformsWithOnePath: ability to set new width or height independently with auto rescaling
+
+- plugins/convertPathData: convert very first m to M, fix applyTransforms with translate() (fix [#112](https://github.com/svg/svgo/issues/112))
+- plugins/transformsWithOnePath: fix real width/height rounding; fix scale transform origin; reorder transforms
+- plugins/transformsWithOnePath: ability to set new width or height independently with auto rescaling
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.2) ] 0.3.2 / 03.05.2013
-* new plugin [plugins/sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js)
-* plugins/transformsWithOnePath: buggy hcrop (fix [#111](https://github.com/svg/svgo/issues/111))
-* Impossible to set output precision to 0 (no fractional part) (fix [#110](https://github.com/svg/svgo/issues/110))
-* Istanbul + coveralls.io
-* update README with NPM version from badge.fury.io
-* update README with dependency status from gemnasium.com
-* npmignore unneeded files
-* reoptimized project logo
+
+- new plugin [plugins/sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js)
+- plugins/transformsWithOnePath: buggy hcrop (fix [#111](https://github.com/svg/svgo/issues/111))
+- Impossible to set output precision to 0 (no fractional part) (fix [#110](https://github.com/svg/svgo/issues/110))
+- Istanbul + coveralls.io
+- update README with NPM version from badge.fury.io
+- update README with dependency status from gemnasium.com
+- npmignore unneeded files
+- reoptimized project logo
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.1) ] 0.3.1 / 15.04.2013
-* plugins/transformsWithOnePath: resize SVG and automatically rescale inner Path
-* better errors handling
+
+- plugins/transformsWithOnePath: resize SVG and automatically rescale inner Path
+- better errors handling
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.3.0) ] 0.3.0 / 12.04.2013
-* global refactoring: getting rid of the many dependencies
-* new plugin [plugins/mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js)
-* new plugin [plugins/transformsWithOnePath](https://github.com/svg/svgo/blob/master/plugins/transformsWithOnePath.js) (renamed and featured `cropAndCenterAlongPath`)
-* config: replace default config with `full: true`
-* coa: JSON string as value of `--config`
-* coa: different types of Data URI strings (close [#105](https://github.com/svg/svgo/issues/105))
-* plugins/_transforms: allow spaces at the beginning of transform
-* Travis CI: Nodejs 0.10 & 0.11
-* `node.extend` → `whet.extend`
-* update `.gitignore`
-* update docs
+
+- global refactoring: getting rid of the many dependencies
+- new plugin [plugins/mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js)
+- new plugin [plugins/transformsWithOnePath](https://github.com/svg/svgo/blob/master/plugins/transformsWithOnePath.js) (renamed and featured `cropAndCenterAlongPath`)
+- config: replace default config with `full: true`
+- coa: JSON string as value of `--config`
+- coa: different types of Data URI strings (close [#105](https://github.com/svg/svgo/issues/105))
+- plugins/\_transforms: allow spaces at the beginning of transform
+- Travis CI: Nodejs 0.10 & 0.11
+- `node.extend` → `whet.extend`
+- update `.gitignore`
+- update docs
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.2.4) ] 0.2.4 / 05.04.2013
-* new plugin [plugins/cropAndCenterAlongPath](https://github.com/svg/svgo/blob/master/plugins/cropAndCenterAlongPath.js) for the [Fontello](https://github.com/fontello) project
+
+- new plugin [plugins/cropAndCenterAlongPath](https://github.com/svg/svgo/blob/master/plugins/cropAndCenterAlongPath.js) for the [Fontello](https://github.com/fontello) project
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.2.3) ] 0.2.3 / 22.02.2013
-* new plugin [plugins/removeNonInheritableGroupAttrs](https://github.com/svg/svgo/blob/master/plugins/removeNonInheritableGroupAttrs.js) (fix [#101](https://github.com/svg/svgo/issues/101))
-* new plugin [plugins/removeRasterImages](https://github.com/svg/svgo/blob/master/plugins/removeRasterImages.js) (close [#98](https://github.com/svg/svgo/issues/98))
-* plugins/convertTransform: bug with trailing spaces in transform value string (fix [#103](https://github.com/svg/svgo/issues/103))
+
+- new plugin [plugins/removeNonInheritableGroupAttrs](https://github.com/svg/svgo/blob/master/plugins/removeNonInheritableGroupAttrs.js) (fix [#101](https://github.com/svg/svgo/issues/101))
+- new plugin [plugins/removeRasterImages](https://github.com/svg/svgo/blob/master/plugins/removeRasterImages.js) (close [#98](https://github.com/svg/svgo/issues/98))
+- plugins/convertTransform: bug with trailing spaces in transform value string (fix [#103](https://github.com/svg/svgo/issues/103))
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.2.2) ] 0.2.2 / 09.02.2013
-* plugins/convertTransforms: wrong translate() shorthand (fix [#94](https://github.com/svg/svgo/issues/94))
-* [yaml.js](https://github.com/jeremyfa/yaml.js) → [js-yaml](https://github.com/nodeca/js-yaml)
-* update outdated deps
+
+- plugins/convertTransforms: wrong translate() shorthand (fix [#94](https://github.com/svg/svgo/issues/94))
+- [yaml.js](https://github.com/jeremyfa/yaml.js) → [js-yaml](https://github.com/nodeca/js-yaml)
+- update outdated deps
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.2.1) ] 0.2.1 / 18.01.2013
-* plugins/moveElemsAttrsToGroup + plugins/moveGroupAttrsToElems: move or just leave transform attr from Group to the inner Path Elems (close [#86](https://github.com/svg/svgo/issues/86))
-* plugins/removeViewBox: doesn't catch floating-point numbers (fix [#88](https://github.com/svg/svgo/issues/88))
-* plugins/cleanupEnableBackground: doesn't catch floating-point numbers (fix [#89](https://github.com/svg/svgo/issues/89))
-* plugins/cleanupNumericValues: wrong floating-point numbers regexp (fix [#92](https://github.com/svg/svgo/issues/92))
-* SVG file generated by fontcustom.com not properly compressed (fix [#90](https://github.com/svg/svgo/issues/90))
-* `README.ru.md`: стилизация русского языка, улучшение языковых конструкций, правка ошибок (close [#91](https://github.com/svg/svgo/issues/91))
-* minor JSHint warning fix
+
+- plugins/moveElemsAttrsToGroup + plugins/moveGroupAttrsToElems: move or just leave transform attr from Group to the inner Path Elems (close [#86](https://github.com/svg/svgo/issues/86))
+- plugins/removeViewBox: doesn't catch floating-point numbers (fix [#88](https://github.com/svg/svgo/issues/88))
+- plugins/cleanupEnableBackground: doesn't catch floating-point numbers (fix [#89](https://github.com/svg/svgo/issues/89))
+- plugins/cleanupNumericValues: wrong floating-point numbers regexp (fix [#92](https://github.com/svg/svgo/issues/92))
+- SVG file generated by fontcustom.com not properly compressed (fix [#90](https://github.com/svg/svgo/issues/90))
+- `README.ru.md`: стилизация русского языка, улучшение языковых конструкций, правка ошибок (close [#91](https://github.com/svg/svgo/issues/91))
+- minor JSHint warning fix
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.2.0) ] 0.2.0 / 23.12.2012
-* plugins/convertPathData: apply transforms to Path pata (close [#33](https://github.com/svg/svgo/issues/33))
-* plugins/convertPathData: `-1.816-9.278.682-13.604` parsing error (fix [#85](https://github.com/svg/svgo/issues/85))
-* plugins/convertTransform: `translate(10, 0)` eq `translate(10)`, but not `translate(10, 10)` eq `translate(10)` (fix [#83](https://github.com/svg/svgo/issues/83))
-* run plugins/cleanupIDs before plugins/collapseGroups (fix [#84](https://github.com/svg/svgo/issues/84))
-* update `.gitignore`
+
+- plugins/convertPathData: apply transforms to Path pata (close [#33](https://github.com/svg/svgo/issues/33))
+- plugins/convertPathData: `-1.816-9.278.682-13.604` parsing error (fix [#85](https://github.com/svg/svgo/issues/85))
+- plugins/convertTransform: `translate(10, 0)` eq `translate(10)`, but not `translate(10, 10)` eq `translate(10)` (fix [#83](https://github.com/svg/svgo/issues/83))
+- run plugins/cleanupIDs before plugins/collapseGroups (fix [#84](https://github.com/svg/svgo/issues/84))
+- update `.gitignore`
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.9) ] 0.1.9 / 17.12.2012
-* plugins/cleanupIDs: renamed from removeUnusedIDs; minify used IDs (fix [#7](https://github.com/svg/svgo/issues/7))
-* lib/svgo/js2svg: restore HTML entities back (fix [#80](https://github.com/svg/svgo/issues/80) + [#81](https://github.com/svg/svgo/issues/81))
-* plugins/removeDoctype: do not remove if custom XML entities presents (fix [#77](https://github.com/svg/svgo/issues/77))
-* lib/svgo/coa: refactoring, colors and fix [#70](https://github.com/svg/svgo/issues/70)
-* lib/svgo: store elapsed time in result object
-* usage examples with SVGZ (close [#18](https://github.com/svg/svgo/issues/18))
-* more optimized logo
-* update `.gitignore`
+
+- plugins/cleanupIDs: renamed from removeUnusedIDs; minify used IDs (fix [#7](https://github.com/svg/svgo/issues/7))
+- lib/svgo/js2svg: restore HTML entities back (fix [#80](https://github.com/svg/svgo/issues/80) + [#81](https://github.com/svg/svgo/issues/81))
+- plugins/removeDoctype: do not remove if custom XML entities presents (fix [#77](https://github.com/svg/svgo/issues/77))
+- lib/svgo/coa: refactoring, colors and fix [#70](https://github.com/svg/svgo/issues/70)
+- lib/svgo: store elapsed time in result object
+- usage examples with SVGZ (close [#18](https://github.com/svg/svgo/issues/18))
+- more optimized logo
+- update `.gitignore`
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.8) ] 0.1.8 / 11.12.2012
-* new plugin [plugins/removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) (close [#75](https://github.com/svg/svgo/issues/75))
-* new plugin [plugins/removeUnusedIDs](https://github.com/svg/svgo/blob/master/plugins/removeUnusedIDs.js) (close [#76](https://github.com/svg/svgo/issues/76))
-* plugins/convertPathData: wrong M interpretation in some cases (fix [#73](https://github.com/svg/svgo/issues/73))
-* plugins/cleanupAttrs: use `isElem()` API
-* `.travis.yml`: check all branches
 
+- new plugin [plugins/removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) (close [#75](https://github.com/svg/svgo/issues/75))
+- new plugin [plugins/removeUnusedIDs](https://github.com/svg/svgo/blob/master/plugins/removeUnusedIDs.js) (close [#76](https://github.com/svg/svgo/issues/76))
+- plugins/convertPathData: wrong M interpretation in some cases (fix [#73](https://github.com/svg/svgo/issues/73))
+- plugins/cleanupAttrs: use `isElem()` API
+- `.travis.yml`: check all branches
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.7) ] 0.1.7 / 08.12.2012
-* plugins/convertPathData: incorrect interpretation of `z + m` (fix [#69](https://github.com/svg/svgo/issues/69))
-* plugins/convertTransform: do a more accurate floating numbers rounding in `matrixToTransform()` (fix [#68](https://github.com/svg/svgo/issues/68))
+
+- plugins/convertPathData: incorrect interpretation of `z + m` (fix [#69](https://github.com/svg/svgo/issues/69))
+- plugins/convertTransform: do a more accurate floating numbers rounding in `matrixToTransform()` (fix [#68](https://github.com/svg/svgo/issues/68))
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.6) ] 0.1.6 / 07.12.2012
-* plugins/convertPathData: collapse repeated instructions only after curveSmoothShorthands (fix [#64](https://github.com/svg/svgo/issues/64))
-* lib/svgo/coa: handle 'there is nothing to optimize' case and display a message about it (fix [#61](https://github.com/svg/svgo/issues/61))
-* plugins/cleanupSVGElem: delete as useless artefact
 
+- plugins/convertPathData: collapse repeated instructions only after curveSmoothShorthands (fix [#64](https://github.com/svg/svgo/issues/64))
+- lib/svgo/coa: handle 'there is nothing to optimize' case and display a message about it (fix [#61](https://github.com/svg/svgo/issues/61))
+- plugins/cleanupSVGElem: delete as useless artefact
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.5) ] 0.1.5 / 06.12.2012
-* E-notated numbers in paths not recognised (fix [#63](https://github.com/svg/svgo/issues/63))
-* update README with `svgo-grunt` and `svgo-osx-folder-action`
-* fix `mocha-as-promised` plug in node 0.6
+
+- E-notated numbers in paths not recognised (fix [#63](https://github.com/svg/svgo/issues/63))
+- update README with `svgo-grunt` and `svgo-osx-folder-action`
+- fix `mocha-as-promised` plug in node 0.6
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.4) ] 0.1.4 / 05.12.2012
-* plugins/_collections: more defaults
-* `README.ru.md`
-* `docs/how-it-works/ru.md`
-* mocha + mocha-as-promised + chai + chai-as-promised + should + istanbul = <3
-* update dependencies semvers in `package.json`
-* `v0.1.x` and `v0.2.x` milestones
+
+- plugins/\_collections: more defaults
+- `README.ru.md`
+- `docs/how-it-works/ru.md`
+- mocha + mocha-as-promised + chai + chai-as-promised + should + istanbul = <3
+- update dependencies semvers in `package.json`
+- `v0.1.x` and `v0.2.x` milestones
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.3) ] 0.1.3 / 30.11.2012
-* new plugin [plugins/cleanupNumericValues](https://github.com/svg/svgo/blob/master/plugins/cleanupNumericValues.js) (close [#8](https://github.com/svg/svgo/issues/8))
-* plugins/removeDefaultPx functionality now included in plugins/removeUnknownsAndDefaults
-* plugins/removeUnknownsAndDefaults: refactoring and picking up the complete elems+attrs collection (close [#59](https://github.com/svg/svgo/issues/59))
-* plugins/convertTransform: error in matrices multiplication (fix [#58](https://github.com/svg/svgo/issues/58))
-* plugins/convertTransform: mark translate() and scale() as useless only with one param (fix [#57](https://github.com/svg/svgo/issues/57))
-* plugins/convertPathData: drastic speed improvement with huge Path data
-* plugins/convertPathData: fix the very first Mm with multiple points (fix [#56](https://github.com/svg/svgo/issues/56))
-* plugins/moveElemsAttrsToGroup: additional check for transform attr
-* brand-new project `logo.svg`
-* `.travis.yml`: build only master branch
-* global `'use strict'`
-* `.jshintignore`
-* README and CHANGELOG: minor corrections
+
+- new plugin [plugins/cleanupNumericValues](https://github.com/svg/svgo/blob/master/plugins/cleanupNumericValues.js) (close [#8](https://github.com/svg/svgo/issues/8))
+- plugins/removeDefaultPx functionality now included in plugins/removeUnknownsAndDefaults
+- plugins/removeUnknownsAndDefaults: refactoring and picking up the complete elems+attrs collection (close [#59](https://github.com/svg/svgo/issues/59))
+- plugins/convertTransform: error in matrices multiplication (fix [#58](https://github.com/svg/svgo/issues/58))
+- plugins/convertTransform: mark translate() and scale() as useless only with one param (fix [#57](https://github.com/svg/svgo/issues/57))
+- plugins/convertPathData: drastic speed improvement with huge Path data
+- plugins/convertPathData: fix the very first Mm with multiple points (fix [#56](https://github.com/svg/svgo/issues/56))
+- plugins/moveElemsAttrsToGroup: additional check for transform attr
+- brand-new project `logo.svg`
+- `.travis.yml`: build only master branch
+- global `'use strict'`
+- `.jshintignore`
+- README and CHANGELOG: minor corrections
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.2) ] 0.1.2 / 24.11.2012
-* lib/svgo/svg2js: correct 'onerror' failure (fix [#51](https://github.com/svg/svgo/issues/51))
-* config: disable sax-js position tracking by default (fix [#52](https://github.com/svg/svgo/issues/52))
-* lib/svgo: rename 'startBytes' to 'inBytes' and 'endBytes' to 'outBytes' (close [#53](https://github.com/svg/svgo/issues/53))
-* plugins/removeUnknownsAndDefaults: remove SVG id attr (close [#54](https://github.com/svg/svgo/issues/54))
+
+- lib/svgo/svg2js: correct 'onerror' failure (fix [#51](https://github.com/svg/svgo/issues/51))
+- config: disable sax-js position tracking by default (fix [#52](https://github.com/svg/svgo/issues/52))
+- lib/svgo: rename 'startBytes' to 'inBytes' and 'endBytes' to 'outBytes' (close [#53](https://github.com/svg/svgo/issues/53))
+- plugins/removeUnknownsAndDefaults: remove SVG id attr (close [#54](https://github.com/svg/svgo/issues/54))
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.1) ] 0.1.1 / 23.11.2012
-* plugins/moveElemsAttrsToGroup: fix inheitable only attrs array (fix [#47](https://github.com/svg/svgo/issues/47))
-* plugins/removeEmptyContainers: do not remove an empty 'svg' element (fix [#48](https://github.com/svg/svgo/issues/48))
-* plugins/removeDefaultPx: should also understand a floating-numbers too (fix [#49](https://github.com/svg/svgo/issues/49))
-* plugins/removeUnknownsAndDefaults: merge multiple groupDefaults attrs (close [#50](https://github.com/svg/svgo/issues/50))
+
+- plugins/moveElemsAttrsToGroup: fix inheitable only attrs array (fix [#47](https://github.com/svg/svgo/issues/47))
+- plugins/removeEmptyContainers: do not remove an empty 'svg' element (fix [#48](https://github.com/svg/svgo/issues/48))
+- plugins/removeDefaultPx: should also understand a floating-numbers too (fix [#49](https://github.com/svg/svgo/issues/49))
+- plugins/removeUnknownsAndDefaults: merge multiple groupDefaults attrs (close [#50](https://github.com/svg/svgo/issues/50))
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.1.0) ] 0.1.0 / 22.11.2012
-* new plugin [plugins/removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js) (close [#6](https://github.com/svg/svgo/issues/6))
-* plugins/convertPathData: convert straight curves into lines segments (close [#17](https://github.com/svg/svgo/issues/17)); remove an absolute coords conversions
-* plugins/convertPathData: convert quadratic Bézier curveto into smooth shorthand (close [#31](https://github.com/svg/svgo/issues/31))
-* plugins/convertPathData: convert curveto into smooth shorthand (close [#30](https://github.com/svg/svgo/issues/30))
-* lib/svgo: global API refactoring (close [#37](https://github.com/svg/svgo/issues/37))
-* lib/svgo: fatal and stupid error in stream chunks concatenation (fix [#40](https://github.com/svg/svgo/issues/40))
-* lib/coa: batch folder optimization (close [#29](https://github.com/svg/svgo/issues/29))
-* lib/coa: support arguments as aliases to `--input` and `--output` (close [#28](https://github.com/svg/svgo/issues/28))
-* project logo by [Egor Bolhshakov](http://xizzzy.ru/)
-* move modules to `./lib/svgo/`
-* rename and convert `config.json` to `.svgo.yml`
-* add [./docs/](https://github.com/svg/svgo/tree/master/docs)
-* plugins/convertPathData: don't remove first `M` even if it's `0,0`
-* plugins/convertPathData: stronger defense from infinite loop
-* plugins/moveElemsAttrsToGroup: should affect only inheritable attributes (fix [#46](https://github.com/svg/svgo/issues/46))*
-* plugins/removeComments: ignore comments which starts with '!' (close [#43](https://github.com/svg/svgo/issues/43))
-* config: `cleanupAttrs` should be before `convertStyleToAttrs` (fix [#44](https://github.com/svg/svgo/issues/44))*
-* lib/svgo/jsAPI: add `eachAttr()` optional context param
-* temporarily remove PhantomJS and `--test` (close [#38](https://github.com/svg/svgo/issues/38))
-* q@0.8.10 compatibility: 'end is deprecated, use done instead' fix
-* add [Istanbul](https://github.com/gotwarlost/istanbul) code coverage
-* update dependencies versions and gitignore
-* README: add TODO section with versions milestones
-* update README with License section
-* update LICENSE with russian translation
-* `.editorconfig`: 2 spaces for YAML
+
+- new plugin [plugins/removeUnknownsAndDefaults](https://github.com/svg/svgo/blob/master/plugins/removeUnknownsAndDefaults.js) (close [#6](https://github.com/svg/svgo/issues/6))
+- plugins/convertPathData: convert straight curves into lines segments (close [#17](https://github.com/svg/svgo/issues/17)); remove an absolute coords conversions
+- plugins/convertPathData: convert quadratic Bézier curveto into smooth shorthand (close [#31](https://github.com/svg/svgo/issues/31))
+- plugins/convertPathData: convert curveto into smooth shorthand (close [#30](https://github.com/svg/svgo/issues/30))
+- lib/svgo: global API refactoring (close [#37](https://github.com/svg/svgo/issues/37))
+- lib/svgo: fatal and stupid error in stream chunks concatenation (fix [#40](https://github.com/svg/svgo/issues/40))
+- lib/coa: batch folder optimization (close [#29](https://github.com/svg/svgo/issues/29))
+- lib/coa: support arguments as aliases to `--input` and `--output` (close [#28](https://github.com/svg/svgo/issues/28))
+- project logo by [Egor Bolhshakov](http://xizzzy.ru/)
+- move modules to `./lib/svgo/`
+- rename and convert `config.json` to `.svgo.yml`
+- add [./docs/](https://github.com/svg/svgo/tree/master/docs)
+- plugins/convertPathData: don't remove first `M` even if it's `0,0`
+- plugins/convertPathData: stronger defense from infinite loop
+- plugins/moveElemsAttrsToGroup: should affect only inheritable attributes (fix [#46](https://github.com/svg/svgo/issues/46))\*
+- plugins/removeComments: ignore comments which starts with '!' (close [#43](https://github.com/svg/svgo/issues/43))
+- config: `cleanupAttrs` should be before `convertStyleToAttrs` (fix [#44](https://github.com/svg/svgo/issues/44))\*
+- lib/svgo/jsAPI: add `eachAttr()` optional context param
+- temporarily remove PhantomJS and `--test` (close [#38](https://github.com/svg/svgo/issues/38))
+- q@0.8.10 compatibility: 'end is deprecated, use done instead' fix
+- add [Istanbul](https://github.com/gotwarlost/istanbul) code coverage
+- update dependencies versions and gitignore
+- README: add TODO section with versions milestones
+- update README with License section
+- update LICENSE with russian translation
+- `.editorconfig`: 2 spaces for YAML
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.9) ] 0.0.9 / 29.10.2012
-* [plugins how-to](https://github.com/svg/svgo/tree/master/plugins#readme) (close [#27](https://github.com/svg/svgo/issues/27))
-* allow any plugin of any type to go in any order (close [#14](https://github.com/svg/svgo/issues/14))
-* allow to do a multiple optimizations with one init (close [#25](https://github.com/svg/svgo/issues/25))
-* plugins/convertPathData: global refactoring
-* plugins/convertPathData: do all the tricks with absolute coords too (fix [#22](https://github.com/svg/svgo/issues/22))
-* plugins/convertPathData: accumulation of rounding errors (fix [#23](https://github.com/svg/svgo/issues/23))
-* plugins/convertPathData: prevent an infinity loop on invalid path data (fix [#26](https://github.com/svg/svgo/issues/26))
-* plugins/convertPathData: do not remove very first M from the path data (fix [#24](https://github.com/svg/svgo/issues/24))
-* plugins/convertPathData: optimize path data in &lt;glyph&gt; and &lt;missing-glyph&gt; (close [#20](https://github.com/svg/svgo/issues/20))
-* plugins/convertTransform: add patternTransform attribute to the process (close [#15](https://github.com/svg/svgo/issues/15))
-* plugins/convertTransform: Firefox: removing extra space in front of negative number is allowed only in path data, but not in transform (fix [#12](https://github.com/svg/svgo/issues/12))
-* plugins/removeXMLProcInst: remove only 'xml' but not 'xml-stylesheet' (fix [#21](https://github.com/svg/svgo/issues/15))
-* plugins/collapseGroups: merge split-level transforms (fix [#13](https://github.com/svg/svgo/issues/13))
-* jsdoc corrections
+
+- [plugins how-to](https://github.com/svg/svgo/tree/master/plugins#readme) (close [#27](https://github.com/svg/svgo/issues/27))
+- allow any plugin of any type to go in any order (close [#14](https://github.com/svg/svgo/issues/14))
+- allow to do a multiple optimizations with one init (close [#25](https://github.com/svg/svgo/issues/25))
+- plugins/convertPathData: global refactoring
+- plugins/convertPathData: do all the tricks with absolute coords too (fix [#22](https://github.com/svg/svgo/issues/22))
+- plugins/convertPathData: accumulation of rounding errors (fix [#23](https://github.com/svg/svgo/issues/23))
+- plugins/convertPathData: prevent an infinity loop on invalid path data (fix [#26](https://github.com/svg/svgo/issues/26))
+- plugins/convertPathData: do not remove very first M from the path data (fix [#24](https://github.com/svg/svgo/issues/24))
+- plugins/convertPathData: optimize path data in &lt;glyph&gt; and &lt;missing-glyph&gt; (close [#20](https://github.com/svg/svgo/issues/20))
+- plugins/convertTransform: add patternTransform attribute to the process (close [#15](https://github.com/svg/svgo/issues/15))
+- plugins/convertTransform: Firefox: removing extra space in front of negative number is allowed only in path data, but not in transform (fix [#12](https://github.com/svg/svgo/issues/12))
+- plugins/removeXMLProcInst: remove only 'xml' but not 'xml-stylesheet' (fix [#21](https://github.com/svg/svgo/issues/15))
+- plugins/collapseGroups: merge split-level transforms (fix [#13](https://github.com/svg/svgo/issues/13))
+- jsdoc corrections
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.8) ] 0.0.8 / 20.10.2012
-* new plugin [convertTransform](plugins/convertTransform.js) (close [#5](https://github.com/svg/svgo/issues/5))
-* new plugin [removeUnusedNS](plugins/removeUnusedNS.js)
-* plugins/convertPathData: remove useless segments
-* plugins/convertPathData: a lot of refactoring
-* plugins/convertPathData: round numbers before conditions because of exponential notation (fix [#3](https://github.com/svg/svgo/issues/3))
-* plugins/moveElemsAttrsToGroup: merge split-level transforms instead of replacing (fix [#10](https://github.com/svg/svgo/issues/10))
-* lib/svg2js: catch and output xml parser errors (fix [#4](https://github.com/svg/svgo/issues/4))
-* lib/coa: open file for writing only when we are ready (fix [#2](https://github.com/svg/svgo/issues/2))
-* lib/tools: node.extend module
-* lib/plugins: refactoring
-* lib/js2svg: refactoring
-* lib/jsAPI: simplification and refactoring
-* absolute urls in README
-* update .editorconfig
-* update .travis.yml with nodejs 0.9
+
+- new plugin [convertTransform](plugins/convertTransform.js) (close [#5](https://github.com/svg/svgo/issues/5))
+- new plugin [removeUnusedNS](plugins/removeUnusedNS.js)
+- plugins/convertPathData: remove useless segments
+- plugins/convertPathData: a lot of refactoring
+- plugins/convertPathData: round numbers before conditions because of exponential notation (fix [#3](https://github.com/svg/svgo/issues/3))
+- plugins/moveElemsAttrsToGroup: merge split-level transforms instead of replacing (fix [#10](https://github.com/svg/svgo/issues/10))
+- lib/svg2js: catch and output xml parser errors (fix [#4](https://github.com/svg/svgo/issues/4))
+- lib/coa: open file for writing only when we are ready (fix [#2](https://github.com/svg/svgo/issues/2))
+- lib/tools: node.extend module
+- lib/plugins: refactoring
+- lib/js2svg: refactoring
+- lib/jsAPI: simplification and refactoring
+- absolute urls in README
+- update .editorconfig
+- update .travis.yml with nodejs 0.9
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.7) ] 0.0.7 / 14.10.2012
-* new plugin [convertPathData](plugins/convertPathData.js)
-* --input data now can be a Data URI base64 string
-* --output data now can be a Data URI base64 string with --datauri flag
-* Travis CI
-* JSHint corrections + .jshintrc
-* [.editorconfig](http://editorconfig.org/)
-* display time spent on optimization
-* .svgo → config.json
-* lib/phantom_wrapper.js → lib/phantom.js
+
+- new plugin [convertPathData](plugins/convertPathData.js)
+- --input data now can be a Data URI base64 string
+- --output data now can be a Data URI base64 string with --datauri flag
+- Travis CI
+- JSHint corrections + .jshintrc
+- [.editorconfig](http://editorconfig.org/)
+- display time spent on optimization
+- .svgo → config.json
+- lib/phantom_wrapper.js → lib/phantom.js
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.6) ] 0.0.6 / 04.10.2012
-* add --test option to make a visual comparison of two files (PhantomJS pre-required)
-* update README and CHANGELOG with the correct relative urls
+
+- add --test option to make a visual comparison of two files (PhantomJS pre-required)
+- update README and CHANGELOG with the correct relative urls
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.5) ] 0.0.5 / 03.10.2012
-* every plugin now has [at least one test](plugins)
-* removeViewBox, cleanupEnableBackground, removeEditorsNSData, convertStyleToAttrs and collapseGroups plugins fixes
-* new --pretty option for the pretty printed SVG
-* lib/config refactoring
+
+- every plugin now has [at least one test](plugins)
+- removeViewBox, cleanupEnableBackground, removeEditorsNSData, convertStyleToAttrs and collapseGroups plugins fixes
+- new --pretty option for the pretty printed SVG
+- lib/config refactoring
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.4) ] 0.0.4 / 30.09.2012
-* new plugin [removeViewBox](plugins/removeViewBox.js)
-* new plugin [cleanupEnableBackground](plugins/cleanupEnableBackground.js)
-* display useful info after successful optimization
-* 'npm test' with 'spec' mocha output by default
+
+- new plugin [removeViewBox](plugins/removeViewBox.js)
+- new plugin [cleanupEnableBackground](plugins/cleanupEnableBackground.js)
+- display useful info after successful optimization
+- 'npm test' with 'spec' mocha output by default
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.3) ] 0.0.3 / 29.09.2012
-* plugins/collapseGroups bugfix
-* plugins/moveElemsAttrsToGroup bugfix
-* svgo now display --help if running w/o arguments
-* massive jsdoc updates
-* plugins engine main filter function optimization
+
+- plugins/collapseGroups bugfix
+- plugins/moveElemsAttrsToGroup bugfix
+- svgo now display --help if running w/o arguments
+- massive jsdoc updates
+- plugins engine main filter function optimization
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.2) ] 0.0.2 / 28.09.2012
-* add --disable and --enable command line options
-* add an empty values rejecting to coa.js
-* update README
+
+- add --disable and --enable command line options
+- add an empty values rejecting to coa.js
+- update README
 
 ### [ [>](https://github.com/svg/svgo/tree/v0.0.1) ] 0.0.1 / 27.09.2012
-* initial public version
+
+- initial public version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ If you've found a bug with SVGO, [create an issue](https://github.com/svg/svgo/i
 
 Your issue should ideally contain:
 
-* A concise description of the bug.
-* How you were using SVGO, the version of the tool, and any configuration or command-line options.
-* The SVG that was effected, or a [Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example).
+- A concise description of the bug.
+- How you were using SVGO, the version of the tool, and any configuration or command-line options.
+- The SVG that was effected, or a [Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example).
 
 If you haven't found a bug, but need help using SVGO in your project, please consider asking on [Stack Overflow](https://stackoverflow.com/questions/tagged/svgo) with the `[svgo]` tag, you may get help faster there. You can still create an issue if the confusion stemmed from a lack of documentation.
 
@@ -20,8 +20,8 @@ See: [SECURITY.md](./SECURITY.md)
 
 ### Requirements
 
-* [Git](https://git-scm.com/)
-* [Node.js 14](https://nodejs.org/) or later
+- [Git](https://git-scm.com/)
+- [Node.js 14](https://nodejs.org/) or later
 
 ### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Process single files:
 ```sh
 svgo one.svg two.svg -o one.min.svg two.min.svg
 ```
+
 Process a directory of files recursively with `-f`/`--folder`:
 
 ```sh
@@ -51,13 +52,14 @@ SVGO has a plugin architecture. You can read more about all plugins in [Plugins 
 SVGO reads the configuration from `svgo.config.js` or the `--config path/to/config.js` command-line option. Some other parameters can be configured though command-line options too.
 
 **`svgo.config.js`**
+
 ```js
 module.exports = {
   multipass: false, // boolean
   datauri: 'base64', // 'base64'|'enc'|'unenc'
   js2svg: {
     indent: 4, // number
-    pretty: false // boolean
+    pretty: false, // boolean
   },
   plugins: [
     'preset-default', // built-in plugins enabled by default
@@ -67,17 +69,19 @@ module.exports = {
     {
       name: 'prefixIds',
       params: {
-        prefix: 'uwu'
-      }
-    }
-  ]
+        prefix: 'uwu',
+      },
+    },
+  ],
 };
 ```
+
 ### Default preset
 
 Instead of configuring SVGO from scratch, you can tweak the default preset to suit your needs by configuring or disabling the respective plugin.
 
 **`svgo.config.js`**
+
 ```js
 module.exports = {
   plugins: [
@@ -91,11 +95,11 @@ module.exports = {
           // customize the params of a default plugin
           inlineStyles: {
             onlyMatchedOnce: false,
-          }
-        }
-      }
-    }
-  ]
+          },
+        },
+      },
+    },
+  ],
 };
 ```
 
@@ -106,6 +110,7 @@ You can find a list of the default plugins in the order they run in [Preset Defa
 You can also specify custom plugins:
 
 **`svgo.config.js`**
+
 ```js
 const importedPlugin = require('./imported-plugin');
 
@@ -120,9 +125,9 @@ module.exports = {
       params: {
         paramName: 'paramValue',
       },
-      fn: (ast, params, info) => {}
-    }
-  ]
+      fn: (ast, params, info) => {},
+    },
+  ],
 };
 ```
 
@@ -139,7 +144,7 @@ const { optimize } = require('svgo');
 
 const result = optimize(svgString, {
   path: 'path-to.svg', // recommended
-  multipass: true // all other config fields are available here
+  multipass: true, // all other config fields are available here
 });
 
 const optimizedSvgString = result.data;
@@ -163,29 +168,29 @@ const config = await loadConfig(configFile, cwd);
 
 ## Other ways to use SVGO
 
-| Method | Reference |
-| --- | --- |
-| Web app | [SVGOMG](https://jakearchibald.github.io/svgomg/) |
-| Grunt task | [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin) |
-| Gulp task | [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin) |
-| Webpack loader | [image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin/#optimize-with-svgo) |
-| PostCSS plugin | [postcss-svgo](https://github.com/cssnano/cssnano/tree/master/packages/postcss-svgo) |
-| Inkscape plugin | [inkscape-svgo](https://github.com/konsumer/inkscape-svgo) |
-| Sketch plugin | [svgo-compressor](https://github.com/BohemianCoding/svgo-compressor) |
-| Rollup plugin | [rollup-plugin-svgo](https://github.com/porsager/rollup-plugin-svgo) |
-| Visual Studio Code plugin | [vscode-svgo](https://github.com/1000ch/vscode-svgo) |
-| Atom plugin | [atom-svgo](https://github.com/1000ch/atom-svgo) |
-| Sublime plugin | [Sublime-svgo](https://github.com/1000ch/Sublime-svgo) |
-| Figma plugin | [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export) |
-| Linux app | [Oh My SVG](https://github.com/sonnyp/OhMySVG) |
-| Browser extension | [SVG Gobbler](https://github.com/rossmoody/svg-gobbler) |
-| API | [Vector Express](https://github.com/smidyo/vectorexpress-api#convertor-svgo) |
+| Method                    | Reference                                                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Web app                   | [SVGOMG](https://jakearchibald.github.io/svgomg/)                                                                       |
+| Grunt task                | [grunt-svgmin](https://github.com/sindresorhus/grunt-svgmin)                                                            |
+| Gulp task                 | [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin)                                                                    |
+| Webpack loader            | [image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin/#optimize-with-svgo) |
+| PostCSS plugin            | [postcss-svgo](https://github.com/cssnano/cssnano/tree/master/packages/postcss-svgo)                                    |
+| Inkscape plugin           | [inkscape-svgo](https://github.com/konsumer/inkscape-svgo)                                                              |
+| Sketch plugin             | [svgo-compressor](https://github.com/BohemianCoding/svgo-compressor)                                                    |
+| Rollup plugin             | [rollup-plugin-svgo](https://github.com/porsager/rollup-plugin-svgo)                                                    |
+| Visual Studio Code plugin | [vscode-svgo](https://github.com/1000ch/vscode-svgo)                                                                    |
+| Atom plugin               | [atom-svgo](https://github.com/1000ch/atom-svgo)                                                                        |
+| Sublime plugin            | [Sublime-svgo](https://github.com/1000ch/Sublime-svgo)                                                                  |
+| Figma plugin              | [Advanced SVG Export](https://www.figma.com/c/plugin/782713260363070260/Advanced-SVG-Export)                            |
+| Linux app                 | [Oh My SVG](https://github.com/sonnyp/OhMySVG)                                                                          |
+| Browser extension         | [SVG Gobbler](https://github.com/rossmoody/svg-gobbler)                                                                 |
+| API                       | [Vector Express](https://github.com/smidyo/vectorexpress-api#convertor-svgo)                                            |
 
 ## Donors
 
 | [<img src="https://sheetjs.com/sketch128.png" width="80">](https://sheetjs.com/) | [<img src="https://raw.githubusercontent.com/fontello/fontello/8.0.0/fontello-image.svg" width="80">](https://fontello.com/) |
-| :---: | :---: |
-| [SheetJS LLC](https://sheetjs.com/) | [Fontello](https://fontello.com/) |
+| :------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------: |
+|                       [SheetJS LLC](https://sheetjs.com/)                        |                                              [Fontello](https://fontello.com/)                                               |
 
 ## License and Copyright
 

--- a/docs/01-index.mdx
+++ b/docs/01-index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-slug: "introduction"
+slug: 'introduction'
 ---
 
 SVGO (short for SVG Optimizer) is a Node.js library and command-line application for optimizing SVG files.
@@ -11,7 +11,7 @@ SVG files, especially those exported from vector editors, usually contain a lot 
 
 ### System Requirements
 
-* [Node.js 14](https://nodejs.org/) or later
+- [Node.js 14](https://nodejs.org/) or later
 
 <Tabs>
   <TabItem value="npm" label="npm" default>

--- a/docs/02-preset-default.mdx
+++ b/docs/02-preset-default.mdx
@@ -14,41 +14,41 @@ If you aren't using SVGO directly, like through [SVGR](https://github.com/gregbe
 
 The following plugins are included in `preset-default`, in the order that they're executed:
 
-* [Remove Doctype](/docs/plugins/remove-doctype/)
-* [Remove XML Declaration](/docs/plugins/remove-xml-proc-inst/)
-* [Remove Comments](/docs/plugins/remove-comments/)
-* [Remove Metadata](/docs/plugins/remove-metadata/)
-* [Remove Editor Namespace Data](/docs/plugins/remove-editors-ns-data/)
-* [Cleanup Attributes](/docs/plugins/cleanup-attrs/)
-* [Merge Styles](/docs/plugins/merge-styles/)
-* [Inline Styles](/docs/plugins/inline-styles/)
-* [Minify Styles](/docs/plugins/minify-styles/)
-* [Cleanup IDs](/docs/plugins/cleanup-ids/)
-* [Remove Useless Defs](/docs/plugins/remove-useless-defs/)
-* [Cleanup Numeric Values](/docs/plugins/cleanup-numeric-values/)
-* [Convert Colors](/docs/plugins/convert-colors/)
-* [Remove Unknowns and Defaults](/docs/plugins/remove-unknowns-and-defaults/)
-* [Remove Non-inheritable Group Attributes](/docs/plugins/remove-non-inheritable-group-attrs/)
-* [Remove Useless Stroke and Fill](/docs/plugins/remove-useless-stroke-and-fill/)
-* [Remove ViewBox](/docs/plugins/remove-viewbox/)
-* [Cleanup Enable Background](/docs/plugins/cleanup-enable-background/)
-* [Remove Hidden Elements](/docs/plugins/remove-hidden-elems/)
-* [Remove Empty Text](/docs/plugins/remove-empty-text/)
-* [Convert Shape to Path](/docs/plugins/convert-shape-to-path/)
-* [Convert Ellipse to Circle](/docs/plugins/convert-ellipse-to-circle/)
-* [Move Element Attributes to Group](/docs/plugins/move-elems-attrs-to-group/)
-* [Move Group Attributes to Element](/docs/plugins/move-group-attrs-to-elem/)
-* [Collapse Groups](/docs/plugins/collapse-groups/)
-* [Convert Path Data](/docs/plugins/convert-path-data/)
-* [Convert Transform](/docs/plugins/convert-transform/)
-* [Remove Empty Attributes](/docs/plugins/remove-empty-attrs/)
-* [Remove Empty Containers](/docs/plugins/remove-empty-containers/)
-* [Remove Unused Namespaces](/docs/plugins/remove-unused-namespaces/)
-* [Merge Paths](/docs/plugins/merge-paths/)
-* [Sort Attributes](/docs/plugins/sort-attrs/)
-* [Sort Defs Children](/docs/plugins/sort-defs-children/)
-* [Remove Title](/docs/plugins/remove-title/)
-* [Remove Description](/docs/plugins/remove-desc/)
+- [Remove Doctype](/docs/plugins/remove-doctype/)
+- [Remove XML Declaration](/docs/plugins/remove-xml-proc-inst/)
+- [Remove Comments](/docs/plugins/remove-comments/)
+- [Remove Metadata](/docs/plugins/remove-metadata/)
+- [Remove Editor Namespace Data](/docs/plugins/remove-editors-ns-data/)
+- [Cleanup Attributes](/docs/plugins/cleanup-attrs/)
+- [Merge Styles](/docs/plugins/merge-styles/)
+- [Inline Styles](/docs/plugins/inline-styles/)
+- [Minify Styles](/docs/plugins/minify-styles/)
+- [Cleanup IDs](/docs/plugins/cleanup-ids/)
+- [Remove Useless Defs](/docs/plugins/remove-useless-defs/)
+- [Cleanup Numeric Values](/docs/plugins/cleanup-numeric-values/)
+- [Convert Colors](/docs/plugins/convert-colors/)
+- [Remove Unknowns and Defaults](/docs/plugins/remove-unknowns-and-defaults/)
+- [Remove Non-inheritable Group Attributes](/docs/plugins/remove-non-inheritable-group-attrs/)
+- [Remove Useless Stroke and Fill](/docs/plugins/remove-useless-stroke-and-fill/)
+- [Remove ViewBox](/docs/plugins/remove-viewbox/)
+- [Cleanup Enable Background](/docs/plugins/cleanup-enable-background/)
+- [Remove Hidden Elements](/docs/plugins/remove-hidden-elems/)
+- [Remove Empty Text](/docs/plugins/remove-empty-text/)
+- [Convert Shape to Path](/docs/plugins/convert-shape-to-path/)
+- [Convert Ellipse to Circle](/docs/plugins/convert-ellipse-to-circle/)
+- [Move Element Attributes to Group](/docs/plugins/move-elems-attrs-to-group/)
+- [Move Group Attributes to Element](/docs/plugins/move-group-attrs-to-elem/)
+- [Collapse Groups](/docs/plugins/collapse-groups/)
+- [Convert Path Data](/docs/plugins/convert-path-data/)
+- [Convert Transform](/docs/plugins/convert-transform/)
+- [Remove Empty Attributes](/docs/plugins/remove-empty-attrs/)
+- [Remove Empty Containers](/docs/plugins/remove-empty-containers/)
+- [Remove Unused Namespaces](/docs/plugins/remove-unused-namespaces/)
+- [Merge Paths](/docs/plugins/merge-paths/)
+- [Sort Attributes](/docs/plugins/sort-attrs/)
+- [Sort Defs Children](/docs/plugins/sort-defs-children/)
+- [Remove Title](/docs/plugins/remove-title/)
+- [Remove Description](/docs/plugins/remove-desc/)
 
 ## Disable a Plugin
 
@@ -63,11 +63,11 @@ module.exports = {
       name: 'preset-default',
       params: {
         overrides: {
-          removeViewBox: false
-        }
-      }
-    }
-  ]
+          removeViewBox: false,
+        },
+      },
+    },
+  ],
 };
 ```
 
@@ -80,7 +80,7 @@ module.exports = {
     'removeXMLProcInst',
     'minifyStyles',
     'sortAttrs',
-    'sortDefsChildren'
-  ]
+    'sortDefsChildren',
+  ],
 };
 ```

--- a/docs/03-plugins/add-attributes-to-svg-elements.mdx
+++ b/docs/03-plugins/add-attributes-to-svg-elements.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Attributes to Elements
-svgo: 
+svgo:
   pluginId: addAttributesToSVGElement
   parameters:
     attributes:
@@ -19,16 +19,16 @@ This plugin is only safe to use when a map of key/value pairs is passed. If you 
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/addAttributesToSVGElement.js
+- https://github.com/svg/svgo/blob/main/plugins/addAttributesToSVGElement.js

--- a/docs/03-plugins/add-classes-to-svg-element.mdx
+++ b/docs/03-plugins/add-classes-to-svg-element.mdx
@@ -24,16 +24,16 @@ By adding classes, if the parent document is aware, you can share styles across 
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/addClassesToSVGElement.js
+- https://github.com/svg/svgo/blob/main/plugins/addClassesToSVGElement.js

--- a/docs/03-plugins/cleanup-attrs.mdx
+++ b/docs/03-plugins/cleanup-attrs.mdx
@@ -24,16 +24,16 @@ This will not modify the attribute keys, nor remove them if the value becomes em
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/cleanupAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/cleanupAttrs.js

--- a/docs/03-plugins/cleanup-enable-background.mdx
+++ b/docs/03-plugins/cleanup-enable-background.mdx
@@ -11,9 +11,8 @@ Only cleans up attribute values and inline-styles, but does not effect styleshee
 
 This plugin will:
 
-* Drop `enable-background` when the width and height values match the width and height of the `<svg>` node.
-* Replace the value with `new` when the width and height values match the width and height of a `<mask>` or `<pattern>` node.
-
+- Drop `enable-background` when the width and height values match the width and height of the `<svg>` node.
+- Replace the value with `new` when the width and height values match the width and height of a `<mask>` or `<pattern>` node.
 
 :::info
 
@@ -23,12 +22,12 @@ Some browsers don't support `enable-background`, so it's best to avoid the attri
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/cleanupEnableBackground.js
+- https://github.com/svg/svgo/blob/main/plugins/cleanupEnableBackground.js

--- a/docs/03-plugins/cleanup-ids.mdx
+++ b/docs/03-plugins/cleanup-ids.mdx
@@ -43,16 +43,16 @@ See [facebook/docusaurus#8297](https://github.com/facebook/docusaurus/issues/829
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/cleanupIds.js
+- https://github.com/svg/svgo/blob/main/plugins/cleanupIds.js

--- a/docs/03-plugins/cleanup-list-of-values.mdx
+++ b/docs/03-plugins/cleanup-list-of-values.mdx
@@ -23,16 +23,16 @@ Rounds numeric values in attributes, such as those found in [`viewBox`](https://
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/cleanupListOfValues.js
+- https://github.com/svg/svgo/blob/main/plugins/cleanupListOfValues.js

--- a/docs/03-plugins/cleanup-numeric-values.mdx
+++ b/docs/03-plugins/cleanup-numeric-values.mdx
@@ -22,16 +22,16 @@ Rounds numeric values, and removes the unit when it's `px` as this is the defaul
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/cleanupNumericValues.js
+- https://github.com/svg/svgo/blob/main/plugins/cleanupNumericValues.js

--- a/docs/03-plugins/collapse-groups.mdx
+++ b/docs/03-plugins/collapse-groups.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
 ---
 
-Finds groups that effectively do nothing and flattens them, preserving the contents of the groups. 
+Finds groups that effectively do nothing and flattens them, preserving the contents of the groups.
 
 Groups can be formed using the [`<g>`](https://developer.mozilla.org/docs/Web/SVG/Element/g) element. They're used for organizing the document, or applying [presentation attributes](https://developer.mozilla.org/docs/Web/SVG/Attribute/Presentation) to all children contained in a group.
 
@@ -17,12 +17,12 @@ This plugin doesn't remove empty groups. That's handled by the [**Remove Empty C
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/collapseGroups.js
+- https://github.com/svg/svgo/blob/main/plugins/collapseGroups.js

--- a/docs/03-plugins/convert-colors.mdx
+++ b/docs/03-plugins/convert-colors.mdx
@@ -25,29 +25,29 @@ Converts color references to the shortest equivalent.
 
 Colors can be represented in various notations, the following table showcases some equivalent colors:
 
-| Name | rgb() | #rrggbb | #rgb |
-|---|---|---|---|
-| `red` | `rgb(255, 0, 0)` | `#ff0000` | `#f00` |
-| `orange` | `rgb(255, 165, 0)` | `#ffa500` | |
+| Name     | rgb()              | #rrggbb   | #rgb   |
+| -------- | ------------------ | --------- | ------ |
+| `red`    | `rgb(255, 0, 0)`   | `#ff0000` | `#f00` |
+| `orange` | `rgb(255, 165, 0)` | `#ffa500` |        |
 | `yellow` | `rgb(255, 255, 0)` | `#ffff00` | `#ff0` |
-| `green` | `rgb(0, 128, 0)` | `#008000` | |
-| `blue` | `rgb(0, 0, 255)` | `#0000FF` | `#00f` |
-| `purple` | `rgb(128, 0, 128)` | `#800080` | |
+| `green`  | `rgb(0, 128, 0)`   | `#008000` |        |
+| `blue`   | `rgb(0, 0, 255)`   | `#0000FF` | `#00f` |
+| `purple` | `rgb(128, 0, 128)` | `#800080` |        |
 
 It makes no difference which format is received by a client, and each one has wide support across browsers and image viewing software.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertColors.js
+- https://github.com/svg/svgo/blob/main/plugins/convertColors.js

--- a/docs/03-plugins/convert-ellipse-to-circle.mdx
+++ b/docs/03-plugins/convert-ellipse-to-circle.mdx
@@ -9,12 +9,12 @@ Convert non-eccentric [`<ellipse>`](https://developer.mozilla.org/docs/Web/SVG/E
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertEllipseToCircle.js
+- https://github.com/svg/svgo/blob/main/plugins/convertEllipseToCircle.js

--- a/docs/03-plugins/convert-one-stop-gradients.mdx
+++ b/docs/03-plugins/convert-one-stop-gradients.mdx
@@ -12,12 +12,12 @@ Definitions of the gradients are removed, and the parent [`<defs>`](https://deve
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertOneStopGradients.js
+- https://github.com/svg/svgo/blob/main/plugins/convertOneStopGradients.js

--- a/docs/03-plugins/convert-path-data.mdx
+++ b/docs/03-plugins/convert-path-data.mdx
@@ -42,7 +42,7 @@ svgo:
     negativeExtraSpace:
       default: true
     forceAbsolutePath:
-      description: If to always convert to absolute coordinates, even if it adds more bytes. 
+      description: If to always convert to absolute coordinates, even if it adds more bytes.
       default: false
 ---
 
@@ -56,26 +56,26 @@ You can get more context on path commands on [MDN Web Docs](https://developer.mo
 
 This plugin uses multiple techniques to either reduce the number of instructions or reduce the attribute length:
 
-* Convert between relative or absolute coordinates, whichever is shortest.
-* Convert between commands. For example, a bézier curve that behaves like a straight line might as well use a line instruction.
-* Remove redundant commands. For example, a command that moves to the current position can be removed.
-* Trim redundant delimiters and leading zeros.
-* Round numeric values using conventional rounding rules.
+- Convert between relative or absolute coordinates, whichever is shortest.
+- Convert between commands. For example, a bézier curve that behaves like a straight line might as well use a line instruction.
+- Remove redundant commands. For example, a command that moves to the current position can be removed.
+- Trim redundant delimiters and leading zeros.
+- Round numeric values using conventional rounding rules.
 
 You can read more about the plugins capabilities by going through the individual parameters.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertPathData.js
+- https://github.com/svg/svgo/blob/main/plugins/convertPathData.js

--- a/docs/03-plugins/convert-shape-to-path.mdx
+++ b/docs/03-plugins/convert-shape-to-path.mdx
@@ -16,16 +16,16 @@ Convert basic shapes to [`<path>`](https://developer.mozilla.org/docs/Web/SVG/El
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertShapeToPath.js
+- https://github.com/svg/svgo/blob/main/plugins/convertShapeToPath.js

--- a/docs/03-plugins/convert-style-to-attrs.mdx
+++ b/docs/03-plugins/convert-style-to-attrs.mdx
@@ -29,16 +29,16 @@ However, because the `style` attribute doesn't require quotes between values, gi
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertStyleToAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/convertStyleToAttrs.js

--- a/docs/03-plugins/convert-transform.mdx
+++ b/docs/03-plugins/convert-transform.mdx
@@ -39,16 +39,16 @@ Collapse multiple transforms into one, convert matrices to the short aliases, an
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/convertTransform.js
+- https://github.com/svg/svgo/blob/main/plugins/convertTransform.js

--- a/docs/03-plugins/index.mdx
+++ b/docs/03-plugins/index.mdx
@@ -12,6 +12,6 @@ Presets are generalized SVGO plugin pipelines, though there is only one built-in
 
 The Preset Default pipeline can be used by either:
 
-* Not defining a `plugins` property in the config.
-* Omitting the config altogether.
-* Specifying the `preset-default` plugin.
+- Not defining a `plugins` property in the config.
+- Omitting the config altogether.
+- Specifying the `preset-default` plugin.

--- a/docs/03-plugins/inline-styles.mdx
+++ b/docs/03-plugins/inline-styles.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: inlineStyles
   defaultPlugin: true
   parameters:
-    onlyMatchedOnce: 
+    onlyMatchedOnce:
       description: If to only inline styles if the selector matches one element.
       default: true
     removeMatchedSelectors:
@@ -13,23 +13,23 @@ svgo:
     useMqs:
       description: An array of media query conditions to use, such as <code>screen</code>. An empty string signifies all selectors outside of a media query.
     usePseudos:
-      description: What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo-classes and non-pseudo-elements. 
+      description: What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo-classes and non-pseudo-elements.
 ---
 
 Merges styles from `<style>` elements to the `style` attribute of matching elements.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/inlineStyles.js
+- https://github.com/svg/svgo/blob/main/plugins/inlineStyles.js

--- a/docs/03-plugins/merge-paths.mdx
+++ b/docs/03-plugins/merge-paths.mdx
@@ -18,16 +18,16 @@ Merge multiple paths into one.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/mergePaths.js
+- https://github.com/svg/svgo/blob/main/plugins/mergePaths.js

--- a/docs/03-plugins/merge-styles.mdx
+++ b/docs/03-plugins/merge-styles.mdx
@@ -9,12 +9,12 @@ Merge multiple `<style>` elements into one.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/mergeStyles.js
+- https://github.com/svg/svgo/blob/main/plugins/mergeStyles.js

--- a/docs/03-plugins/minify-styles.mdx
+++ b/docs/03-plugins/minify-styles.mdx
@@ -13,16 +13,16 @@ Minify `<style>` elements with [CSSO](https://github.com/css/csso).
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/minifyStyles.js
+- https://github.com/svg/svgo/blob/main/plugins/minifyStyles.js

--- a/docs/03-plugins/move-elems-attrs-to-group.mdx
+++ b/docs/03-plugins/move-elems-attrs-to-group.mdx
@@ -9,12 +9,12 @@ Move an elements attributes to their enclosing group.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/moveElemsAttrsToGroup.js
+- https://github.com/svg/svgo/blob/main/plugins/moveElemsAttrsToGroup.js

--- a/docs/03-plugins/move-group-attrs-to-elem.mdx
+++ b/docs/03-plugins/move-group-attrs-to-elem.mdx
@@ -9,12 +9,12 @@ Move some group attributes to the contained elements.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/moveGroupAttrsToElems.js
+- https://github.com/svg/svgo/blob/main/plugins/moveGroupAttrsToElems.js

--- a/docs/03-plugins/prefix-ids.mdx
+++ b/docs/03-plugins/prefix-ids.mdx
@@ -5,7 +5,7 @@ svgo:
   parameters:
     delim:
       description: Content to insert between the prefix and original value.
-      default: "__"
+      default: '__'
     prefix:
       description: Either a string or a function that resolves to a string.
     prefixIds:
@@ -20,16 +20,16 @@ Prefix element IDs and class names with the filename or another arbitrary string
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/prefixIds.js
+- https://github.com/svg/svgo/blob/main/plugins/prefixIds.js

--- a/docs/03-plugins/remove-attributes-by-selector.mdx
+++ b/docs/03-plugins/remove-attributes-by-selector.mdx
@@ -12,16 +12,16 @@ Removes specific attributes from elements that match a CSS selector.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeAttributesBySelector.js
+- https://github.com/svg/svgo/blob/main/plugins/removeAttributesBySelector.js

--- a/docs/03-plugins/remove-attrs.mdx
+++ b/docs/03-plugins/remove-attrs.mdx
@@ -8,7 +8,7 @@ svgo:
       default: null
     elemSeparator:
       description: The pattern syntax used by this plugin is <code>element:attribute:value</code>, this changes the delimiter from <code>:</code> to another string.
-      default: ":"
+      default: ':'
     preserveCurrentColor:
       description: If to ignore the attribute if it's set to <code>currentColor</code>.
       default: false
@@ -18,24 +18,24 @@ Remove attributes from elements matching a custom syntax.
 
 The format accepted is `[ element* : attribute* : value* ]`, where:
 
-* `element`: A regular expression matching element names. An asterisk or omission matches all elements.
-* `attribute`: A regular expression matching attribute names.
-* `value`: A regular expresison matching attribute values. An asterisk or omission matches all values.
+- `element`: A regular expression matching element names. An asterisk or omission matches all elements.
+- `attribute`: A regular expression matching attribute names.
+- `value`: A regular expresison matching attribute values. An asterisk or omission matches all values.
 
 For example, `path:fill` matches all `fill` attributes in `<path>` elements.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/removeAttrs.js

--- a/docs/03-plugins/remove-comments.mdx
+++ b/docs/03-plugins/remove-comments.mdx
@@ -7,14 +7,14 @@ svgo:
     preservePatterns:
       description: An array of regular expressions (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp" target="_blank">RegExp</a> or string). If the comment matches any of these, including partial matches, the comment is preserved. Set to <code>false</code> to disable this behavior and remove comments indiscriminately.
       default:
-        - "^!"
+        - '^!'
 ---
 
 Removes XML comments from the document.
 
 XML comments are the content between the `<!--` and `-->` syntax, and do not effect rendering. From an optimization perspective, these can always be safely removed.
 
-By default, this plugin ignores legal comments, also known as "special comments" or "protected comments". These are comments that start with an exclamation point (`!`) and are often used for legal information like copyright notices, licensing, or attribution. 
+By default, this plugin ignores legal comments, also known as "special comments" or "protected comments". These are comments that start with an exclamation point (`!`) and are often used for legal information like copyright notices, licensing, or attribution.
 
 For example, the following comment can be found in [Font Awesome Free](https://fontawesome.com/license/free) icons:
 
@@ -26,15 +26,15 @@ Removing a comment like this may be considered a breach of the license terms, as
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Trivia
 
@@ -42,14 +42,14 @@ Removing a comment like this may be considered a breach of the license terms, as
 
 It's unclear if there are authoritative resources promoting this syntax for legal comments. However, the convention to preserve them based on this can be seen by a number of minification and build tools:
 
-* [clean-css](https://github.com/clean-css/clean-css#how-to-preserve-a-comment-block)
-* [CSSO](https://github.com/css/csso#syntaxcompressast-options)
-* [esbuild](https://esbuild.github.io/api/#legal-comments)
-* [Sass](https://sass-lang.com/documentation/syntax/comments/)
-* [Terser](https://github.com/terser/terser#keeping-copyright-notices-or-other-comments) / [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#preserve-comments)
-* [UglifyJS](https://github.com/mishoo/UglifyJS#keeping-copyright-notices-or-other-comments)
-* [YUI Compressor](https://github.com/yui/yuicompressor#notes)
+- [clean-css](https://github.com/clean-css/clean-css#how-to-preserve-a-comment-block)
+- [CSSO](https://github.com/css/csso#syntaxcompressast-options)
+- [esbuild](https://esbuild.github.io/api/#legal-comments)
+- [Sass](https://sass-lang.com/documentation/syntax/comments/)
+- [Terser](https://github.com/terser/terser#keeping-copyright-notices-or-other-comments) / [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#preserve-comments)
+- [UglifyJS](https://github.com/mishoo/UglifyJS#keeping-copyright-notices-or-other-comments)
+- [YUI Compressor](https://github.com/yui/yuicompressor#notes)
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeComments.js
+- https://github.com/svg/svgo/blob/main/plugins/removeComments.js

--- a/docs/03-plugins/remove-desc.mdx
+++ b/docs/03-plugins/remove-desc.mdx
@@ -5,30 +5,30 @@ svgo:
   defaultPlugin: true
   parameters:
     removeAny:
-      description: By default, this plugin only removes descriptions that are either empty or contain editor attribution. Enabling this removes the <code>&lt;desc&gt;</code> element indiscriminately. 
+      description: By default, this plugin only removes descriptions that are either empty or contain editor attribution. Enabling this removes the <code>&lt;desc&gt;</code> element indiscriminately.
       type: boolean
       default: false
 ---
 
 Removes the [`<desc>`](https://developer.mozilla.org/docs/Web/SVG/Element/desc) element from the document in one of the following conditions:
 
-* The `<desc>` element is empty.
-* The `<desc>` element appears to only contain editor attribution.
+- The `<desc>` element is empty.
+- The `<desc>` element appears to only contain editor attribution.
 
 This plugin does not remove the `<desc>` indiscriminately by default, as it is a crucial aspect of accessibility for users of assistive technologies.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeDesc.js
+- https://github.com/svg/svgo/blob/main/plugins/removeDesc.js

--- a/docs/03-plugins/remove-dimensions.mdx
+++ b/docs/03-plugins/remove-dimensions.mdx
@@ -14,12 +14,12 @@ This is effectively the opposite of the [Remove ViewBox](/docs/plugins/remove-vi
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeDimensions.js
+- https://github.com/svg/svgo/blob/main/plugins/removeDimensions.js

--- a/docs/03-plugins/remove-doctype.mdx
+++ b/docs/03-plugins/remove-doctype.mdx
@@ -9,12 +9,12 @@ Removes the [Document Type Definition](https://en.wikipedia.org/wiki/Document_ty
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeDoctype.js
+- https://github.com/svg/svgo/blob/main/plugins/removeDoctype.js

--- a/docs/03-plugins/remove-editors-ns-data.mdx
+++ b/docs/03-plugins/remove-editors-ns-data.mdx
@@ -19,16 +19,16 @@ You can find a list of removed editor namespaces in [`_collections.js`](https://
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeEditorsNSData.js
+- https://github.com/svg/svgo/blob/main/plugins/removeEditorsNSData.js

--- a/docs/03-plugins/remove-elements-by-attr.mdx
+++ b/docs/03-plugins/remove-elements-by-attr.mdx
@@ -15,16 +15,16 @@ Removes arbitrary elements by ID or className.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeElementsByAttr.js
+- https://github.com/svg/svgo/blob/main/plugins/removeElementsByAttr.js

--- a/docs/03-plugins/remove-empty-attrs.mdx
+++ b/docs/03-plugins/remove-empty-attrs.mdx
@@ -9,18 +9,18 @@ Remove empty attributes from elements in the document.
 
 This ignores the following attributes, as they're used for conditional rendering:
 
-* `requiredFeatures`
-* `requiredExtensions`
-* `systemLanguage`
+- `requiredFeatures`
+- `requiredExtensions`
+- `systemLanguage`
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeEmptyAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/removeEmptyAttrs.js

--- a/docs/03-plugins/remove-empty-containers.mdx
+++ b/docs/03-plugins/remove-empty-containers.mdx
@@ -9,28 +9,28 @@ Remove container elements in the document that have no children or meaningful at
 
 A container, as defined in the [SVG specifications](https://www.w3.org/TR/SVG11/intro.html#TermContainerElement), is an SVG element that can have graphical child elements. Container elements include:
 
-* [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a)
-* [`<defs>`](https://developer.mozilla.org/docs/Web/SVG/Element/defs)
-* [`<glyph>`](https://developer.mozilla.org/docs/Web/SVG/Element/glyph)
-* [`<g>`](https://developer.mozilla.org/docs/Web/SVG/Element/g)
-* [`<marker>`](https://developer.mozilla.org/docs/Web/SVG/Element/marker)
-* [`<mask>`](https://developer.mozilla.org/docs/Web/SVG/Element/mask)
-* [`<missing-glyph>`](https://developer.mozilla.org/docs/Web/SVG/Element/missing-glyph)
-* [`<pattern>`](https://developer.mozilla.org/docs/Web/SVG/Element/pattern)
-* [`<svg>`](https://developer.mozilla.org/docs/Web/SVG/Element/svg)
-* [`<switch>`](https://developer.mozilla.org/docs/Web/SVG/Element/switch)
-* [`<symbol>`](https://developer.mozilla.org/docs/Web/SVG/Element/symbol)
+- [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a)
+- [`<defs>`](https://developer.mozilla.org/docs/Web/SVG/Element/defs)
+- [`<glyph>`](https://developer.mozilla.org/docs/Web/SVG/Element/glyph)
+- [`<g>`](https://developer.mozilla.org/docs/Web/SVG/Element/g)
+- [`<marker>`](https://developer.mozilla.org/docs/Web/SVG/Element/marker)
+- [`<mask>`](https://developer.mozilla.org/docs/Web/SVG/Element/mask)
+- [`<missing-glyph>`](https://developer.mozilla.org/docs/Web/SVG/Element/missing-glyph)
+- [`<pattern>`](https://developer.mozilla.org/docs/Web/SVG/Element/pattern)
+- [`<svg>`](https://developer.mozilla.org/docs/Web/SVG/Element/svg)
+- [`<switch>`](https://developer.mozilla.org/docs/Web/SVG/Element/switch)
+- [`<symbol>`](https://developer.mozilla.org/docs/Web/SVG/Element/symbol)
 
 Despite the `<svg>` element being a container element, they are not ignored by this plugin.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeEmptyContainers.js
+- https://github.com/svg/svgo/blob/main/plugins/removeEmptyContainers.js

--- a/docs/03-plugins/remove-empty-text.mdx
+++ b/docs/03-plugins/remove-empty-text.mdx
@@ -25,16 +25,16 @@ No browsers supports `<tref>`, so it's best to avoid that element regardless.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeEmptyText.js
+- https://github.com/svg/svgo/blob/main/plugins/removeEmptyText.js

--- a/docs/03-plugins/remove-hidden-elems.mdx
+++ b/docs/03-plugins/remove-hidden-elems.mdx
@@ -59,16 +59,16 @@ Refer to the parameters for the conditions this plugin looks for. All checks ena
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeHiddenElems.js
+- https://github.com/svg/svgo/blob/main/plugins/removeHiddenElems.js

--- a/docs/03-plugins/remove-metadata.mdx
+++ b/docs/03-plugins/remove-metadata.mdx
@@ -19,12 +19,12 @@ You can learn more about referencing copyright and licensing on the [SVG Tiny 1.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeMetadata.js
+- https://github.com/svg/svgo/blob/main/plugins/removeMetadata.js

--- a/docs/03-plugins/remove-non-inheritable-group-attrs.mdx
+++ b/docs/03-plugins/remove-non-inheritable-group-attrs.mdx
@@ -9,12 +9,12 @@ Removes non-inheritable [presentation attributes](https://developer.mozilla.org/
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeNonInheritableGroupAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/removeNonInheritableGroupAttrs.js

--- a/docs/03-plugins/remove-off-canvas-paths.mdx
+++ b/docs/03-plugins/remove-off-canvas-paths.mdx
@@ -4,19 +4,19 @@ svgo:
   pluginId: removeOffCanvasPaths
 ---
 
-If a [`viewBox`](https://developer.mozilla.org/docs/Web/SVG/Attribute/viewBox) is present, 
+If a [`viewBox`](https://developer.mozilla.org/docs/Web/SVG/Attribute/viewBox) is present,
 removes [`<path>`](https://developer.mozilla.org/docs/Web/SVG/Element/path) elements that are drawn outside of it.
 
 Elements with a [`transform`](https://developer.mozilla.org/docs/Web/SVG/Attribute/transform) attribute are ignored, to avoid falsely removing elements that are brought into view through styles or an animation.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeOffCanvasPaths.js
+- https://github.com/svg/svgo/blob/main/plugins/removeOffCanvasPaths.js

--- a/docs/03-plugins/remove-raster-images.mdx
+++ b/docs/03-plugins/remove-raster-images.mdx
@@ -8,12 +8,12 @@ Removes inline JPEGs, PNGs, and GIFs from the document.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeRasterImages.js
+- https://github.com/svg/svgo/blob/main/plugins/removeRasterImages.js

--- a/docs/03-plugins/remove-scripts.mdx
+++ b/docs/03-plugins/remove-scripts.mdx
@@ -16,18 +16,18 @@ This **will** break interactive SVGs that rely on JavaScript.
 
 This plugin performs the following operations:
 
-* Removes [`<script>`](https://developer.mozilla.org/docs/Web/SVG/Element/script) elements.
-* Removes [SVG event attributes](https://developer.mozilla.org/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
-* Collapses [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a) elements, moving children up to the parent element.
+- Removes [`<script>`](https://developer.mozilla.org/docs/Web/SVG/Element/script) elements.
+- Removes [SVG event attributes](https://developer.mozilla.org/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
+- Collapses [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a) elements, moving children up to the parent element.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeScriptElement.js
+- https://github.com/svg/svgo/blob/main/plugins/removeScriptElement.js

--- a/docs/03-plugins/remove-style-element.mdx
+++ b/docs/03-plugins/remove-style-element.mdx
@@ -8,12 +8,12 @@ Remove all [`<style>`](https://developer.mozilla.org/docs/Web/SVG/Element/style)
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeStyleElement.js
+- https://github.com/svg/svgo/blob/main/plugins/removeStyleElement.js

--- a/docs/03-plugins/remove-title.mdx
+++ b/docs/03-plugins/remove-title.mdx
@@ -11,19 +11,19 @@ This plugin may have significant accessibility implications. The purpose of `<ti
 
 It can be sensible to remove the `<title>` element in one of the following scenarios:
 
-*  The SVG is purly aesthetic and has no impact on the user-experience.
-* Accessibility is handled elsewhere, such as in the [`aria-label`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-describedby`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes in an HTML document.
+- The SVG is purly aesthetic and has no impact on the user-experience.
+- Accessibility is handled elsewhere, such as in the [`aria-label`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-describedby`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes in an HTML document.
 
 Consider doing the free [Introduction to Web Accessibility](https://www.w3.org/WAI/courses/foundations-course/) course by W3Cx for more information.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeTitle.js
+- https://github.com/svg/svgo/blob/main/plugins/removeTitle.js

--- a/docs/03-plugins/remove-unknowns-and-defaults.mdx
+++ b/docs/03-plugins/remove-unknowns-and-defaults.mdx
@@ -31,16 +31,16 @@ Removes unknown elements and attributes, as well as attributes that are set to t
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeUnknownsAndDefaults.js
+- https://github.com/svg/svgo/blob/main/plugins/removeUnknownsAndDefaults.js

--- a/docs/03-plugins/remove-unused-namespaces.mdx
+++ b/docs/03-plugins/remove-unused-namespaces.mdx
@@ -15,12 +15,12 @@ This plugin currently only removes unused namespaces from the top-most `<svg>` e
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeUnusedNS.js
+- https://github.com/svg/svgo/blob/main/plugins/removeUnusedNS.js

--- a/docs/03-plugins/remove-useless-defs.mdx
+++ b/docs/03-plugins/remove-useless-defs.mdx
@@ -9,12 +9,12 @@ Removes children of [`<defs>`](https://developer.mozilla.org/docs/Web/SVG/Elemen
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeUselessDefs.js
+- https://github.com/svg/svgo/blob/main/plugins/removeUselessDefs.js

--- a/docs/03-plugins/remove-useless-stroke-and-fill.mdx
+++ b/docs/03-plugins/remove-useless-stroke-and-fill.mdx
@@ -21,16 +21,16 @@ Assigning these attributes can sometimes change nothing in the document. For exa
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeUselessStrokeAndFill.js
+- https://github.com/svg/svgo/blob/main/plugins/removeUselessStrokeAndFill.js

--- a/docs/03-plugins/remove-viewbox.mdx
+++ b/docs/03-plugins/remove-viewbox.mdx
@@ -19,12 +19,12 @@ See [svg/svgo#1128](https://github.com/svg/svgo/issues/1128) for more context.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeViewBox.js
+- https://github.com/svg/svgo/blob/main/plugins/removeViewBox.js

--- a/docs/03-plugins/remove-xlink.mdx
+++ b/docs/03-plugins/remove-xlink.mdx
@@ -10,11 +10,11 @@ svgo:
 
 Removes XLink namespace prefixes and converts references to XLink attributes to the native SVG equivalent by performing the following operations:
 
-* Convert `*:href` to [`href`](https://developer.mozilla.org/docs/Web/SVG/Attribute/href).
-* Convert `*:show` to [`target`](https://developer.mozilla.org/docs/Web/SVG/Attribute/target).
-* Convert `*:title` to [`<title>`](https://developer.mozilla.org/docs/Web/SVG/Element/title).
-* Drop all other references to the XLink namespace.
-* Remove XLink namespace declarations.
+- Convert `*:href` to [`href`](https://developer.mozilla.org/docs/Web/SVG/Attribute/href).
+- Convert `*:show` to [`target`](https://developer.mozilla.org/docs/Web/SVG/Attribute/target).
+- Convert `*:title` to [`<title>`](https://developer.mozilla.org/docs/Web/SVG/Element/title).
+- Drop all other references to the XLink namespace.
+- Remove XLink namespace declarations.
 
 :::tip
 
@@ -26,11 +26,11 @@ In most cases this will remove all references to XLink, but if legacy elements t
 
 The following support `xlink:href` but not the SVG 2 `href` attribute:
 
-* [`<cursor>`](https://developer.mozilla.org/docs/Web/SVG/Element/cursor)
-* [`<filter>`](https://developer.mozilla.org/docs/Web/SVG/Element/filter)
-* [`<font-face-uri>`](https://developer.mozilla.org/docs/Web/SVG/Element/font-face-uri)
-* [`<glyphRef>`](https://developer.mozilla.org/docs/Web/SVG/Element/glyphRef)
-* [`<tref>`](https://developer.mozilla.org/docs/Web/SVG/Element/tref)
+- [`<cursor>`](https://developer.mozilla.org/docs/Web/SVG/Element/cursor)
+- [`<filter>`](https://developer.mozilla.org/docs/Web/SVG/Element/filter)
+- [`<font-face-uri>`](https://developer.mozilla.org/docs/Web/SVG/Element/font-face-uri)
+- [`<glyphRef>`](https://developer.mozilla.org/docs/Web/SVG/Element/glyphRef)
+- [`<tref>`](https://developer.mozilla.org/docs/Web/SVG/Element/tref)
 
 It's recommended to use this plugin if you intend to inline SVGs into an HTML document, `includeLegacy` can be safely set to `true` in this case too. HTML does not support explicit namespaces, so namespace prefixes are ignored by the browser anyway.
 
@@ -42,16 +42,16 @@ This replaces XLink with features that are only supported in the SVGO 2 spec, an
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeXlink.js
+- https://github.com/svg/svgo/blob/main/plugins/removeXlink.js

--- a/docs/03-plugins/remove-xml-proc-inst.mdx
+++ b/docs/03-plugins/remove-xml-proc-inst.mdx
@@ -21,12 +21,12 @@ It can be safely removed without impacting compatibility.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeXMLProcInst.js
+- https://github.com/svg/svgo/blob/main/plugins/removeXMLProcInst.js

--- a/docs/03-plugins/remove-xmlns.mdx
+++ b/docs/03-plugins/remove-xmlns.mdx
@@ -22,12 +22,12 @@ This plugin renders SVGs unusable as standalone assets, in HTML `<img>` elements
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/removeXMLNS.js
+- https://github.com/svg/svgo/blob/main/plugins/removeXMLNS.js

--- a/docs/03-plugins/reuse-paths.mdx
+++ b/docs/03-plugins/reuse-paths.mdx
@@ -18,12 +18,12 @@ If you only need SVG 2 or inline HTML compatibility, it's recommended to include
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/reusePaths.js
+- https://github.com/svg/svgo/blob/main/plugins/reusePaths.js

--- a/docs/03-plugins/sort-attrs.mdx
+++ b/docs/03-plugins/sort-attrs.mdx
@@ -7,55 +7,55 @@ svgo:
     order:
       description: An array of attribute keys to order by. Attributes not found in the array are sorted alphabetically.
       default:
-        - "id"
-        - "width"
-        - "height"
-        - "x"
-        - "x1"
-        - "x2"
-        - "y"
-        - "y1"
-        - "y2"
-        - "cx"
-        - "cy"
-        - "r"
-        - "fill"
-        - "stroke"
-        - "marker"
-        - "d"
-        - "points"
+        - 'id'
+        - 'width'
+        - 'height'
+        - 'x'
+        - 'x1'
+        - 'x2'
+        - 'y'
+        - 'y1'
+        - 'y2'
+        - 'cx'
+        - 'cy'
+        - 'r'
+        - 'fill'
+        - 'stroke'
+        - 'marker'
+        - 'd'
+        - 'points'
     xmlnsOrder:
       description: Set to <code>'front'</code> if XML namespaces should be placed infront of all other attributes.
-      default: "front"
+      default: 'front'
 ---
 
 Sorts attributes in all elements in the document. This does not reduce the size of the SVG, but improves readability and _may_ improve how compression algorithms perform on it.
 
 Here is a demonstration of SVGs that have been gzipped by [NGINX](https://nginx.org/en/docs/http/ngx_http_gzip_module.html) using the default compression level of 1.
 
-| SVG | Unsorted ¹ | Sorted ² | Reduced (%) |
-|---|---|---|---|
-| [Arch Linux Logo](https://archlinux.org/art/) | 2.61 kB | 2.61 kB | 0 kB (0%) |
-| [Blobs](https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/blob/main/backgrounds/blobs-d.svg) | 13.89 kB | 13.88 kB | 0.01 kB (0.1%) |
-| [Isometric Madness](https://inkscape.org/~Denis_Kuznetsky/%E2%98%85isometric-madness) | 123.87 kB | 120.09 kB | 3.78 kB (3.1%) |
-| [tldr-pages Banner](https://github.com/tldr-pages/tldr/blob/main/images/banner.svg) | 791 B | 786 B | 5 B (0.6%) |
-| [Wikipedia Logo](https://en.wikipedia.org/wiki/File:Wikipedia-logo-v2.svg) | 53.96 kB | 53.87 kB | 0.09 kB (0.2%) |
+| SVG                                                                                           | Unsorted ¹ | Sorted ²  | Reduced (%)    |
+| --------------------------------------------------------------------------------------------- | ---------- | --------- | -------------- |
+| [Arch Linux Logo](https://archlinux.org/art/)                                                 | 2.61 kB    | 2.61 kB   | 0 kB (0%)      |
+| [Blobs](https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/blob/main/backgrounds/blobs-d.svg) | 13.89 kB   | 13.88 kB  | 0.01 kB (0.1%) |
+| [Isometric Madness](https://inkscape.org/~Denis_Kuznetsky/%E2%98%85isometric-madness)         | 123.87 kB  | 120.09 kB | 3.78 kB (3.1%) |
+| [tldr-pages Banner](https://github.com/tldr-pages/tldr/blob/main/images/banner.svg)           | 791 B      | 786 B     | 5 B (0.6%)     |
+| [Wikipedia Logo](https://en.wikipedia.org/wiki/File:Wikipedia-logo-v2.svg)                    | 53.96 kB   | 53.87 kB  | 0.09 kB (0.2%) |
 
 ¹ Uses the default plugins preset excluding `sortAttr` and `sortDefsChildren`.  
 ² Uses the default plugins preset as-is.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ### Parameters
 
-<PluginParams/>
+<PluginParams />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/sortAttrs.js
+- https://github.com/svg/svgo/blob/main/plugins/sortAttrs.js

--- a/docs/03-plugins/sort-defs-children.mdx
+++ b/docs/03-plugins/sort-defs-children.mdx
@@ -9,31 +9,31 @@ Sorts all children in the `<defs>` element. This does not reduce the size of the
 
 To group similar nodes together, elements are sorted by the following attributes:
 
-* Frequency
-* Element name length
-* Element name
+- Frequency
+- Element name length
+- Element name
 
 Here is a demonstration of SVGs that have been gzipped by [NGINX](https://nginx.org/en/docs/http/ngx_http_gzip_module.html) using the default compression level of 1.
 
-| SVG | Unsorted ¹ | Sorted ² | Reduced (%) |
-|---|---|---|---|
-| [Arch Linux Logo](https://archlinux.org/art/) | 2.61 kB | 2.61 kB | 0 kB (0%) |
-| [Blobs](https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/blob/main/backgrounds/blobs-d.svg) | 13.89 kB | 13.88 kB | 0.01 kB (0.1%) |
-| [Isometric Madness](https://inkscape.org/~Denis_Kuznetsky/%E2%98%85isometric-madness) | 123.87 kB | 120.09 kB | 3.78 kB (3.1%) |
-| [tldr-pages Banner](https://github.com/tldr-pages/tldr/blob/main/images/banner.svg) | 791 B | 786 B | 5 B (0.6%) |
-| [Wikipedia Logo](https://en.wikipedia.org/wiki/File:Wikipedia-logo-v2.svg) | 53.96 kB | 53.87 kB | 0.09 kB (0.2%) |
+| SVG                                                                                           | Unsorted ¹ | Sorted ²  | Reduced (%)    |
+| --------------------------------------------------------------------------------------------- | ---------- | --------- | -------------- |
+| [Arch Linux Logo](https://archlinux.org/art/)                                                 | 2.61 kB    | 2.61 kB   | 0 kB (0%)      |
+| [Blobs](https://gitlab.gnome.org/GNOME/gnome-backgrounds/-/blob/main/backgrounds/blobs-d.svg) | 13.89 kB   | 13.88 kB  | 0.01 kB (0.1%) |
+| [Isometric Madness](https://inkscape.org/~Denis_Kuznetsky/%E2%98%85isometric-madness)         | 123.87 kB  | 120.09 kB | 3.78 kB (3.1%) |
+| [tldr-pages Banner](https://github.com/tldr-pages/tldr/blob/main/images/banner.svg)           | 791 B      | 786 B     | 5 B (0.6%)     |
+| [Wikipedia Logo](https://en.wikipedia.org/wiki/File:Wikipedia-logo-v2.svg)                    | 53.96 kB   | 53.87 kB  | 0.09 kB (0.2%) |
 
 ¹ Uses the default plugins preset excluding `sortAttr` and `sortDefsChildren`.  
 ² Uses the default plugins preset as-is.
 
 ## Usage
 
-<PluginUsage/>
+<PluginUsage />
 
 ## Demo
 
-<PluginDemo/>
+<PluginDemo />
 
 ## Implementation
 
-* https://github.com/svg/svgo/blob/main/plugins/sortDefsChildren.js
+- https://github.com/svg/svgo/blob/main/plugins/sortDefsChildren.js

--- a/docs/04-plugins-api.mdx
+++ b/docs/04-plugins-api.mdx
@@ -12,8 +12,8 @@ A minimal plugin looks like this:
 export const myPlugin = {
   name: 'myPlugin',
   description: 'A plugin that does nothing.',
-  fn: () => {}
-}
+  fn: () => {},
+};
 ```
 
 It currently does nothing, but can still be referenced in your `svgo.config.js`:
@@ -22,10 +22,8 @@ It currently does nothing, but can still be referenced in your `svgo.config.js`:
 import { myPlugin } from './myPlugin.js';
 
 export default {
-  plugins: [
-    myPlugin
-  ]
-}
+  plugins: [myPlugin],
+};
 ```
 
 The visitor pattern lets you to access nodes as the parser enters and exits them, in the order that the respective tag appears.
@@ -40,35 +38,35 @@ const myPlugin = {
     return {
       root: {
         enter: (node) => {},
-        exit: (node) => {}
+        exit: (node) => {},
       },
       element: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
+        exit: (node, parentNode) => {},
       },
       doctype: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
+        exit: (node, parentNode) => {},
       },
       instruction: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
+        exit: (node, parentNode) => {},
       },
       comment: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
+        exit: (node, parentNode) => {},
       },
       cdata: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
+        exit: (node, parentNode) => {},
       },
       text: {
         enter: (node, parentNode) => {},
-        exit: (node, parentNode) => {}
-      }
-    }
-  }
-}
+        exit: (node, parentNode) => {},
+      },
+    };
+  },
+};
 ```
 
 Where a parent node is present, it will always be a direct child of the current node.
@@ -90,11 +88,11 @@ const myPlugin = {
           }
 
           node.attributes.fill = 'pink';
-        }
-      }
-    }
-  }
-}
+        },
+      },
+    };
+  },
+};
 ```
 
 Remove a node from its parent:
@@ -114,9 +112,9 @@ const removeNoAttributes = {
           parentNode.children = parentNode.children.filter(
             (child) => child !== node
           );
-        }
-      }
-    }
-  }
-}
+        },
+      },
+    };
+  },
+};
 ```

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=4 --coverage",
-    "lint": "eslint --ignore-path .gitignore . && prettier --check \"**/*.js\" --ignore-path .gitignore",
-    "fix": "eslint --ignore-path .gitignore --fix . && prettier --write \"**/*.js\" --ignore-path .gitignore",
+    "lint": "eslint --ignore-path .gitignore . && prettier --check . --ignore-path .gitignore",
+    "fix": "eslint --ignore-path .gitignore --fix . && prettier --write . --ignore-path .gitignore",
     "typecheck": "tsc",
     "test-browser": "rollup -c && node ./test/browser.js",
     "test-regression": "node ./test/regression-extract.js && NO_DIFF=1 node ./test/regression.js",

--- a/plugins/plugins-types.d.ts
+++ b/plugins/plugins-types.d.ts
@@ -249,7 +249,7 @@ export type BuiltinsWithOptionalParams = DefaultPlugins & {
      *
      * @default false
      */
-    includeLegacy: boolean
+    includeLegacy: boolean;
   };
   removeXMLNS: void;
   reusePaths: void;


### PR DESCRIPTION
Let prettier format Markdown, YAML, TypeScript, and JSON files. This makes contributing easier as contributors don't need to learn the project's particular formatting style and can instead let the tool handle it.

This is a followup to using prettier for JavaScript in commit a99cc08e4f6a1bc9b6d61b65e14c138195ba14c1.