### PR TITLE
chore: updating prettier and eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,30 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2021
+  },
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "overrides": [
+    {
+      "files": ["rollup.config.js", "**/*.mjs"],
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    },
+    {
+      "files": ["**/*.cjs"],
+      "parserOptions": {
+        "sourceType": "commonjs"
+      }
+    },
+    {
+      "files": ["**/*.test.js"],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/bin/svgo
+++ b/bin/svgo
@@ -4,7 +4,7 @@ const colors = require('picocolors');
 const { program } = require('commander');
 const makeProgram = require('../lib/svgo/coa');
 makeProgram(program);
-program.parseAsync(process.argv).catch(error => {
+program.parseAsync(process.argv).catch((error) => {
   console.error(colors.red(error.stack));
   process.exit(1);
 });

--- a/docs/04-plugins-api.mdx
+++ b/docs/04-plugins-api.mdx
@@ -110,7 +110,7 @@ const removeNoAttributes = {
           }
 
           parentNode.children = parentNode.children.filter(
-            (child) => child !== node
+            (child) => child !== node,
           );
         },
       },

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -249,7 +249,7 @@ const parseSvg = (data, from) => {
       e.line + 1,
       e.column,
       data,
-      from
+      from,
     );
     if (e.message.indexOf('Unexpected end') === -1) {
       throw error;

--- a/lib/path.test.js
+++ b/lib/path.test.js
@@ -69,8 +69,8 @@ describe('parse path data', () => {
           25,75 -30 01.2,-25
           a25,100 -30 0150,-25
           l 50,-25
-        `
-      )
+        `,
+      ),
     ).toEqual([
       { command: 'M', args: [600, 350] },
       { command: 'l', args: [50, -25] },
@@ -95,7 +95,7 @@ describe('stringify path data', () => {
           { command: 'H', args: [40] },
           { command: 'H', args: [50] },
         ],
-      })
+      }),
     ).toEqual('M0 0h10 20 30H40 50');
   });
   it('should not combine sequence of moveto', () => {
@@ -107,7 +107,7 @@ describe('stringify path data', () => {
           { command: 'm', args: [20, 30] },
           { command: 'm', args: [40, 50] },
         ],
-      })
+      }),
     ).toEqual('M0 0M10 10m20 30m40 50');
   });
   it('should combine moveto and sequence of lineto', () => {
@@ -121,7 +121,7 @@ describe('stringify path data', () => {
           { command: 'M', args: [0, 0] },
           { command: 'L', args: [10, 10] },
         ],
-      })
+      }),
     ).toEqual('m0 0 10 10M0 0l10 10M0 0 10 10');
     expect(
       stringifyPathData({
@@ -129,7 +129,7 @@ describe('stringify path data', () => {
           { command: 'm', args: [0, 0] },
           { command: 'L', args: [10, 10] },
         ],
-      })
+      }),
     ).toEqual('M0 0 10 10');
   });
   it('should avoid space before first, negative and decimals', () => {
@@ -141,7 +141,7 @@ describe('stringify path data', () => {
           { command: 'L', args: [5, -0.6] },
           { command: 'L', args: [7, 0.8] },
         ],
-      })
+      }),
     ).toEqual('M0-1.2.3 4 5-.6 7 .8');
   });
   it('should configure precision', () => {
@@ -158,13 +158,13 @@ describe('stringify path data', () => {
       stringifyPathData({
         pathData,
         precision: 3,
-      })
+      }),
     ).toEqual('M0-1.988.3 3.142-.3-3.142 100 200');
     expect(
       stringifyPathData({
         pathData,
         precision: 0,
-      })
+      }),
     ).toEqual('M0-2 0 3 0-3 100 200');
   });
   it('allows to avoid spaces after arc flags', () => {
@@ -181,13 +181,13 @@ describe('stringify path data', () => {
       stringifyPathData({
         pathData,
         disableSpaceAfterFlags: false,
-      })
+      }),
     ).toEqual('M0 0A50 50 10 1 0 .2 20a50 50 10 1 0 .2 20 50 50 10 1 0 .2 20');
     expect(
       stringifyPathData({
         pathData,
         disableSpaceAfterFlags: true,
-      })
+      }),
     ).toEqual('M0 0A50 50 10 10.2 20a50 50 10 10.2 20 50 50 10 10.2 20');
   });
 });

--- a/lib/style.js
+++ b/lib/style.js
@@ -295,7 +295,7 @@ const includesAttrSelector = (
   selector,
   name,
   value = null,
-  traversed = false
+  traversed = false,
 ) => {
   const selectors =
     typeof selector === 'string'

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -65,23 +65,23 @@ it('collects styles', () => {
     {
       fill: { type: 'static', inherited: false, value: 'green' },
       stroke: { type: 'static', inherited: false, value: 'black' },
-    }
+    },
   );
   expect(computeStyle(stylesheet, getElementById(root, 'attribute'))).toEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
   expect(
-    computeStyle(stylesheet, getElementById(root, 'inline-style'))
+    computeStyle(stylesheet, getElementById(root, 'inline-style')),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'grey' },
   });
   expect(computeStyle(stylesheet, getElementById(root, 'inheritance'))).toEqual(
     {
       fill: { type: 'static', inherited: true, value: 'yellow' },
-    }
+    },
   );
   expect(
-    computeStyle(stylesheet, getElementById(root, 'nested-inheritance'))
+    computeStyle(stylesheet, getElementById(root, 'nested-inheritance')),
   ).toEqual({
     fill: { type: 'static', inherited: true, value: 'blue' },
   });
@@ -106,30 +106,33 @@ it('prioritizes different kinds of styles', () => {
     `);
   const stylesheet = collectStylesheet(root);
   expect(
-    computeStyle(stylesheet, getElementById(root, 'complex-selector'))
+    computeStyle(stylesheet, getElementById(root, 'complex-selector')),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'red' },
   });
   expect(
-    computeStyle(stylesheet, getElementById(root, 'override-selector'))
-  ).toEqual({
-    fill: { type: 'static', inherited: false, value: 'blue' },
-  });
-  expect(
-    computeStyle(stylesheet, getElementById(root, 'attribute-over-inheritance'))
-  ).toEqual({
-    fill: { type: 'static', inherited: false, value: 'orange' },
-  });
-  expect(
-    computeStyle(stylesheet, getElementById(root, 'style-rule-over-attribute'))
+    computeStyle(stylesheet, getElementById(root, 'override-selector')),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
   expect(
     computeStyle(
       stylesheet,
-      getElementById(root, 'inline-style-over-style-rule')
-    )
+      getElementById(root, 'attribute-over-inheritance'),
+    ),
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'orange' },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'style-rule-over-attribute')),
+  ).toEqual({
+    fill: { type: 'static', inherited: false, value: 'blue' },
+  });
+  expect(
+    computeStyle(
+      stylesheet,
+      getElementById(root, 'inline-style-over-style-rule'),
+    ),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
@@ -149,23 +152,23 @@ it('prioritizes important styles', () => {
     `);
   const stylesheet = collectStylesheet(root);
   expect(
-    computeStyle(stylesheet, getElementById(root, 'complex-selector'))
+    computeStyle(stylesheet, getElementById(root, 'complex-selector')),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
     computeStyle(
       stylesheet,
-      getElementById(root, 'style-rule-over-inline-style')
-    )
+      getElementById(root, 'style-rule-over-inline-style'),
+    ),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
     computeStyle(
       stylesheet,
-      getElementById(root, 'inline-style-over-style-rule')
-    )
+      getElementById(root, 'inline-style-over-style-rule'),
+    ),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
@@ -195,7 +198,7 @@ it('treats at-rules and pseudo-classes as dynamic styles', () => {
   expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
     {
       fill: { type: 'dynamic', inherited: false },
-    }
+    },
   );
   expect(computeStyle(stylesheet, getElementById(root, 'hover'))).toEqual({
     fill: { type: 'dynamic', inherited: false },
@@ -204,7 +207,7 @@ it('treats at-rules and pseudo-classes as dynamic styles', () => {
     fill: { type: 'dynamic', inherited: true },
   });
   expect(
-    computeStyle(stylesheet, getElementById(root, 'inherited-overriden'))
+    computeStyle(stylesheet, getElementById(root, 'inherited-overriden')),
   ).toEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
@@ -234,10 +237,10 @@ it('considers <style> media attribute', () => {
   expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
     {
       fill: { type: 'dynamic', inherited: false },
-    }
+    },
   );
   expect(
-    computeStyle(stylesheet, getElementById(root, 'kinda-static'))
+    computeStyle(stylesheet, getElementById(root, 'kinda-static')),
   ).toEqual({
     fill: { type: 'dynamic', inherited: false },
   });
@@ -271,7 +274,7 @@ it('ignores <style> with invalid type', () => {
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
-    computeStyle(stylesheet, getElementById(root, 'invalid-type'))
+    computeStyle(stylesheet, getElementById(root, 'invalid-type')),
   ).toEqual({});
 });
 

--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -25,7 +25,7 @@ describeLF('with LF line-endings', () => {
     const { data } = optimize(svg);
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>'
+      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
 
@@ -44,7 +44,7 @@ describeLF('with LF line-endings', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
 
@@ -63,7 +63,7 @@ describeLF('with LF line-endings', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n'
+      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
 });
@@ -82,7 +82,7 @@ describeCRLF('with CRLF line-endings', () => {
     const { data } = optimize(svg);
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>'
+      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
 
@@ -101,7 +101,7 @@ describeCRLF('with CRLF line-endings', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n'
+      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
 
@@ -120,7 +120,7 @@ describeCRLF('with CRLF line-endings', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
 });
@@ -145,7 +145,7 @@ describe('loadConfig', () => {
       plugins: [],
     });
     expect(
-      await loadConfig(null, path.join(cwd, './test/fixtures/missing'))
+      await loadConfig(null, path.join(cwd, './test/fixtures/missing')),
     ).toEqual(null);
     expect(await loadConfig(null, path.join(fixtures, 'mjs'))).toEqual({
       plugins: ['mjs'],

--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -61,9 +61,9 @@ export declare function optimize(input: string, config?: Config): Output;
  */
 export declare function loadConfig(
   configFile: string,
-  cwd?: string
+  cwd?: string,
 ): Promise<Config>;
 export declare function loadConfig(
   configFile?: null,
-  cwd?: string
+  cwd?: string,
 ): Promise<Config | null>;

--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -67,7 +67,7 @@ const optimize = (input, config) => {
     const plugins = config.plugins || ['preset-default'];
     if (!Array.isArray(plugins)) {
       throw Error(
-        'malformed config, `plugins` property must be an array.\nSee more info here: https://github.com/svg/svgo#configuration'
+        'malformed config, `plugins` property must be an array.\nSee more info here: https://github.com/svg/svgo#configuration',
       );
     }
     const resolvedPlugins = plugins
@@ -76,7 +76,7 @@ const optimize = (input, config) => {
 
     if (resolvedPlugins.length < plugins.length) {
       console.warn(
-        'Warning: plugins list includes null or undefined elements, these will be ignored.'
+        'Warning: plugins list includes null or undefined elements, these will be ignored.',
       );
     }
     const globalOverrides = {};

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -111,7 +111,7 @@ describe('allow to configure EOL', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
 
@@ -130,7 +130,7 @@ describe('allow to configure EOL', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n'
+      '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
 
@@ -149,7 +149,7 @@ describe('allow to configure EOL', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
 });
@@ -168,7 +168,7 @@ describe('allow to configure final newline', () => {
     const { data } = optimize(svg, { js2svg: { eol: 'lf' } });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>'
+      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
 
@@ -187,7 +187,7 @@ describe('allow to configure final newline', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>\n'
+      '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>\n',
     );
   });
 
@@ -206,7 +206,7 @@ describe('allow to configure final newline', () => {
     });
     // using toEqual because line endings matter in these tests
     expect(data).toEqual(
-      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n'
+      '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
 });
@@ -392,7 +392,7 @@ test('encode as datauri', () => {
     plugins: ['convertTransform'],
   });
   expect(dataSinglePass).toMatchInlineSnapshot(
-    `"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20transform%3D%22scale(2)rotate(-45%20130.898%20-126.14)%22%2F%3E%3C%2Fsvg%3E"`
+    `"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20transform%3D%22scale(2)rotate(-45%20130.898%20-126.14)%22%2F%3E%3C%2Fsvg%3E"`,
   );
   const { data: dataMultiPass } = optimize(input, {
     multipass: true,
@@ -400,6 +400,6 @@ test('encode as datauri', () => {
     plugins: ['convertTransform'],
   });
   expect(dataMultiPass).toMatchInlineSnapshot(
-    `"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20transform%3D%22rotate(-45%20261.796%20-252.28)scale(2)%22%2F%3E%3C%2Fsvg%3E"`
+    `"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20transform%3D%22rotate(-45%20261.796%20-252.28)scale(2)%22%2F%3E%3C%2Fsvg%3E"`,
   );
 });

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -35,43 +35,43 @@ module.exports = function makeProgram(program) {
     .option('-s, --string <STRING>', 'Input SVG data string')
     .option(
       '-f, --folder <FOLDER>',
-      'Input folder, optimize and rewrite all *.svg files'
+      'Input folder, optimize and rewrite all *.svg files',
     )
     .option(
       '-o, --output <OUTPUT...>',
-      'Output file or folder (by default the same as the input), "-" for STDOUT'
+      'Output file or folder (by default the same as the input), "-" for STDOUT',
     )
     .option(
       '-p, --precision <INTEGER>',
-      'Set number of digits in the fractional part, overrides plugins params'
+      'Set number of digits in the fractional part, overrides plugins params',
     )
     .option('--config <CONFIG>', 'Custom config file, only .js is supported')
     .option(
       '--datauri <FORMAT>',
-      'Output as Data URI string (base64), URI encoded (enc) or unencoded (unenc)'
+      'Output as Data URI string (base64), URI encoded (enc) or unencoded (unenc)',
     )
     .option(
       '--multipass',
-      'Pass over SVGs multiple times to ensure all optimizations are applied'
+      'Pass over SVGs multiple times to ensure all optimizations are applied',
     )
     .option('--pretty', 'Make SVG pretty printed')
     .option('--indent <INTEGER>', 'Indent number when pretty printing SVGs')
     .option(
       '--eol <EOL>',
-      'Line break to use when outputting SVG: lf, crlf. If unspecified, uses platform default.'
+      'Line break to use when outputting SVG: lf, crlf. If unspecified, uses platform default.',
     )
     .option('--final-newline', 'Ensure SVG ends with a line break')
     .option(
       '-r, --recursive',
-      "Use with '--folder'. Optimizes *.svg files in folders recursively."
+      "Use with '--folder'. Optimizes *.svg files in folders recursively.",
     )
     .option(
       '--exclude <PATTERN...>',
-      "Use with '--folder'. Exclude files matching regular expression pattern."
+      "Use with '--folder'. Exclude files matching regular expression pattern.",
     )
     .option(
       '-q, --quiet',
-      'Only output error messages, not regular status messages'
+      'Only output error messages, not regular status messages',
     )
     .option('--show-plugins', 'Show available plugins and exit')
     // used by picocolors internally
@@ -88,7 +88,7 @@ async function action(args, opts, command) {
     const number = Number.parseInt(opts.precision, 10);
     if (Number.isNaN(number)) {
       console.error(
-        "error: option '-p, --precision' argument must be an integer number"
+        "error: option '-p, --precision' argument must be an integer number",
       );
       process.exit(1);
     } else {
@@ -103,7 +103,7 @@ async function action(args, opts, command) {
       opts.datauri !== 'unenc'
     ) {
       console.error(
-        "error: option '--datauri' must have one of the following values: 'base64', 'enc' or 'unenc'"
+        "error: option '--datauri' must have one of the following values: 'base64', 'enc' or 'unenc'",
       );
       process.exit(1);
     }
@@ -113,7 +113,7 @@ async function action(args, opts, command) {
     const number = Number.parseInt(opts.indent, 10);
     if (Number.isNaN(number)) {
       console.error(
-        "error: option '--indent' argument must be an integer number"
+        "error: option '--indent' argument must be an integer number",
       );
       process.exit(1);
     } else {
@@ -123,7 +123,7 @@ async function action(args, opts, command) {
 
   if (opts.eol != null && opts.eol !== 'lf' && opts.eol !== 'crlf') {
     console.error(
-      "error: option '--eol' must have one of the following values: 'lf' or 'crlf'"
+      "error: option '--eol' must have one of the following values: 'lf' or 'crlf'",
     );
     process.exit(1);
   }
@@ -155,7 +155,7 @@ async function action(args, opts, command) {
     var nodeVersion = String(PKG.engines.node).match(/\d*(\.\d+)*/)[0];
     if (parseFloat(process.versions.node) < parseFloat(nodeVersion)) {
       throw Error(
-        `${PKG.name} requires Node.js version ${nodeVersion} or higher.`
+        `${PKG.name} requires Node.js version ${nodeVersion} or higher.`,
       );
     }
   }
@@ -256,14 +256,14 @@ async function action(args, opts, command) {
           .once('end', () =>
             processSVGData(config, { input: 'string' }, data, file).then(
               resolve,
-              reject
-            )
+              reject,
+            ),
           );
       });
       // file
     } else {
       await Promise.all(
-        input.map((file, n) => optimizeFile(config, file, output[n]))
+        input.map((file, n) => optimizeFile(config, file, output[n])),
       );
     }
 
@@ -311,12 +311,12 @@ function processDirectory(config, dir, files, output) {
           optimizeFile(
             config,
             fileDescription.inputPath,
-            fileDescription.outputPath
-          )
-        )
+            fileDescription.outputPath,
+          ),
+        ),
       )
     : Promise.reject(
-        new Error(`No SVG files have been found in '${dir}' directory.`)
+        new Error(`No SVG files have been found in '${dir}' directory.`),
       );
 }
 
@@ -334,7 +334,7 @@ function getFilesDescriptions(config, dir, files, output) {
     .filter(
       (name) =>
         regSVGFile.test(name) &&
-        !config.exclude.some((regExclude) => regExclude.test(name))
+        !config.exclude.some((regExclude) => regExclude.test(name)),
     )
     .map((name) => ({
       inputPath: path.resolve(dir, name),
@@ -354,10 +354,10 @@ function getFilesDescriptions(config, dir, files, output) {
               config,
               subFolderPath,
               subFolderFiles,
-              subFolderOutput
+              subFolderOutput,
             );
           })
-          .reduce((a, b) => [].concat(a, b), [])
+          .reduce((a, b) => [].concat(a, b), []),
       )
     : filesInThisFolder;
 }
@@ -374,7 +374,7 @@ function optimizeFile(config, file, output) {
   return fs.promises.readFile(file, 'utf8').then(
     (data) =>
       processSVGData(config, { input: 'file', path: file }, data, output, file),
-    (error) => checkOptimizeFileError(config, file, output, error)
+    (error) => checkOptimizeFileError(config, file, output, error),
   );
 }
 
@@ -423,9 +423,9 @@ function processSVGData(config, info, data, output, input) {
         new Error(
           error.code === 'ENOTDIR'
             ? `Error: output '${output}' is not a directory.`
-            : error
-        )
-      )
+            : error,
+        ),
+      ),
   );
 }
 
@@ -475,7 +475,7 @@ function printProfitInfo(inBytes, outBytes) {
     ui[0],
     ui[1](Math.abs(Math.round(profitPercent * 10) / 10) + '%'),
     '=',
-    Math.round((outBytes / 1024) * 1000) / 1000 + ' KiB'
+    Math.round((outBytes / 1024) * 1000) / 1000 + ' KiB',
   );
 }
 
@@ -493,7 +493,7 @@ function checkOptimizeFileError(config, input, output, error) {
     return optimizeFolder(config, input, output);
   } else if (error.code == 'ENOENT') {
     return Promise.reject(
-      new Error(`Error: no such file or directory '${error.path}'.`)
+      new Error(`Error: no such file or directory '${error.path}'.`),
     );
   }
   return Promise.reject(error);
@@ -513,7 +513,7 @@ function checkWriteFileError(input, output, data, error) {
     return fs.promises.writeFile(
       path.resolve(output, path.basename(input)),
       data,
-      'utf8'
+      'utf8',
     );
   } else {
     return Promise.reject(error);

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -49,7 +49,7 @@ const createPreset = ({ name, plugins }) => {
                 `    name: '${name}',\n` +
                 `  },\n` +
                 `  '${pluginName}'\n` +
-                `]\n`
+                `]\n`,
             );
           }
         }

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -161,7 +161,7 @@ const hasScripts = (node) => {
       ([attrKey, attrValue]) =>
         (attrKey === 'href' || attrKey.endsWith(':href')) &&
         attrValue != null &&
-        attrValue.trimStart().startsWith('javascript:')
+        attrValue.trimStart().startsWith('javascript:'),
     );
 
     if (hasJsLinks) {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -108,7 +108,7 @@ export type PluginInfo = {
 export type Plugin<Params> = (
   root: XastRoot,
   params: Params,
-  info: PluginInfo
+  info: PluginInfo,
 ) => null | Visitor;
 
 export type Specificity = [number, number, number, number];

--- a/lib/xast.test.js
+++ b/lib/xast.test.js
@@ -117,6 +117,6 @@ test('visit skips entering children when symbol is passed', () => {
   });
   expect(entered).toEqual(['g', 'ellipse']);
   expect(ast).toEqual(
-    root([x('g', null, [x('rect'), x('circle')]), x('ellipse')])
+    root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]),
   );
 });

--- a/package.json
+++ b/package.json
@@ -72,48 +72,6 @@
     "prepublishOnly": "rm -rf dist && rollup -c",
     "qa": "yarn lint && yarn typecheck && yarn test && yarn test-browser && yarn test-regression"
   },
-  "prettier": {
-    "singleQuote": true
-  },
-  "eslintConfig": {
-    "parserOptions": {
-      "ecmaVersion": 2021
-    },
-    "env": {
-      "node": true,
-      "es2021": true
-    },
-    "extends": [
-      "eslint:recommended"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "rollup.config.js",
-          "**/*.mjs"
-        ],
-        "parserOptions": {
-          "sourceType": "module"
-        }
-      },
-      {
-        "files": [
-          "**/*.cjs"
-        ],
-        "parserOptions": {
-          "sourceType": "commonjs"
-        }
-      },
-      {
-        "files": [
-          "**/*.test.js"
-        ],
-        "env": {
-          "jest": true
-        }
-      }
-    ]
-  },
   "jest": {
     "coveragePathIgnorePatterns": [
       "fixtures"
@@ -135,13 +93,13 @@
     "@types/csso": "~5.0.3",
     "@types/jest": "^29.5.5",
     "del": "^6.0.0",
-    "eslint": "^8.24.0",
+    "eslint": "^8.55.0",
     "jest": "^29.5.5",
     "node-fetch": "^2.7.0",
     "pixelmatch": "^5.2.1",
     "playwright": "^1.14.1",
     "pngjs": "^6.0.0",
-    "prettier": "^2.7.1",
+    "prettier": "^3.1.1",
     "rollup": "^2.79.1",
     "rollup-plugin-terser": "^7.0.2",
     "tar-stream": "^3.1.6",

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -269,7 +269,7 @@ exports.intersects = function (path1, path2) {
       while (true) {
         if (iterations-- == 0) {
           console.error(
-            'Error: infinite loop while processing mergePaths plugin.'
+            'Error: infinite loop while processing mergePaths plugin.',
           );
           return true; // true is the safe value that means “do nothing with paths”
         }
@@ -303,8 +303,8 @@ exports.intersects = function (path1, path2) {
             ? polygon.maxY
             : polygon.maxX
           : direction[0] < 0
-          ? polygon.minX
-          : polygon.minY,
+            ? polygon.minX
+            : polygon.minY,
       max = -Infinity,
       value;
     while ((value = dot(polygon.list[index], direction)) > max) {
@@ -703,7 +703,7 @@ const a2c = (
   sweep_flag,
   x2,
   y2,
-  recursive
+  recursive,
 ) => {
   // for more information of where this Math came from visit:
   // https://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
@@ -744,8 +744,8 @@ const a2c = (
       (large_arc_flag == sweep_flag ? -1 : 1) *
       Math.sqrt(
         Math.abs(
-          (rx2 * ry2 - rx2 * y * y - ry2 * x * x) / (rx2 * y * y + ry2 * x * x)
-        )
+          (rx2 * ry2 - rx2 * y * y - ry2 * x * x) / (rx2 * y * y + ry2 * x * x),
+        ),
       );
     var cx = (k * rx * y) / ry + (x1 + x2) / 2;
     var cy = (k * -ry * x) / rx + (y1 + y2) / 2;

--- a/plugins/_transforms.js
+++ b/plugins/_transforms.js
@@ -160,12 +160,12 @@ exports.matrixToTransform = (transform, params) => {
   let data = transform.data;
   let transforms = [];
   let sx = Number(
-    Math.hypot(data[0], data[1]).toFixed(params.transformPrecision)
+    Math.hypot(data[0], data[1]).toFixed(params.transformPrecision),
   );
   let sy = Number(
     ((data[0] * data[3] - data[1] * data[2]) / sx).toFixed(
-      params.transformPrecision
-    )
+      params.transformPrecision,
+    ),
   );
   let colsSum = data[0] * data[2] + data[1] * data[3];
   let rowsSum = data[0] * data[1] + data[2] * data[3];

--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -67,7 +67,7 @@ exports.fn = (root, params) => {
           const classList = new Set(
             node.attributes.class == null
               ? null
-              : node.attributes.class.split(' ')
+              : node.attributes.class.split(' '),
           );
           for (const className of classNames) {
             if (className != null) {

--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -57,7 +57,7 @@ const applyTransforms = (root, params) => {
           node.attributes.style != null ||
           Object.entries(node.attributes).some(
             ([name, value]) =>
-              referencesProps.includes(name) && includesUrlReference(value)
+              referencesProps.includes(name) && includesUrlReference(value),
           )
         ) {
           return;
@@ -75,7 +75,7 @@ const applyTransforms = (root, params) => {
         }
 
         const matrix = transformsMultiply(
-          transform2js(node.attributes.transform)
+          transform2js(node.attributes.transform),
         );
 
         const stroke =
@@ -98,8 +98,8 @@ const applyTransforms = (root, params) => {
 
         const scale = Number(
           Math.sqrt(
-            matrix.data[0] * matrix.data[0] + matrix.data[1] * matrix.data[1]
-          ).toFixed(transformPrecision)
+            matrix.data[0] * matrix.data[0] + matrix.data[1] * matrix.data[1],
+          ).toFixed(transformPrecision),
         );
 
         if (stroke && stroke != 'none') {
@@ -125,7 +125,7 @@ const applyTransforms = (root, params) => {
               )
                 .trim()
                 .replace(regNumericValues, (num) =>
-                  removeLeadingZero(Number(num) * scale)
+                  removeLeadingZero(Number(num) * scale),
                 );
 
               if (node.attributes['stroke-dashoffset'] != null) {
@@ -134,7 +134,7 @@ const applyTransforms = (root, params) => {
                 ]
                   .trim()
                   .replace(regNumericValues, (num) =>
-                    removeLeadingZero(Number(num) * scale)
+                    removeLeadingZero(Number(num) * scale),
                   );
               }
 
@@ -144,7 +144,7 @@ const applyTransforms = (root, params) => {
                 ]
                   .trim()
                   .replace(regNumericValues, (num) =>
-                    removeLeadingZero(Number(num) * scale)
+                    removeLeadingZero(Number(num) * scale),
                   );
               }
             }

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -25,12 +25,12 @@ exports.fn = (root, params) => {
             // new line which requires a space instead of themself
             node.attributes[name] = node.attributes[name].replace(
               regNewlinesNeedSpace,
-              (match, p1, p2) => p1 + ' ' + p2
+              (match, p1, p2) => p1 + ' ' + p2,
             );
             // simple new line
             node.attributes[name] = node.attributes[name].replace(
               regNewlines,
-              ''
+              '',
             );
           }
           if (trim) {
@@ -39,7 +39,7 @@ exports.fn = (root, params) => {
           if (spaces) {
             node.attributes[name] = node.attributes[name].replace(
               regSpaces,
-              ' '
+              ' ',
             );
           }
         }

--- a/plugins/cleanupEnableBackground.js
+++ b/plugins/cleanupEnableBackground.js
@@ -99,7 +99,7 @@ exports.fn = (root) => {
             attrValue,
             node.name,
             node.attributes.width,
-            node.attributes.height
+            node.attributes.height,
           );
 
           if (attrCleaned) {
@@ -114,13 +114,13 @@ exports.fn = (root) => {
           ) {
             const styleValue = csstree.generate(
               // @ts-ignore
-              enableBackgroundDeclaration.data.value
+              enableBackgroundDeclaration.data.value,
             );
             const styleCleaned = cleanupValue(
               styleValue,
               node.name,
               node.attributes.width,
-              node.attributes.height
+              node.attributes.height,
             );
 
             if (styleCleaned) {

--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -132,13 +132,13 @@ exports.fn = (_root, params) => {
     force = false,
   } = params;
   const preserveIds = new Set(
-    Array.isArray(preserve) ? preserve : preserve ? [preserve] : []
+    Array.isArray(preserve) ? preserve : preserve ? [preserve] : [],
   );
   const preserveIdPrefixes = Array.isArray(preservePrefixes)
     ? preservePrefixes
     : preservePrefixes
-    ? [preservePrefixes]
-    : [];
+      ? [preservePrefixes]
+      : [];
   /**
    * @type {Map<string, XastElement>}
    */
@@ -236,13 +236,13 @@ exports.fn = (_root, params) => {
                   // replace id in href and url()
                   element.attributes[name] = value.replace(
                     `#${encodeURI(id)}`,
-                    `#${currentIdString}`
+                    `#${currentIdString}`,
                   );
                 } else {
                   // replace id in begin attribute
                   element.attributes[name] = value.replace(
                     `${id}.`,
-                    `${currentIdString}.`
+                    `${currentIdString}.`,
                   );
                 }
               }

--- a/plugins/cleanupListOfValues.js
+++ b/plugins/cleanupListOfValues.js
@@ -68,7 +68,7 @@ exports.fn = (_root, params) => {
         // convert absolute values to pixels
         if (convertToPx && units && units in absoluteLengths) {
           const pxNum = Number(
-            (absoluteLengths[units] * Number(match[1])).toFixed(floatPrecision)
+            (absoluteLengths[units] * Number(match[1])).toFixed(floatPrecision),
           );
 
           if (pxNum.toString().length < match[0].length) {
@@ -112,7 +112,7 @@ exports.fn = (_root, params) => {
 
         if (node.attributes['enable-background'] != null) {
           node.attributes['enable-background'] = roundValues(
-            node.attributes['enable-background']
+            node.attributes['enable-background'],
           );
         }
 
@@ -122,7 +122,7 @@ exports.fn = (_root, params) => {
 
         if (node.attributes['stroke-dasharray'] != null) {
           node.attributes['stroke-dasharray'] = roundValues(
-            node.attributes['stroke-dasharray']
+            node.attributes['stroke-dasharray'],
           );
         }
 

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -75,8 +75,8 @@ exports.fn = (_root, params) => {
             if (convertToPx && units !== '' && units in absoluteLengths) {
               const pxNum = Number(
                 (absoluteLengths[units] * Number(match[1])).toFixed(
-                  floatPrecision
-                )
+                  floatPrecision,
+                ),
               );
               if (pxNum.toString().length < match[0].length) {
                 num = pxNum;

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -8,7 +8,7 @@ exports.description = 'converts colors: rgb() to #rrggbb and #rrggbb to #rgb';
 const rNumber = '([+-]?(?:\\d*\\.\\d+|\\d+\\.?)%?)';
 const rComma = '\\s*,\\s*';
 const regRGB = new RegExp(
-  '^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$'
+  '^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$',
 );
 const regHEX = /^#(([a-fA-F0-9])\2){3}$/;
 

--- a/plugins/convertOneStopGradients.js
+++ b/plugins/convertOneStopGradients.js
@@ -128,7 +128,7 @@ exports.fn = (root) => {
 
         const styledElements = querySelectorAll(
           root,
-          `[style*=${selectorVal}]`
+          `[style*=${selectorVal}]`,
         );
         for (const element of styledElements) {
           if (element.type !== 'element') {
@@ -137,7 +137,7 @@ exports.fn = (root) => {
 
           element.attributes.style = element.attributes.style.replace(
             selectorVal,
-            color || attrsGroupsDefaults.presentation['stop-color']
+            color || attrsGroupsDefaults.presentation['stop-color'],
           );
         }
       },

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -139,7 +139,7 @@ exports.fn = (root, params) => {
       applyTransforms(root, {
         transformPrecision,
         applyTransformsStroked,
-      })
+      }),
     );
   }
 
@@ -387,7 +387,7 @@ const convertToRelative = (pathData) => {
 function filters(
   path,
   params,
-  { isSafeToUseZ, maybeHasStrokeAndLinecap, hasMarkerMid }
+  { isSafeToUseZ, maybeHasStrokeAndLinecap, hasMarkerMid },
 ) {
   var stringify = data2Path.bind(null, params),
     relSubpoint = [0, 0],
@@ -496,7 +496,7 @@ function filters(
           if (next.command == 's') {
             nextLonghand = makeLonghand(
               { command: 's', args: next.args.slice() },
-              path[j - 1].args
+              path[j - 1].args,
             );
             nextData = nextLonghand.args;
             nextLonghand.args = nextData.slice(0, 2);
@@ -582,7 +582,7 @@ function filters(
             path.splice.apply(
               path,
               // @ts-ignore
-              [index + 1, arcCurves.length - 1 - hasPrev].concat(output)
+              [index + 1, arcCurves.length - 1 - hasPrev].concat(output),
             );
           }
           if (!arc) return false;
@@ -1078,7 +1078,7 @@ function makeLonghand(item, data) {
   }
   item.args.unshift(
     data[data.length - 2] - data[data.length - 4],
-    data[data.length - 1] - data[data.length - 3]
+    data[data.length - 1] - data[data.length - 3],
   );
   return item;
 }
@@ -1145,7 +1145,7 @@ function findCircle(curve) {
       return (
         Math.abs(
           // @ts-ignore
-          getDistance(getCubicBezierPoint(curve, point), center) - radius
+          getDistance(getCubicBezierPoint(curve, point), center) - radius,
         ) <= tolerance
       );
     })
@@ -1163,14 +1163,14 @@ function findCircle(curve) {
 function isArc(curve, circle) {
   var tolerance = Math.min(
     arcThreshold * error,
-    (arcTolerance * circle.radius) / 100
+    (arcTolerance * circle.radius) / 100,
   );
 
   return [0, 1 / 4, 1 / 2, 3 / 4, 1].every(function (point) {
     return (
       Math.abs(
         getDistance(getCubicBezierPoint(curve, point), circle.center) -
-          circle.radius
+          circle.radius,
       ) <= tolerance
     );
   });
@@ -1202,7 +1202,7 @@ function findArcAngle(curve, relCircle) {
     y2 = curve[5] - relCircle.center[1];
 
   return Math.acos(
-    (x1 * x2 + y1 * y2) / Math.sqrt((x1 * x1 + y1 * y1) * (x2 * x2 + y2 * y2))
+    (x1 * x2 + y1 * y2) / Math.sqrt((x1 * x1 + y1 * y1) * (x2 * x2 + y2 * y2)),
   );
 }
 

--- a/plugins/convertShapeToPath.js
+++ b/plugins/convertShapeToPath.js
@@ -91,7 +91,7 @@ exports.fn = (root, params) => {
           node.attributes.points != null
         ) {
           const coords = (node.attributes.points.match(regNumber) || []).map(
-            Number
+            Number,
           );
           if (coords.length < 4) {
             detachNodeFromParent(node, parentNode);

--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -31,7 +31,7 @@ const rValue =
     rSingleQuotes,
     rQuotes,
     rParenthesis,
-    '[^;]*?'
+    '[^;]*?',
   ) +
   '*?' +
   ')';
@@ -42,12 +42,12 @@ const rImportant = '(\\s*!important(?![-(\\w]))?';
 // Final RegExp to parse CSS declarations.
 const regDeclarationBlock = new RegExp(
   rAttr + ':' + rValue + rImportant + rDeclEnd,
-  'ig'
+  'ig',
 );
 // Comments expression. Honors escape sequences and strings.
 const regStripComments = new RegExp(
   g(rEscape, rSingleQuotes, rQuotes, '/\\*[^]*?\\*/'),
-  'ig'
+  'ig',
 );
 
 /**
@@ -87,9 +87,9 @@ exports.fn = (_root, params) => {
               return match[0] == '/'
                 ? ''
                 : match[0] == '\\' && /[-g-z]/i.test(match[1])
-                ? match[1]
-                : match;
-            }
+                  ? match[1]
+                  : match;
+            },
           );
 
           regDeclarationBlock.lastIndex = 0;

--- a/plugins/convertTransform.js
+++ b/plugins/convertTransform.js
@@ -151,20 +151,20 @@ const definePrecision = (data, { ...newParams }) => {
     newParams.transformPrecision = Math.min(
       newParams.transformPrecision,
       Math.max.apply(Math, matrixData.map(floatDigits)) ||
-        newParams.transformPrecision
+        newParams.transformPrecision,
     );
     significantDigits = Math.max.apply(
       Math,
       matrixData.map(
-        (n) => n.toString().replace(/\D+/g, '').length // Number of digits in a number. 123.45 → 5
-      )
+        (n) => n.toString().replace(/\D+/g, '').length, // Number of digits in a number. 123.45 → 5
+      ),
     );
   }
   // No sense in angle precision more then number of significant digits in matrix.
   if (newParams.degPrecision == null) {
     newParams.degPrecision = Math.max(
       0,
-      Math.min(newParams.floatPrecision, significantDigits - 2)
+      Math.min(newParams.floatPrecision, significantDigits - 2),
     );
   }
   return newParams;

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -145,13 +145,13 @@ exports.fn = (root, params) => {
                           list: grandchildList,
                         });
                       }
-                    }
+                    },
                   );
 
                   const pseudoSelectors = csstree.generate({
                     type: 'Selector',
                     children: new csstree.List().fromArray(
-                      pseudos.map((pseudo) => pseudo.item.data)
+                      pseudos.map((pseudo) => pseudo.item.data),
                     ),
                   });
 
@@ -216,7 +216,7 @@ exports.fn = (root, params) => {
               {
                 context: 'declarationList',
                 parseValue: false,
-              }
+              },
             );
             if (styleDeclarationList.type !== 'DeclarationList') {
               continue;
@@ -249,7 +249,7 @@ exports.fn = (root, params) => {
                 if (
                   attrsGroups.presentation.includes(property) &&
                   !selectors.some((selector) =>
-                    includesAttrSelector(selector.item, property)
+                    includesAttrSelector(selector.item, property),
                   )
                 ) {
                   delete selectedEl.attributes[property];
@@ -261,7 +261,7 @@ exports.fn = (root, params) => {
                 if (matchedItem == null) {
                   styleDeclarationList.children.insert(
                     ruleDeclarationItem,
-                    firstListItem
+                    firstListItem,
                   );
                 } else if (
                   matchedItem.data.important !== true &&
@@ -269,7 +269,7 @@ exports.fn = (root, params) => {
                 ) {
                   styleDeclarationList.children.replace(
                     matchedItem,
-                    ruleDeclarationItem
+                    ruleDeclarationItem,
                   );
                   styleDeclarationItems.set(property, ruleDeclarationItem);
                 }
@@ -314,14 +314,19 @@ exports.fn = (root, params) => {
             const classList = new Set(
               selectedEl.attributes.class == null
                 ? null
-                : selectedEl.attributes.class.split(' ')
+                : selectedEl.attributes.class.split(' '),
             );
 
             for (const child of selector.node.children) {
               if (
                 child.type === 'ClassSelector' &&
                 !selectors.some((selector) =>
-                  includesAttrSelector(selector.item, 'class', child.name, true)
+                  includesAttrSelector(
+                    selector.item,
+                    'class',
+                    child.name,
+                    true,
+                  ),
                 )
               ) {
                 classList.delete(child.name);
@@ -344,8 +349,8 @@ exports.fn = (root, params) => {
                   selector.item,
                   'id',
                   firstSubSelector.name,
-                  true
-                )
+                  true,
+                ),
               )
             ) {
               delete selectedEl.attributes.id;

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -37,13 +37,13 @@ exports.fn = () => {
           node.attributes.transform != null &&
           Object.entries(node.attributes).some(
             ([name, value]) =>
-              referencesProps.includes(name) && includesUrlReference(value)
+              referencesProps.includes(name) && includesUrlReference(value),
           ) === false &&
           node.children.every(
             (child) =>
               child.type === 'element' &&
               pathElemsWithGroupsAndText.includes(child.name) &&
-              child.attributes.id == null
+              child.attributes.id == null,
           )
         ) {
           for (const child of node.children) {

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -178,7 +178,7 @@ exports.fn = (_root, params, info) => {
                 const prefixed = prefixReference(
                   prefixGenerator,
                   // @ts-ignore
-                  unquote(node.value)
+                  unquote(node.value),
                 );
                 if (prefixed != null) {
                   // @ts-ignore
@@ -222,7 +222,7 @@ exports.fn = (_root, params, info) => {
           ) {
             const prefixed = prefixReference(
               prefixGenerator,
-              node.attributes[name]
+              node.attributes[name],
             );
             if (prefixed != null) {
               node.attributes[name] = prefixed;
@@ -244,7 +244,7 @@ exports.fn = (_root, params, info) => {
                   return match;
                 }
                 return `url(${prefixed})`;
-              }
+              },
             );
           }
         }

--- a/plugins/removeComments.js
+++ b/plugins/removeComments.js
@@ -31,7 +31,7 @@ exports.fn = (_root, params) => {
         if (preservePatterns) {
           if (!Array.isArray(preservePatterns)) {
             throw Error(
-              `Expected array in removeComments preservePatterns parameter but received ${preservePatterns}`
+              `Expected array in removeComments preservePatterns parameter but received ${preservePatterns}`,
             );
           }
 

--- a/plugins/removeElementsByAttr.js
+++ b/plugins/removeElementsByAttr.js
@@ -46,8 +46,8 @@ exports.fn = (root, params) => {
     params.class == null
       ? []
       : Array.isArray(params.class)
-      ? params.class
-      : [params.class];
+        ? params.class
+        : [params.class];
   return {
     element: {
       enter: (node, parentNode) => {

--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -57,7 +57,7 @@ exports.fn = () => {
           // ensure that the dimensions are 4 values separated by space
           const m =
             /^(-?\d*\.?\d+) (-?\d*\.?\d+) (\d*\.?\d+) (\d*\.?\d+)$/.exec(
-              viewBox
+              viewBox,
             );
           if (m == null) {
             return;

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -129,7 +129,7 @@ exports.fn = (root, params) => {
         // remove unknown element's content
         if (unknownContent && parentNode.type === 'element') {
           const allowedChildren = allowedChildrenPerElement.get(
-            parentNode.name
+            parentNode.name,
           );
           if (allowedChildren == null || allowedChildren.size === 0) {
             // remove unknown elements

--- a/plugins/removeXlink.js
+++ b/plugins/removeXlink.js
@@ -136,7 +136,7 @@ exports.fn = (_, params) => {
           const attr = titleAttrs[i];
           const value = node.attributes[attr];
           const hasTitle = node.children.filter(
-            (child) => child.type === 'element' && child.name === 'title'
+            (child) => child.type === 'element' && child.name === 'title',
           );
 
           if (hasTitle.length > 0) {

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -123,7 +123,7 @@ exports.fn = (root) => {
                 originalId == null ||
                 hrefs.has(originalId) ||
                 stylesheet.rules.some(
-                  (rule) => rule.selector === `#${originalId}`
+                  (rule) => rule.selector === `#${originalId}`,
                 )
               ) {
                 reusablePath.attributes.id = 'reuse-' + index++;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -34,7 +34,7 @@ test('shows plugins when flag specified', async () => {
   const proc = spawn(
     'node',
     ['../../bin/svgo', '--no-color', '--show-plugins'],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   const stdout = await waitStdout(proc);
   expect(stdout).toMatch(/Currently available plugins:/);
@@ -55,7 +55,7 @@ test('accepts svg as string', async () => {
   const proc = spawn(
     'node',
     ['../../bin/svgo', '--no-color', '--string', input],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   const stdout = await waitStdout(proc);
   expect(stdout).toEqual('<svg/>');
@@ -65,12 +65,12 @@ test('accepts svg as filename', async () => {
   const proc = spawn(
     'node',
     ['../../bin/svgo', '--no-color', 'single.svg', '-o', 'output/single.svg'],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   await waitClose(proc);
   const output = fs.readFileSync(
     path.join(__dirname, 'output/single.svg'),
-    'utf-8'
+    'utf-8',
   );
   expect(output).toEqual('<svg/>');
 });
@@ -79,7 +79,7 @@ test('output as stream when "-" is specified', async () => {
   const proc = spawn(
     'node',
     ['../../bin/svgo', '--no-color', 'single.svg', '-o', '-'],
-    { cwd: __dirname }
+    { cwd: __dirname },
   );
   const stdout = await waitStdout(proc);
   expect(stdout).toEqual('<svg/>');

--- a/test/coa/_index.test.js
+++ b/test/coa/_index.test.js
@@ -60,7 +60,7 @@ describe('coa', function () {
           (checkIsDir(path.join(folderPath, name))
             ? calcFolderSvgWeight(path.join(folderPath, name))
             : 0),
-        0
+        0,
       );
   }
 

--- a/test/plugins/prefixIds.test.js
+++ b/test/plugins/prefixIds.test.js
@@ -7,18 +7,18 @@ test('should extract prefix from path basename', () => {
   expect(
     optimize(svg, {
       plugins: ['prefixIds'],
-    }).data
+    }).data,
   ).toEqual(`<svg id="prefix__my-id"/>`);
   expect(
     optimize(svg, {
       plugins: ['prefixIds'],
       path: 'input.svg',
-    }).data
+    }).data,
   ).toEqual(`<svg id="input_svg__my-id"/>`);
   expect(
     optimize(svg, {
       plugins: ['prefixIds'],
       path: 'path/to/input.svg',
-    }).data
+    }).data,
   ).toEqual(`<svg id="input_svg__my-id"/>`);
 });

--- a/test/regression-extract.js
+++ b/test/regression-extract.js
@@ -31,7 +31,7 @@ const extractTarGz = async (url, baseDir, include) => {
           await pipeline(
             stream,
             zlib.createGunzip(),
-            fs.createWriteStream(file)
+            fs.createWriteStream(file),
           );
         }
       }
@@ -52,7 +52,7 @@ const extractTarGz = async (url, baseDir, include) => {
     await extractTarGz(
       'https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz',
       path.join(__dirname, 'regression-fixtures', 'w3c-svg-11-test-suite'),
-      /^svg\//
+      /^svg\//,
     );
   } catch (error) {
     console.error(error);

--- a/test/regression.js
+++ b/test/regression.js
@@ -69,7 +69,7 @@ const runTests = async ({ list }) => {
       optimizedPng.data,
       diff.data,
       width,
-      height
+      height,
     );
     // ignore small aliasing issues
     if (matched <= 4) {
@@ -82,7 +82,7 @@ const runTests = async ({ list }) => {
         const file = path.join(
           __dirname,
           'regression-diffs',
-          `${name}.diff.png`
+          `${name}.diff.png`,
         );
         await fs.promises.mkdir(path.dirname(file), { recursive: true });
         await fs.promises.writeFile(file, PNG.sync.write(diff));
@@ -99,7 +99,7 @@ const runTests = async ({ list }) => {
         await processFile(page, name);
       }
       await page.close();
-    })
+    }),
   );
   await browser.close();
   console.info(`Skipped: ${skipped}`);

--- a/test/svg2js/_index.test.js
+++ b/test/svg2js/_index.test.js
@@ -76,7 +76,7 @@ describe('svg2js', function () {
         expect(root.children[3]).toEqual(
           expect.objectContaining({
             name: 'svg',
-          })
+          }),
         );
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@aashutoshrathi/word-wrap@npm:^1.2.3":
+  version: 1.2.6
+  resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
+  checksum: ada901b9e7c680d190f1d012c84217ce0063d8f5c5a7725bb91ec3c5ed99bb7572680eb2d2938a531ccbaec39a95422fcd8a6b4a13110c7d98dd75402f66a0cd
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -410,20 +417,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@eslint/eslintrc@npm:1.3.2"
+"@eslint-community/eslint-utils@npm:^4.2.0":
+  version: 4.4.0
+  resolution: "@eslint-community/eslint-utils@npm:4.4.0"
+  dependencies:
+    eslint-visitor-keys: ^3.3.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: cdfe3ae42b4f572cbfb46d20edafe6f36fc5fb52bf2d90875c58aefe226892b9677fef60820e2832caf864a326fe4fc225714c46e8389ccca04d5f9288aabd22
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.6.1":
+  version: 4.10.0
+  resolution: "@eslint-community/regexpp@npm:4.10.0"
+  checksum: 2a6e345429ea8382aaaf3a61f865cae16ed44d31ca917910033c02dc00d505d939f10b81e079fa14d43b51499c640138e153b7e40743c4c094d9df97d4e56f7b
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@eslint/eslintrc@npm:2.1.4"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.3.2
-    espree: ^9.4.0
-    globals: ^13.15.0
+    espree: ^9.6.0
+    globals: ^13.19.0
     ignore: ^5.2.0
     import-fresh: ^3.2.1
     js-yaml: ^4.1.0
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
-  checksum: 2074dca47d7e1c5c6323ff353f690f4b25d3ab53fe7d27337e2592d37a894cf60ca0e85ca66b50ff2db0bc7e630cc1e9c7347d65bb185b61416565584c38999c
+  checksum: 10957c7592b20ca0089262d8c2a8accbad14b4f6507e35416c32ee6b4dbf9cad67dfb77096bbd405405e9ada2b107f3797fe94362e1c55e0b09d6e90dd149127
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:8.55.0":
+  version: 8.55.0
+  resolution: "@eslint/js@npm:8.55.0"
+  checksum: fa33ef619f0646ed15649b0c2e313e4d9ccee8425884bdbfc78020d6b6b64c0c42fa9d83061d0e6158e1d4274f03f0f9008786540e2efab8fcdc48082259908c
   languageName: node
   linkType: hard
 
@@ -434,21 +466,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.10.5":
-  version: 0.10.7
-  resolution: "@humanwhocodes/config-array@npm:0.10.7"
+"@humanwhocodes/config-array@npm:^0.11.13":
+  version: 0.11.13
+  resolution: "@humanwhocodes/config-array@npm:0.11.13"
   dependencies:
-    "@humanwhocodes/object-schema": ^1.2.1
+    "@humanwhocodes/object-schema": ^2.0.1
     debug: ^4.1.1
-    minimatch: ^3.0.4
-  checksum: 009d64be8d5bd098ff04e10af79e34f5633245250581fca032fac12a8667b2df8e7d169e69c05bff4d83ea3dd3c7d2d0e05ea9b94d89a7d092e26530caf6f8a3
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/gitignore-to-minimatch@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@humanwhocodes/gitignore-to-minimatch@npm:1.0.2"
-  checksum: aba5c40c9e3770ed73a558b0bfb53323842abfc2ce58c91d7e8b1073995598e6374456d38767be24ab6176915f0a8d8b23eaae5c85e2b488c0dccca6d795e2ad
+    minimatch: ^3.0.5
+  checksum: f8ea57b0d7ed7f2d64cd3944654976829d9da91c04d9c860e18804729a33f7681f78166ef4c761850b8c324d362f7d53f14c5c44907a6b38b32c703ff85e4805
   languageName: node
   linkType: hard
 
@@ -459,10 +484,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@humanwhocodes/object-schema@npm:1.2.1"
-  checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+"@humanwhocodes/object-schema@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
+  checksum: 24929487b1ed48795d2f08346a0116cc5ee4634848bce64161fb947109352c562310fd159fc64dda0e8b853307f5794605191a9547f7341158559ca3c8262a45
   languageName: node
   linkType: hard
 
@@ -795,7 +820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodelib/fs.walk@npm:^1.2.3":
+"@nodelib/fs.walk@npm:^1.2.3, @nodelib/fs.walk@npm:^1.2.8":
   version: 1.2.8
   resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
@@ -1066,6 +1091,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ungap/structured-clone@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@ungap/structured-clone@npm:1.2.0"
+  checksum: 4f656b7b4672f2ce6e272f2427d8b0824ed11546a601d8d5412b9d7704e83db38a8d9f402ecdf2b9063fc164af842ad0ec4a55819f621ed7e7ea4d1efcc74524
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
@@ -1082,12 +1114,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.8.0, acorn@npm:^8.8.2":
-  version: 8.10.0
-  resolution: "acorn@npm:8.10.0"
+"acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+  version: 8.11.2
+  resolution: "acorn@npm:8.11.2"
   bin:
     acorn: bin/acorn
-  checksum: 538ba38af0cc9e5ef983aee196c4b8b4d87c0c94532334fa7e065b2c8a1f85863467bb774231aae91613fcda5e68740c15d97b1967ae3394d20faddddd8af61d
+  checksum: 818450408684da89423e3daae24e4dc9b68692db8ab49ea4569c7c5abb7a3f23669438bf129cc81dfdada95e1c9b944ee1bfca2c57a05a4dc73834a612fbf6a7
   languageName: node
   linkType: hard
 
@@ -1121,7 +1153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
+"ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -1939,98 +1971,79 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "eslint-scope@npm:7.1.1"
+"eslint-scope@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "eslint-scope@npm:7.2.2"
   dependencies:
     esrecurse: ^4.3.0
     estraverse: ^5.2.0
-  checksum: 9f6e974ab2db641ca8ab13508c405b7b859e72afe9f254e8131ff154d2f40c99ad4545ce326fd9fde3212ff29707102562a4834f1c48617b35d98c71a97fbf3e
+  checksum: ec97dbf5fb04b94e8f4c5a91a7f0a6dd3c55e46bfc7bbcd0e3138c3a76977570e02ed89a1810c778dcd72072ff0e9621ba1379b4babe53921d71e2e4486fda3e
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "eslint-utils@npm:3.0.0"
+"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^8.55.0":
+  version: 8.55.0
+  resolution: "eslint@npm:8.55.0"
   dependencies:
-    eslint-visitor-keys: ^2.0.0
-  peerDependencies:
-    eslint: ">=5"
-  checksum: 0668fe02f5adab2e5a367eee5089f4c39033af20499df88fe4e6aba2015c20720404d8c3d6349b6f716b08fdf91b9da4e5d5481f265049278099c4c836ccb619
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "eslint-visitor-keys@npm:2.1.0"
-  checksum: e3081d7dd2611a35f0388bbdc2f5da60b3a3c5b8b6e928daffff7391146b434d691577aa95064c8b7faad0b8a680266bcda0a42439c18c717b80e6718d7e267d
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "eslint-visitor-keys@npm:3.3.0"
-  checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
-  languageName: node
-  linkType: hard
-
-"eslint@npm:^8.24.0":
-  version: 8.24.0
-  resolution: "eslint@npm:8.24.0"
-  dependencies:
-    "@eslint/eslintrc": ^1.3.2
-    "@humanwhocodes/config-array": ^0.10.5
-    "@humanwhocodes/gitignore-to-minimatch": ^1.0.2
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.6.1
+    "@eslint/eslintrc": ^2.1.4
+    "@eslint/js": 8.55.0
+    "@humanwhocodes/config-array": ^0.11.13
     "@humanwhocodes/module-importer": ^1.0.1
-    ajv: ^6.10.0
+    "@nodelib/fs.walk": ^1.2.8
+    "@ungap/structured-clone": ^1.2.0
+    ajv: ^6.12.4
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
     debug: ^4.3.2
     doctrine: ^3.0.0
     escape-string-regexp: ^4.0.0
-    eslint-scope: ^7.1.1
-    eslint-utils: ^3.0.0
-    eslint-visitor-keys: ^3.3.0
-    espree: ^9.4.0
-    esquery: ^1.4.0
+    eslint-scope: ^7.2.2
+    eslint-visitor-keys: ^3.4.3
+    espree: ^9.6.1
+    esquery: ^1.4.2
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
     find-up: ^5.0.0
-    glob-parent: ^6.0.1
-    globals: ^13.15.0
-    globby: ^11.1.0
-    grapheme-splitter: ^1.0.4
+    glob-parent: ^6.0.2
+    globals: ^13.19.0
+    graphemer: ^1.4.0
     ignore: ^5.2.0
-    import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
-    js-sdsl: ^4.1.4
+    is-path-inside: ^3.0.3
     js-yaml: ^4.1.0
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
     lodash.merge: ^4.6.2
     minimatch: ^3.1.2
     natural-compare: ^1.4.0
-    optionator: ^0.9.1
-    regexpp: ^3.2.0
+    optionator: ^0.9.3
     strip-ansi: ^6.0.1
-    strip-json-comments: ^3.1.0
     text-table: ^0.2.0
   bin:
     eslint: bin/eslint.js
-  checksum: ca293ce7116599b742d7ab4d43db469beec22f40dd272092d809498be3cff3a7c567769f9763bdf6799aac13dd53447b93a99629b7b54092783046eb57eaced6
+  checksum: 83f82a604559dc1faae79d28fdf3dfc9e592ca221052e2ea516e1b379b37e77e4597705a16880e2f5ece4f79087c1dd13fd7f6e9746f794a401175519db18b41
   languageName: node
   linkType: hard
 
-"espree@npm:^9.4.0":
-  version: 9.4.0
-  resolution: "espree@npm:9.4.0"
+"espree@npm:^9.6.0, espree@npm:^9.6.1":
+  version: 9.6.1
+  resolution: "espree@npm:9.6.1"
   dependencies:
-    acorn: ^8.8.0
+    acorn: ^8.9.0
     acorn-jsx: ^5.3.2
-    eslint-visitor-keys: ^3.3.0
-  checksum: 2e3020dde67892d2ba3632413b44d0dc31d92c29ce72267d7ec24216a562f0a6494d3696e2fa39a3ec8c0e0088d773947ab2925fbb716801a11eb8dd313ac89c
+    eslint-visitor-keys: ^3.4.1
+  checksum: eb8c149c7a2a77b3f33a5af80c10875c3abd65450f60b8af6db1bfcfa8f101e21c1e56a561c6dc13b848e18148d43469e7cd208506238554fb5395a9ea5a1ab9
   languageName: node
   linkType: hard
 
@@ -2044,12 +2057,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "esquery@npm:1.4.0"
+"esquery@npm:^1.4.2":
+  version: 1.5.0
+  resolution: "esquery@npm:1.5.0"
   dependencies:
     estraverse: ^5.1.0
-  checksum: a0807e17abd7fbe5fbd4fab673038d6d8a50675cdae6b04fbaa520c34581be0c5fa24582990e8acd8854f671dd291c78bb2efb9e0ed5b62f33bac4f9cf820210
+  checksum: aefb0d2596c230118656cd4ec7532d447333a410a48834d80ea648b1e7b5c9bc9ed8b5e33a89cb04e487b60d622f44cf5713bf4abed7c97343edefdc84a35900
   languageName: node
   linkType: hard
 
@@ -2371,7 +2384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^6.0.1":
+"glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
@@ -2401,16 +2414,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^13.15.0":
-  version: 13.17.0
-  resolution: "globals@npm:13.17.0"
+"globals@npm:^13.19.0":
+  version: 13.24.0
+  resolution: "globals@npm:13.24.0"
   dependencies:
     type-fest: ^0.20.2
-  checksum: fbaf4112e59b92c9f5575e85ce65e9e17c0b82711196ec5f58beb08599bbd92fd72703d6dfc9b080381fd35b644e1b11dcf25b38cc2341ec21df942594cbc8ce
+  checksum: 56066ef058f6867c04ff203b8a44c15b038346a62efbc3060052a1016be9f56f4cf0b2cd45b74b22b81e521a889fc7786c73691b0549c2f3a6e825b3d394f43c
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.1, globby@npm:^11.1.0":
+"globby@npm:^11.0.1":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -2431,10 +2444,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"grapheme-splitter@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "grapheme-splitter@npm:1.0.4"
-  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+"graphemer@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "graphemer@npm:1.4.0"
+  checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
   languageName: node
   linkType: hard
 
@@ -2535,7 +2548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -2701,7 +2714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-inside@npm:^3.0.2":
+"is-path-inside@npm:^3.0.2, is-path-inside@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
@@ -3260,13 +3273,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sdsl@npm:^4.1.4":
-  version: 4.1.5
-  resolution: "js-sdsl@npm:4.1.5"
-  checksum: 695f657ddc5be462b97cac4e8e60f37de28d628ee0e23016baecff0bb584a18dddb5caeac537a775030f180b5afd62133ac4481e7024c8d03a62d73e4da0713e
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -3498,7 +3504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -3735,17 +3741,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optionator@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "optionator@npm:0.9.1"
+"optionator@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "optionator@npm:0.9.3"
   dependencies:
+    "@aashutoshrathi/word-wrap": ^1.2.3
     deep-is: ^0.1.3
     fast-levenshtein: ^2.0.6
     levn: ^0.4.1
     prelude-ls: ^1.2.1
     type-check: ^0.4.0
-    word-wrap: ^1.2.3
-  checksum: dbc6fa065604b24ea57d734261914e697bd73b69eff7f18e967e8912aa2a40a19a9f599a507fa805be6c13c24c4eae8c71306c239d517d42d4c041c942f508a0
+  checksum: 09281999441f2fe9c33a5eeab76700795365a061563d66b098923eb719251a42bdbe432790d35064d0816ead9296dbeb1ad51a733edf4167c96bd5d0882e428a
   languageName: node
   linkType: hard
 
@@ -3957,12 +3963,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "prettier@npm:2.7.1"
+"prettier@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "prettier@npm:3.1.1"
   bin:
-    prettier: bin-prettier.js
-  checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
+    prettier: bin/prettier.cjs
+  checksum: e386855e3a1af86a748e16953f168be555ce66d6233f4ba54eb6449b88eb0c6b2ca79441b11eae6d28a7f9a5c96440ce50864b9d5f6356d331d39d6bb66c648e
   languageName: node
   linkType: hard
 
@@ -4102,13 +4108,6 @@ __metadata:
     string_decoder: ~1.1.1
     util-deprecate: ~1.0.1
   checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
-  languageName: node
-  linkType: hard
-
-"regexpp@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "regexpp@npm:3.2.0"
-  checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
   languageName: node
   linkType: hard
 
@@ -4521,7 +4520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.0, strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
@@ -4571,14 +4570,14 @@ __metadata:
     css-what: ^6.1.0
     csso: 5.0.5
     del: ^6.0.0
-    eslint: ^8.24.0
+    eslint: ^8.55.0
     jest: ^29.5.5
     node-fetch: ^2.7.0
     picocolors: ^1.0.0
     pixelmatch: ^5.2.1
     playwright: ^1.14.1
     pngjs: ^6.0.0
-    prettier: ^2.7.1
+    prettier: ^3.1.1
     rollup: ^2.79.1
     rollup-plugin-terser: ^7.0.2
     tar-stream: ^3.1.6
@@ -4827,13 +4826,6 @@ __metadata:
   dependencies:
     string-width: ^1.0.2 || 2
   checksum: d09c8012652a9e6cab3e82338d1874a4d7db2ad1bd19ab43eb744acf0b9b5632ec406bdbbbb970a8f4771a7d5ef49824d038ba70aa884e7723f5b090ab87134d
-  languageName: node
-  linkType: hard
-
-"word-wrap@npm:^1.2.3":
-  version: 1.2.5
-  resolution: "word-wrap@npm:1.2.5"
-  checksum: f93ba3586fc181f94afdaff3a6fef27920b4b6d9eaefed0f428f8e07adea2a7f54a5f2830ce59406c8416f033f86902b91eb824072354645eea687dff3691ccb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Updates ESLint and Prettier, which applies rules more uniformly across file types.
* Pull the ESLint and Prettier configs out into their own files instead of in `package.json`, so that they aren't being distributed on npm.