### PR TITLE
fix(removeHiddenElems): handle defs better

### DIFF
--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -81,7 +81,7 @@ exports.fn = (root, params) => {
   const allDefs = new Map();
 
   /**
-   * @type {Map<string, Array<{node: XastElement, parentNode: XastParent }>>}
+   * @type {Map<string, Array<{ node: XastElement, parentNode: XastParent }>>}
    */
   const referencesById = new Map();
 
@@ -396,7 +396,6 @@ exports.fn = (root, params) => {
     },
     root: {
       exit: () => {
-        // Remove uses of deleted definitions
         for (const id of removedDefIds) {
           const refs = referencesById.get(id);
           if (refs) {
@@ -406,7 +405,6 @@ exports.fn = (root, params) => {
           }
         }
 
-        // Remove definitions that are unused
         if (!deoptimized) {
           for (const [
             nonRenderedNode,
@@ -425,7 +423,6 @@ exports.fn = (root, params) => {
           }
         }
 
-        // Remove empty defs
         for (const [node, parentNode] of allDefs.entries()) {
           if (node.children.length === 0) {
             detachNodeFromParent(node, parentNode);

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -143,19 +143,16 @@ exports.fn = (root, params) => {
           return;
         }
 
-        // Store uses so that they can be removed if broken
-        // and used to determine if a definition is unused
-        if (node.name == 'use') {
-          const reference = Object.keys(node.attributes).find(
-            (attr) => attr === 'href' || attr.endsWith('href')
-          );
-          const referenceValue = reference && node.attributes[reference];
-          const referenceId = referenceValue && referenceValue.slice(1);
-          if (referenceId) {
-            let refs = referencesById.get(referenceId);
+        if (node.name === 'use') {
+          for (const attr of Object.keys(node.attributes)) {
+            if (attr !== 'href' && !attr.endsWith(':href')) continue;
+            const value = node.attributes[attr];
+            const id = value.slice(1);
+
+            let refs = referencesById.get(id);
             if (!refs) {
               refs = [];
-              referencesById.set(referenceId, refs);
+              referencesById.set(id, refs);
             }
             refs.push({ node, parentNode });
           }

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -120,7 +120,6 @@ exports.fn = (root, params) => {
           nonRenderedNodes.set(node, parentNode);
           return visitSkip;
         }
-
         const computedStyle = computeStyle(stylesheet, node);
         // opacity="0"
         //

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -81,13 +81,6 @@ exports.fn = (root, params) => {
   const allDefs = new Map();
 
   /**
-   * Defs that may have had their children removed.
-   *
-   * @type {Set<XastParent>}
-   */
-  const affectedDefs = new Set();
-
-  /**
    * @type {Map<string, Array<{node: XastElement, parentNode: XastParent }>>}
    */
   const referencesById = new Map();
@@ -103,16 +96,12 @@ exports.fn = (root, params) => {
    */
   function removeElement(node, parentNode) {
     if (
+      node.type === 'element' &&
+      node.attributes.id != null &&
       parentNode.type === 'element' &&
       parentNode.name === 'defs'
     ) {
-      affectedDefs.add(parentNode)
-      if (
-        node.type === 'element' &&
-        node.attributes.id != null
-      ) {
-        removedDefIds.add(node.attributes.id);
-      }
+      removedDefIds.add(node.attributes.id);
     }
 
     detachNodeFromParent(node, parentNode);
@@ -438,10 +427,9 @@ exports.fn = (root, params) => {
         }
 
         // Remove empty defs
-        for (const node of affectedDefs) {
+        for (const [node, parentNode] of allDefs.entries()) {
           if (node.children.length === 0) {
-            const parentNode = allDefs.get(node);
-            detachNodeFromParent(node, parentNode)
+            detachNodeFromParent(node, parentNode);
           }
         }
       },

--- a/test/plugins/removeHiddenElems.14.svg
+++ b/test/plugins/removeHiddenElems.14.svg
@@ -11,4 +11,4 @@ Remove unused defs
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"/>
+<svg xmlns="http://www.w3.org/2000/svg"/>

--- a/test/plugins/removeHiddenElems.14.svg
+++ b/test/plugins/removeHiddenElems.14.svg
@@ -1,0 +1,14 @@
+Remove unused defs
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="a">
+        </linearGradient>
+    </defs>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"/>

--- a/test/plugins/removeHiddenElems.15.svg
+++ b/test/plugins/removeHiddenElems.15.svg
@@ -1,0 +1,20 @@
+Don't remove used defs
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <defs>
+        <linearGradient id="a">
+        </linearGradient>
+    </defs>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <defs>
+        <linearGradient id="a"/>
+    </defs>
+</svg>


### PR DESCRIPTION
Relocate logic to run in node.exit instead of checking in svg's exit:
  - remove broken uses
  Changed from checking each use to making a list of uses, to fix #1851
  - remove unused defs
  Fixed a typo so it actually removes them, and add some safeguards
  - remove empty defs
  Changed from checking each def to making a list of defs
