### PR TITLE
fix(cleanupIds): handle uri encoded references

### DIFF
--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -215,10 +215,11 @@ exports.fn = (_root, params) => {
               }
             }
             for (const id of ids) {
-              let refs = referencesById.get(id);
+              const decodedId = decodeURI(id);
+              let refs = referencesById.get(decodedId);
               if (refs == null) {
                 refs = [];
-                referencesById.set(id, refs);
+                referencesById.set(decodedId, refs);
               }
               refs.push({ element: node, name });
             }
@@ -261,7 +262,7 @@ exports.fn = (_root, params) => {
                 if (value.includes('#')) {
                   // replace id in href and url()
                   element.attributes[name] = value.replace(
-                    `#${id}`,
+                    `#${encodeURI(id)}`,
                     `#${currentIdString}`
                   );
                 } else {

--- a/test/plugins/cleanupIds.25.svg
+++ b/test/plugins/cleanupIds.25.svg
@@ -1,0 +1,21 @@
+Should handle non-ASCII IDs and resolve URI encoded references.
+
+See: https://github.com/svg/svgo/issues/1696
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9">
+  <defs>
+    <path id="人口" d="M1 1l2 2" stroke="black"/>
+  </defs>
+  <use href="#%E4%BA%BA%E5%8F%A3"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9">
+    <defs>
+        <path id="a" d="M1 1l2 2" stroke="black"/>
+    </defs>
+    <use href="#a"/>
+</svg>


### PR DESCRIPTION
References to IDs in `href` or `url()` references are URIs, and so should be URI encoded/decoded.

We'll have to review and update all usage in SVGO for this, but for now, I've resolved the immediate issue found in Cleanup IDs.

## Related

* Fixes https://github.com/svg/svgo/issues/1696