### PR TITLE
chore: Run CI on all branches to assist contributors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,8 @@ env:
   FORCE_COLOR: 2
   NODE: 20
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  - push
+  - pull_request
 
 permissions:
   contents: read


### PR DESCRIPTION
Running CI on all branches allows contributors to run GitHub actions on their fork with minimal resistance. The contributor can inspect the results of their fork before opening a PR.