### PR TITLE
chore: Use idiomatic Jest patterns to assert exceptions

### DIFF
--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -156,56 +156,33 @@ describe('loadConfig', () => {
   });
 
   test('fails when specified config does not exist', async () => {
-    try {
-      await loadConfig('{}');
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/Cannot find module/);
-    }
+    await expect(loadConfig('{}')).rejects.toThrow(/Cannot find module/);
   });
 
   test('fails when exported config not an object', async () => {
-    try {
-      await loadConfig(path.join(fixtures, 'invalid-null.js'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/Invalid config file/);
-    }
-    try {
-      await loadConfig(path.join(fixtures, 'invalid-array.js'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/Invalid config file/);
-    }
-    try {
-      await loadConfig(path.join(fixtures, 'invalid-string.js'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/Invalid config file/);
-    }
+    await expect(
+      loadConfig(path.join(fixtures, 'invalid-null.js')),
+    ).rejects.toThrow(/Invalid config file/);
+    await expect(
+      loadConfig(path.join(fixtures, 'invalid-array.js')),
+    ).rejects.toThrow(/Invalid config file/);
+    await expect(
+      loadConfig(path.join(fixtures, 'invalid-string.js')),
+    ).rejects.toThrow(/Invalid config file/);
   });
 
   test('handles runtime errors properly', async () => {
-    try {
-      await loadConfig(path.join(fixtures, 'invalid-runtime.js'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/plugins is not defined/);
-    }
-    try {
-      await loadConfig(path.join(fixtures, 'invalid-runtime.mjs'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/plugins is not defined/);
-    }
+    await expect(
+      loadConfig(path.join(fixtures, 'invalid-runtime.js')),
+    ).rejects.toThrow(/plugins is not defined/);
+    await expect(
+      loadConfig(path.join(fixtures, 'invalid-runtime.mjs')),
+    ).rejects.toThrow(/plugins is not defined/);
   });
 
   test('handles MODULE_NOT_FOUND properly', async () => {
-    try {
-      await loadConfig(path.join(fixtures, 'module-not-found.js'));
-      expect.fail('Config is loaded successfully');
-    } catch (error) {
-      expect(error.message).toMatch(/Cannot find module 'unknown-module'/);
-    }
+    await expect(
+      loadConfig(path.join(fixtures, 'module-not-found.js')),
+    ).rejects.toThrow(/Cannot find module 'unknown-module'/);
   });
 });

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -267,13 +267,13 @@ test('plugin precision should override preset precision', () => {
 });
 
 test('provides informative error in result', () => {
+  expect.assertions(6);
   const svg = `<svg viewBox="0 0 120 120">
       <circle fill="#ff0000" cx=60.444444" cy="60" r="50"/>
     </svg>
   `;
   try {
     optimize(svg, { path: 'test.svg' });
-    expect(true).toEqual(false);
   } catch (error) {
     expect(error.name).toEqual('SvgoParserError');
     expect(error.message).toEqual('test.svg:2:33: Unquoted attribute value');
@@ -285,13 +285,13 @@ test('provides informative error in result', () => {
 });
 
 test('provides code snippet in rendered error', () => {
+  expect.assertions(1);
   const svg = `<svg viewBox="0 0 120 120">
   <circle fill="#ff0000" cx=60.444444" cy="60" r="50"/>
 </svg>
 `;
   try {
     optimize(svg, { path: 'test.svg' });
-    expect(true).toEqual(false);
   } catch (error) {
     expect(error.toString())
       .toEqual(`SvgoParserError: test.svg:2:29: Unquoted attribute value
@@ -306,6 +306,7 @@ test('provides code snippet in rendered error', () => {
 });
 
 test('supports errors without path', () => {
+  expect.assertions(1);
   const svg = `<svg viewBox="0 0 120 120">
   <circle/>
   <circle/>
@@ -321,7 +322,6 @@ test('supports errors without path', () => {
 `;
   try {
     optimize(svg);
-    expect(true).toEqual(false);
   } catch (error) {
     expect(error.toString())
       .toEqual(`SvgoParserError: <input>:11:29: Unquoted attribute value
@@ -337,13 +337,13 @@ test('supports errors without path', () => {
 });
 
 test('slices long line in error code snippet', () => {
+  expect.assertions(1);
   const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" viewBox="0 0 230 120">
   <path d="M318.198 551.135 530.33 918.56l-289.778-77.646 38.823-144.889c77.646-289.778 294.98-231.543 256.156-86.655s178.51 203.124 217.334 58.235q58.234-217.334 250.955 222.534t579.555 155.292z stroke-width="1.5" fill="red" stroke="red" />
 </svg>
 `;
   try {
     optimize(svg);
-    expect(true).toEqual(false);
   } catch (error) {
     expect(error.toString())
       .toEqual(`SvgoParserError: <input>:2:211: Invalid attribute name

--- a/test/coa/_index.test.js
+++ b/test/coa/_index.test.js
@@ -124,15 +124,11 @@ describe('coa', function () {
   it('should throw error when stated in input folder does not exist', async () => {
     replaceConsoleError();
     try {
-      await runProgram([
-        '--input',
-        svgFolderPath + 'temp',
-        '--output',
-        tempFolder,
-      ]);
-    } catch (error) {
+      await expect(
+        runProgram(['--input', svgFolderPath + 'temp', '--output', tempFolder]),
+      ).rejects.toThrow(/no such file or directory/);
+    } finally {
       restoreConsoleError();
-      expect(error.message).toMatch(/no such file or directory/);
     }
   });
 
@@ -142,23 +138,19 @@ describe('coa', function () {
       if (!fs.existsSync(emptyFolderPath)) {
         fs.mkdirSync(emptyFolderPath);
       }
-      try {
-        await runProgram(['--folder', emptyFolderPath, '--quiet']);
-      } catch (error) {
-        expect(error.message).toMatch(/No SVG files/);
-      }
+      await expect(
+        runProgram(['--folder', emptyFolderPath, '--quiet']),
+      ).rejects.toThrow(/No SVG files/);
     });
 
     it('should show message when folder does not consists any svg files', async () => {
-      try {
-        await runProgram([
+      await expect(
+        runProgram([
           '--folder',
           path.resolve(__dirname, 'testFolderWithNoSvg'),
           '--quiet',
-        ]);
-      } catch (error) {
-        expect(error.message).toMatch(/No SVG files have been found/);
-      }
+        ]),
+      ).rejects.toThrow(/No SVG files have been found/);
     });
   });
 });


### PR DESCRIPTION
Avoid unnecessary assertions such as `expect(true).toBe(false)`. Instead, assert the exception using the `toThrow()` matcher. Where that is insufficient, use `expect.assertions()`. Unwrap exceptions in promises using `expect.rejects`.

These patterns are documented at:

- https://jestjs.io/docs/expect#tothrowerror
- https://jestjs.io/docs/tutorial-async#rejects
- https://jestjs.io/docs/expect#expectassertionsnumber