### PR TITLE
chore: speedier regression testing

### DIFF
--- a/test/regression.js
+++ b/test/regression.js
@@ -125,10 +125,17 @@ const height = 720;
     // setup server
     const server = http.createServer(async (req, res) => {
       const name = req.url.slice(req.url.indexOf('/', 1));
-      const file = await fs.promises.readFile(
-        path.join(fixturesDir, name),
-        'utf-8',
-      );
+      let file;
+      try {
+        file = await fs.promises.readFile(
+          path.join(fixturesDir, name),
+          'utf-8',
+        );
+      } catch (error) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
 
       if (req.url.startsWith('/original/')) {
         res.setHeader('Content-Type', 'image/svg+xml');

--- a/test/regression.js
+++ b/test/regression.js
@@ -124,7 +124,7 @@ const height = 720;
     const list = await readdirRecursive(fixturesDir);
     // setup server
     const server = http.createServer(async (req, res) => {
-      const name = req.url.split('/')[2];
+      const name = req.url.slice(req.url.indexOf("/", 1));
       let file;
       try {
         file = await fs.promises.readFile(
@@ -156,8 +156,7 @@ const height = 720;
         res.end(optimized.data);
         return;
       }
-      res.statusCode = 404;
-      res.end();
+      throw new Error(`unknown path ${req.url}`);
     });
     await new Promise((resolve) => {
       server.listen(5000, resolve);

--- a/test/regression.js
+++ b/test/regression.js
@@ -8,17 +8,6 @@ const { PNG } = require('pngjs');
 const pixelmatch = require('pixelmatch');
 const { optimize } = require('../lib/svgo.js');
 
-const chunkInto = (array, chunksCount) => {
-  // take upper bound to include tail
-  const chunkSize = Math.ceil(array.length / chunksCount);
-  const result = [];
-  for (let i = 0; i < chunksCount; i += 1) {
-    const offset = i * chunkSize;
-    result.push(array.slice(offset, offset + chunkSize));
-  }
-  return result;
-};
-
 const runTests = async ({ list }) => {
   let skipped = 0;
   let mismatched = 0;
@@ -48,8 +37,6 @@ const runTests = async ({ list }) => {
       skipped += 1;
       return;
     }
-    const width = 960;
-    const height = 720;
     await page.goto(`http://localhost:5000/original/${name}`);
     await page.setViewportSize({ width, height });
     const originalBuffer = await page.screenshot({
@@ -89,18 +76,27 @@ const runTests = async ({ list }) => {
       }
     }
   };
+  const worker = async () => {
+    let item;
+    const page = await context.newPage();
+    while ((item = list.shift())) {
+      await processFile(page, item);
+    }
+    await page.close();
+  };
+
   const browser = await chromium.launch();
   const context = await browser.newContext({ javaScriptEnabled: false });
-  const chunks = chunkInto(list, 8);
-  await Promise.all(
-    chunks.map(async (chunk) => {
-      const page = await context.newPage();
-      for (const name of chunk) {
-        await processFile(page, name);
-      }
-      await page.close();
-    }),
-  );
+  await Promise.all([
+    worker(),
+    worker(),
+    worker(),
+    worker(),
+    worker(),
+    worker(),
+    worker(),
+    worker(),
+  ]);
   await browser.close();
   console.info(`Skipped: ${skipped}`);
   console.info(`Mismatched: ${mismatched}`);
@@ -124,54 +120,52 @@ const readdirRecursive = async (absolute, relative = '') => {
   return result;
 };
 
+const width = 960;
+const height = 720;
 (async () => {
   try {
     const start = process.hrtime.bigint();
     const fixturesDir = path.join(__dirname, 'regression-fixtures');
     const list = await readdirRecursive(fixturesDir);
-    const originalFiles = new Map();
-    const optimizedFiles = new Map();
-    // read original and optimize
-    let failed = 0;
-    for (const name of list) {
-      try {
-        const file = path.join(fixturesDir, name);
-        const original = await fs.promises.readFile(file, 'utf-8');
-        const result = optimize(original, { path: name, floatPrecision: 4 });
-        if (result.error) {
-          console.error(result.error);
-          console.error(`File: ${name}`);
-          failed += 1;
-        } else {
-          originalFiles.set(name, original);
-          optimizedFiles.set(name, result.data);
-        }
-      } catch (error) {
-        console.error(error);
-        console.error(`File: ${name}`);
-        failed += 1;
-      }
-    }
-    if (failed !== 0) {
-      throw Error(`Failed to optimize ${failed} cases`);
-    }
     // setup server
-    const server = http.createServer((req, res) => {
-      if (req.url.startsWith('/original/')) {
-        const name = req.url.slice('/original/'.length);
-        if (originalFiles.has(name)) {
-          res.setHeader('Content-Type', 'image/svg+xml');
-          res.end(originalFiles.get(name));
+    const server = http.createServer(async (req, res) => {
+      const name = req.url.startsWith('/original/')
+        ? req.url.slice('/original/'.length)
+        : req.url.startsWith('/optimized/')
+          ? req.url.slice('/optimized/'.length)
+          : undefined;
+      let file;
+      if (name) {
+        try {
+          file = await fs.promises.readFile(
+            path.join(fixturesDir, name),
+            'utf-8',
+          );
+        } catch (error) {
+          res.statusCode = 404;
+          res.end();
           return;
         }
+      }
+
+      if (req.url.startsWith('/original/')) {
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.end(file);
+        return;
       }
       if (req.url.startsWith('/optimized/')) {
-        const name = req.url.slice('/optimized/'.length);
-        if (optimizedFiles.has(name)) {
-          res.setHeader('Content-Type', 'image/svg+xml');
-          res.end(optimizedFiles.get(name));
-          return;
+        const optimized = optimize(file, {
+          path: name,
+          floatPrecision: 4,
+        });
+        if (optimized.error) {
+          throw new Error(`Failed to optimize ${name}`, {
+            cause: optimized.error,
+          });
         }
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.end(optimized.data);
+        return;
       }
       res.statusCode = 404;
       res.end();

--- a/test/regression.js
+++ b/test/regression.js
@@ -125,17 +125,10 @@ const height = 720;
     // setup server
     const server = http.createServer(async (req, res) => {
       const name = req.url.slice(req.url.indexOf("/", 1));
-      let file;
-      try {
-        file = await fs.promises.readFile(
-          path.join(fixturesDir, name),
-          'utf-8',
-        );
-      } catch (error) {
-        res.statusCode = 404;
-        res.end();
-        return;
-      }
+      const file = await fs.promises.readFile(
+        path.join(fixturesDir, name),
+        'utf-8',
+      );
 
       if (req.url.startsWith('/original/')) {
         res.setHeader('Content-Type', 'image/svg+xml');

--- a/test/regression.js
+++ b/test/regression.js
@@ -124,7 +124,7 @@ const height = 720;
     const list = await readdirRecursive(fixturesDir);
     // setup server
     const server = http.createServer(async (req, res) => {
-      const name = req.url.slice(req.url.indexOf("/", 1));
+      const name = req.url.slice(req.url.indexOf('/', 1));
       const file = await fs.promises.readFile(
         path.join(fixturesDir, name),
         'utf-8',


### PR DESCRIPTION
Goes from 76 seconds to 61 seconds in my tests.
Two main changes:
- instead of chunking the array, use workers that subtract as needed
Bonus: this means that they go in alphabetical order
- serve SVGs, optimized or not, on demand instead of warming them up
This means no optimizing skipped tests
Admittedly won't be as useful once the PR that moves skipping tests into the extractor gets merged, but hey, it'll still decrease initial startup time

*I was going to make it even faster with `node-canvas`, but the w3 tests are a bit eccentric and fail to render properly there, and I don't know of any other convenient rendering libs