### PR TITLE
feat(moveElemsAttrsToGroup): remove attributes that are overriden by children

### DIFF
--- a/docs/03-plugins/move-elems-attrs-to-group.mdx
+++ b/docs/03-plugins/move-elems-attrs-to-group.mdx
@@ -5,7 +5,10 @@ svgo:
   defaultPlugin: true
 ---
 
-Move an elements attributes to their enclosing group.
+Optimize the flow of attributes for a group by:
+
+- Removing attributes that are overriden by children
+- Moving attributes common among children to the group
 
 ## Usage
 

--- a/test/plugins/moveElemsAttrsToGroup.08.svg
+++ b/test/plugins/moveElemsAttrsToGroup.08.svg
@@ -1,0 +1,15 @@
+Remove SVG attributes which are overridden
+
+===
+
+<svg fill="red">
+    <rect fill="blue"/>
+    <circle fill="blue"/>
+</svg>
+
+@@@
+
+<svg>
+    <rect fill="blue"/>
+    <circle fill="blue"/>
+</svg>


### PR DESCRIPTION
Sometimes there is a `svg` or a `g` that has a redundant attribute, like this:
```
<svg fill="red">
    <rect fill="blue"/>
    <circle fill="blue"/>
</svg>
```
These can be removed. This PR does that.

\* This PR might be updated to optimize attribute flow further - that is, utilize default values to make things shorter.

## Results
While this doesn't affect the demo SVGs I tested, in conjunction with #1894 this would help reduce icon size even further.