### PR TITLE
chore: Update @types/csso and correct types

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -16,7 +16,6 @@
 const csstree = require('css-tree');
 const csswhat = require('css-what');
 const {
-  // @ts-ignore internal api
   syntax: { specificity },
 } = require('csso');
 const { visit, matches } = require('./xast.js');

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -111,7 +111,7 @@ export type Plugin<Params> = (
   info: PluginInfo,
 ) => null | Visitor;
 
-export type Specificity = [number, number, number, number];
+export type Specificity = [number, number, number];
 
 export type StylesheetDeclaration = {
   name: string;

--- a/package.json
+++ b/package.json
@@ -83,14 +83,14 @@
     "css-select": "^5.1.0",
     "css-tree": "^2.2.1",
     "css-what": "^6.1.0",
-    "csso": "5.0.5",
+    "csso": "^5.0.5",
     "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@types/css-tree": "^2.0.0",
-    "@types/csso": "~5.0.3",
+    "@types/csso": "^5.0.4",
     "@types/jest": "^29.5.5",
     "del": "^6.0.0",
     "eslint": "^8.55.0",

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -7,7 +7,6 @@
 
 const csstree = require('css-tree');
 const {
-  // @ts-ignore internal api
   syntax: { specificity },
 } = require('csso');
 const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,12 +983,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/csso@npm:~5.0.3":
-  version: 5.0.3
-  resolution: "@types/csso@npm:5.0.3"
+"@types/csso@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@types/csso@npm:5.0.4"
   dependencies:
     "@types/css-tree": "*"
-  checksum: 3d299ea755732f9b913cfb3d94849e173cd1019559058af0a372aa1ca8f48a3c63aa74932fdfa2f2f25ee78255a115feaaec01ae4fe9578e76b7c4acd8ae3f2a
+  checksum: 606ea4de171e807ffc8908f7ffec774c8a40f3c81e7c60f8a84c7f5327eb00f3c9948b021b91e2e8fe3a76af4623ac58538780f0789f1e03947b7de96c5f7994
   languageName: node
   linkType: hard
 
@@ -1704,7 +1704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csso@npm:5.0.5":
+"csso@npm:^5.0.5":
   version: 5.0.5
   resolution: "csso@npm:5.0.5"
   dependencies:
@@ -4430,13 +4430,13 @@ __metadata:
     "@rollup/plugin-node-resolve": ^14.1.0
     "@trysound/sax": 0.2.0
     "@types/css-tree": ^2.0.0
-    "@types/csso": ~5.0.3
+    "@types/csso": ^5.0.4
     "@types/jest": ^29.5.5
     commander: ^7.2.0
     css-select: ^5.1.0
     css-tree: ^2.2.1
     css-what: ^6.1.0
-    csso: 5.0.5
+    csso: ^5.0.5
     del: ^6.0.0
     eslint: ^8.55.0
     jest: ^29.5.5


### PR DESCRIPTION
Follow upstream commit:
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/394c175b3bee0890febfb41b2321b1e11e8b1bdd

Can remove the ts-ignore when importing specificity.

The specificity function return a 3-tuple, so update the type alias in lib/types.d.ts.