### PR TITLE
feat(removeUnknownAndDefaults): apply to xml declarations

### DIFF
--- a/docs/03-plugins/remove-unknowns-and-defaults.mdx
+++ b/docs/03-plugins/remove-unknowns-and-defaults.mdx
@@ -13,6 +13,9 @@ svgo:
     defaultAttrs:
       description: If to remove attributes that are assigned their default value anyway.
       default: true
+    defaultMarkupDeclarations:
+      description: If to remove XML declarations that are assigned their default value. XML declarations are the properties in the <code>&lt;?xml … ?&gt;</code> block at the top of the document.
+      default: true
     uselessOverrides:
       description: If to remove attributes that are being if the same value is being inherited by it's parent element anyway.
       default: true
@@ -28,6 +31,8 @@ svgo:
 ---
 
 Removes unknown elements and attributes, as well as attributes that are set to their default value.
+
+This can also remove defaults from the XML declaration if present in the document, namely [`standalone`](https://www.w3.org/TR/REC-xml/#sec-rmd) if it's set to `no`.
 
 ## Usage
 

--- a/docs/03-plugins/remove-xml-proc-inst.mdx
+++ b/docs/03-plugins/remove-xml-proc-inst.mdx
@@ -17,7 +17,7 @@ An XML declaration is the line at the top of an XML file to indicate document me
 
 The XML declaration is optional in [XML 1.0](https://www.w3.org/TR/REC-xml/#sec-prolog-dtd), but mandatory in the [XML 1.1](https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-prolog-dtd). If the XML declaration is omitted, the document is assumed to follow the XML 1.0 specifications, which won't impact SVG documents.
 
-It can be safely removed without impacting compatibility.
+It can be safely removed without impacting compatibility with SVG clients. However, some tools may fail to detect the MIME-type as `image/svg+xml` if this is removed.
 
 ## Usage
 

--- a/plugins/plugins-types.d.ts
+++ b/plugins/plugins-types.d.ts
@@ -14,8 +14,8 @@ type DefaultPlugins = {
   cleanupIds: {
     remove?: boolean;
     minify?: boolean;
-    preserve?: Array<string>;
-    preservePrefixes?: Array<string>;
+    preserve?: string[];
+    preservePrefixes?: string[];
     force?: boolean;
   };
   cleanupNumericValues: {
@@ -146,7 +146,7 @@ type DefaultPlugins = {
   };
   removeDoctype: void;
   removeEditorsNSData: {
-    additionalNamespaces?: Array<string>;
+    additionalNamespaces?: string[];
   };
   removeEmptyAttrs: void;
   removeEmptyContainers: void;
@@ -179,6 +179,12 @@ type DefaultPlugins = {
     unknownContent?: boolean;
     unknownAttrs?: boolean;
     defaultAttrs?: boolean;
+    /**
+     * If to remove XML declarations that are assigned their default value. XML
+     * declarations are the properties in the `<?xml … ?>` block at the top of
+     * the document.
+     */
+    defaultMarkupDeclarations?: boolean;
     uselessOverrides?: boolean;
     keepDataAttrs?: boolean;
     keepAriaAttrs?: boolean;
@@ -194,7 +200,7 @@ type DefaultPlugins = {
   removeViewBox: void;
   removeXMLProcInst: void;
   sortAttrs: {
-    order?: Array<string>;
+    order?: string[];
     xmlnsOrder?: 'front' | 'alphabetical';
   };
   sortDefsChildren: void;
@@ -262,17 +268,17 @@ export type BuiltinsWithRequiredParams = {
   };
   addClassesToSVGElement: {
     className?: string;
-    classNames?: Array<string>;
+    classNames?: string[];
   };
   removeAttributesBySelector: any;
   removeAttrs: {
     elemSeparator?: string;
     preserveCurrentColor?: boolean;
-    attrs: string | Array<string>;
+    attrs: string | string[];
   };
   removeElementsByAttr: {
-    id?: string | Array<string>;
-    class?: string | Array<string>;
+    id?: string | string[];
+    class?: string | string[];
   };
 };
 

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -99,6 +99,7 @@ exports.fn = (root, params) => {
     unknownContent = true,
     unknownAttrs = true,
     defaultAttrs = true,
+    defaultMarkupDeclarations = true,
     uselessOverrides = true,
     keepDataAttrs = true,
     keepAriaAttrs = true,
@@ -107,6 +108,13 @@ exports.fn = (root, params) => {
   const stylesheet = collectStylesheet(root);
 
   return {
+    instruction: {
+      enter: (node) => {
+        if (defaultMarkupDeclarations) {
+          node.value = node.value.replace(/\s*standalone\s*=\s*(["'])no\1/, '');
+        }
+      },
+    },
     element: {
       enter: (node, parentNode) => {
         // skip namespaced elements

--- a/test/plugins/removeUnknownsAndDefaults.16.svg
+++ b/test/plugins/removeUnknownsAndDefaults.16.svg
@@ -1,0 +1,17 @@
+Removes standalone="no" XML declaration.
+
+See: https://github.com/svg/svgo/issues/836
+
+===
+
+<?xml version="1.0" standalone="no"?>
+<svg width="64" height="18" xmlns="http://www.w3.org/2000/svg">
+  <text x="4" y="18">uwu</text>
+</svg>
+
+@@@
+
+<?xml version="1.0"?>
+<svg width="64" height="18" xmlns="http://www.w3.org/2000/svg">
+    <text x="4" y="18">uwu</text>
+</svg>


### PR DESCRIPTION
As `standalone="no"` is the default value in the XML declaration, it can be safely removed. I've separated this into a separate parameter of the `removeUnknownsAndDefaults` plugin, and is enabled by default.

Our XML parser doesn't parse the individual properties in the XML declaration, so we just get the full string of all values. Rather than parse it myself, I opted to use a regex to pull out the sole value we're interested in, since it's the only one with a default.

See: https://www.w3.org/TR/REC-xml/#sec-rmd

The regex would do the following conversions:

```xml
<?xml version="1.0" standalone="no"?>
→
<?xml version="1.0"?>

<?xml standalone='no' version='1.0'?>
→
<?xml version='1.0'?>

<?xml encoding="utf-8" standalone="no" version="1.0"?>
→
<?xml encoding="utf-8" version="1.0"?>
```

* Closes https://github.com/svg/svgo/issues/836