### PR TITLE
chore: Add dependabot config for action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
I went with monthly so that it's not too noisy, but should still help keeping up actions up to date.