### PR TITLE
refactor: improve performance of stringifyPathData

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -243,15 +243,21 @@ const parsePathData = (string) => {
 exports.parsePathData = parsePathData;
 
 /**
- * @type {(number: number, precision?: number) => string}
+ * @type {(number: number, precision?: number) => {
+ *   roundedStr: string,
+ *   rounded: number
+ * }}
  */
-const stringifyNumber = (number, precision) => {
+const roundAndStringify = (number, precision) => {
   if (precision != null) {
     const ratio = 10 ** precision;
     number = Math.round(number * ratio) / ratio;
   }
-  // remove zero whole from decimal number
-  return removeLeadingZero(number);
+
+  return {
+    roundedStr: removeLeadingZero(number),
+    rounded: number,
+  };
 };
 
 /**
@@ -267,29 +273,35 @@ const stringifyNumber = (number, precision) => {
  */
 const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
   let result = '';
-  let prev = '';
-  for (let i = 0; i < args.length; i += 1) {
-    const number = args[i];
-    const numberString = stringifyNumber(number, precision);
+  let previous;
+
+  for (let i = 0; i < args.length; i++) {
+    const { roundedStr, rounded } = roundAndStringify(args[i], precision);
     if (
       disableSpaceAfterFlags &&
       (command === 'A' || command === 'a') &&
       // consider combined arcs
       (i % 7 === 4 || i % 7 === 5)
     ) {
-      result += numberString;
-    } else if (i === 0 || numberString.startsWith('-')) {
+      result += roundedStr;
+    } else if (i === 0 || rounded < 0) {
       // avoid space before first and negative numbers
-      result += numberString;
-    } else if (prev.includes('.') && numberString.startsWith('.')) {
+      result += roundedStr;
+    } else if (
+      !Number.isInteger(previous) &&
+      rounded != 0 &&
+      rounded < 1 &&
+      rounded > -1
+    ) {
       // remove space before decimal with zero whole
       // only when previous number is also decimal
-      result += numberString;
+      result += roundedStr;
     } else {
-      result += ` ${numberString}`;
+      result += ` ${roundedStr}`;
     }
-    prev = numberString;
+    previous = rounded;
   }
+
   return result;
 };
 
@@ -302,48 +314,68 @@ const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
  */
 
 /**
- * @type {(options: StringifyPathDataOptions) => string}
+ * @param {StringifyPathDataOptions} options
+ * @returns {string}
  */
 const stringifyPathData = ({ pathData, precision, disableSpaceAfterFlags }) => {
-  // combine sequence of the same commands
-  let combined = [];
-  for (let i = 0; i < pathData.length; i += 1) {
+  if (pathData.length === 1) {
+    const { command, args } = pathData[0];
+    return (
+      command + stringifyArgs(command, args, precision, disableSpaceAfterFlags)
+    );
+  }
+
+  let result = '';
+  let prev = { ...pathData[0] };
+
+  // match leading moveto with following lineto
+  if (pathData[1].command === 'L') {
+    prev.command = 'M';
+  } else if (pathData[1].command === 'l') {
+    prev.command = 'm';
+  }
+
+  for (let i = 1; i < pathData.length; i++) {
     const { command, args } = pathData[i];
-    if (i === 0) {
-      combined.push({ command, args });
-    } else {
-      /**
-       * @type {PathDataItem}
-       */
-      const last = combined[combined.length - 1];
-      // match leading moveto with following lineto
-      if (i === 1) {
-        if (command === 'L') {
-          last.command = 'M';
-        }
-        if (command === 'l') {
-          last.command = 'm';
-        }
+    if (
+      (prev.command === command &&
+        prev.command !== 'M' &&
+        prev.command !== 'm') ||
+      // combine matching moveto and lineto sequences
+      (prev.command === 'M' && command === 'L') ||
+      (prev.command === 'm' && command === 'l')
+    ) {
+      prev.args = [...prev.args, ...args];
+      if (i === pathData.length - 1) {
+        result +=
+          prev.command +
+          stringifyArgs(
+            prev.command,
+            prev.args,
+            precision,
+            disableSpaceAfterFlags,
+          );
       }
-      if (
-        (last.command === command &&
-          last.command !== 'M' &&
-          last.command !== 'm') ||
-        // combine matching moveto and lineto sequences
-        (last.command === 'M' && command === 'L') ||
-        (last.command === 'm' && command === 'l')
-      ) {
-        last.args = [...last.args, ...args];
+    } else {
+      result +=
+        prev.command +
+        stringifyArgs(
+          prev.command,
+          prev.args,
+          precision,
+          disableSpaceAfterFlags,
+        );
+
+      if (i === pathData.length - 1) {
+        result +=
+          command +
+          stringifyArgs(command, args, precision, disableSpaceAfterFlags);
       } else {
-        combined.push({ command, args });
+        prev = { command, args };
       }
     }
   }
-  let result = '';
-  for (const { command, args } of combined) {
-    result +=
-      command + stringifyArgs(command, args, precision, disableSpaceAfterFlags);
-  }
+
   return result;
 };
 exports.stringifyPathData = stringifyPathData;

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -124,23 +124,24 @@ exports.cleanupOutData = (data, params, command) => {
 /**
  * Remove floating-point numbers leading zero.
  *
+ * @param {number} value
+ * @returns {string}
  * @example
  * 0.5 → .5
- *
- * @example
  * -0.5 → -.5
- *
- * @type {(num: number) => string}
  */
-const removeLeadingZero = (num) => {
-  var strNum = num.toString();
+const removeLeadingZero = (value) => {
+  const strValue = value.toString();
 
-  if (0 < num && num < 1 && strNum.charAt(0) === '0') {
-    strNum = strNum.slice(1);
-  } else if (-1 < num && num < 0 && strNum.charAt(1) === '0') {
-    strNum = strNum.charAt(0) + strNum.slice(2);
+  if (0 < value && value < 1 && strValue.startsWith('0')) {
+    return strValue.slice(1);
   }
-  return strNum;
+
+  if (-1 < value && value < 0 && strValue[1] === '0') {
+    return strValue[0] + strValue.slice(2);
+  }
+
+  return strValue;
 };
 exports.removeLeadingZero = removeLeadingZero;
 


### PR DESCRIPTION
Refactors `#stringifyPathData` and the functions it calls, which now runs notably faster.
The scenarios I measured in microbenchmarks ran in half the time.

* When stringifying, return both the numeric and string representation so we can perform checks with math instead of string parsing.
* When stringifying path data, use a single loop instead of creating an intermediate array and looping through that after.

### Metrics

Time to run the full SVGO Test Suite proposed in https://github.com/SethFalco/svgo/pull/1.

| Environment | Time |
|---|---|
| GitHub Actions | 20.5 minutes |
| My personal laptop (4 cores, 8 threads) | 15.0 minutes |
