### PR TITLE
fix: improve handling of url references in reference attributes

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -6,7 +6,11 @@
  * @typedef {import('../types').DataUri} DataUri
  */
 
-const { attrsGroups } = require('../../plugins/_collections');
+const { attrsGroups, referencesProps } = require('../../plugins/_collections');
+
+const regReferencesUrl = /\burl\((["'])?#(.+?)\1\)/g;
+const regReferencesHref = /^#(.+?)$/;
+const regReferencesBegin = /(\w+)\.[a-zA-Z]/;
 
 /**
  * Encode plain SVG data string into Data URI string.
@@ -188,6 +192,39 @@ exports.hasScripts = hasScripts;
  * @returns {boolean} If the given string includes a URL reference.
  */
 const includesUrlReference = (body) => {
-  return /\burl\((["'])?#(.+?)\1\)/g.test(body);
+  return new RegExp(regReferencesUrl).test(body);
 };
 exports.includesUrlReference = includesUrlReference;
+
+/**
+ * @param {string} attribute
+ * @param {string} value
+ * @returns {string[]}
+ */
+const findReferences = (attribute, value) => {
+  const results = [];
+
+  if (referencesProps.includes(attribute)) {
+    const matches = value.matchAll(regReferencesUrl);
+    for (const match of matches) {
+      results.push(match[2]);
+    }
+  }
+
+  if (attribute === 'href' || attribute.endsWith(':href')) {
+    const match = regReferencesHref.exec(value);
+    if (match != null) {
+      results.push(match[1]);
+    }
+  }
+
+  if (attribute === 'begin') {
+    const match = regReferencesBegin.exec(value);
+    if (match != null) {
+      results.push(match[1]);
+    }
+  }
+
+  return results.map((body) => decodeURI(body));
+};
+exports.findReferences = findReferences;

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -237,8 +237,8 @@ exports.fn = (_root, params, info) => {
             node.attributes[name].length !== 0
           ) {
             node.attributes[name] = node.attributes[name].replace(
-              /url\((.*?)\)/gi,
-              (match, url) => {
+              /\burl\((["'])?(#.+?)\1\)/gi,
+              (match, _, url) => {
                 const prefixed = prefixReference(prefixGenerator, url);
                 if (prefixed == null) {
                   return match;


### PR DESCRIPTION
In multiple areas in the code, we were handling URL references in attributes poorly. Namely, when checking for them, we should check for `url(#a)`, `url('#a')`, and `url("#a")`, but in some places we were only checking the first.

This also migrates some logic from `cleanupIds` to a new utility to centralize collecting references from an attribute, which is already being used by another plugin.

## Related

* Closes https://github.com/svg/svgo/issues/1711