### PR TITLE
Tidy up eslint config and usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,10 +89,19 @@
     "overrides": [
       {
         "files": [
-          "rollup.config.js"
+          "rollup.config.js",
+          "**/*.mjs"
         ],
         "parserOptions": {
           "sourceType": "module"
+        }
+      },
+      {
+        "files": [
+          "**/*.cjs"
+        ],
+        "parserOptions": {
+          "sourceType": "commonjs"
         }
       },
       {

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -267,7 +267,6 @@ exports.intersects = function (path1, path2) {
       var iterations = 1e4; // infinite loop protection, 10 000 iterations is more than enough
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        // eslint-disable-next-line no-constant-condition
         if (iterations-- == 0) {
           console.error(
             'Error: infinite loop while processing mergePaths plugin.'

--- a/plugins/_transforms.js
+++ b/plugins/_transforms.js
@@ -37,7 +37,6 @@ exports.transform2js = (transformString) => {
         // else if item is data
       } else {
         // then split it into [10, 50] and collect as context.data
-        // eslint-disable-next-line no-cond-assign
         while ((num = regNumericValues.exec(item))) {
           num = Number(num);
           if (current != null) {

--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -93,7 +93,6 @@ exports.fn = (_root, params) => {
           );
 
           regDeclarationBlock.lastIndex = 0;
-          // eslint-disable-next-line no-cond-assign
           for (var rule; (rule = regDeclarationBlock.exec(styleValue)); ) {
             if (!keepImportant || !rule[3]) {
               styles.push([rule[1], rule[2]]);


### PR DESCRIPTION
- Include *.mjs and *.cjs files in the eslint configuration. These files exist in the test suite.

- Remove eslint-disable comments that aren't silencing a error.