### PR TITLE
feat(convertPathData): allow converting q to t in more cases

### DIFF
--- a/test/plugins/convertPathData.34.svg
+++ b/test/plugins/convertPathData.34.svg
@@ -1,0 +1,16 @@
+Shouldn't incorrectly convert q to t. Should convert q to t when feasible.
+
+===
+
+<svg viewBox="0 0 20 20">
+    <path d="M0 0q2 0 5 5t5 5q5 0 5 5"/>
+    <path d="M0 0q2 0 5 5t5 5q2 0 5-2"/>
+</svg>
+
+@@@
+
+
+<svg viewBox="0 0 20 20">
+    <path d="M0 0q2 0 5 5t5 5q5 0 5 5"/>
+    <path d="M0 0q2 0 5 5t5 5 5-2"/>
+</svg>


### PR DESCRIPTION
`t` works by reflecting points. This PR simply keeps track of the previous point, so `q` can be converted to `t` when the control point reflects properly.

## Results
closes #1888

this doesn't affect the test cases much but applies to some certain icons (found in places like material-symbols), where circles are approximated using `t`

the previous logic was also incorrect (it would convert some stuff wrongly)