### PR TITLE
deps: update css-tree and clean ts-ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@trysound/sax": "0.2.0",
     "commander": "^7.2.0",
     "css-select": "^5.1.0",
-    "css-tree": "^2.2.1",
+    "css-tree": "^2.3.1",
     "css-what": "^6.1.0",
     "csso": "^5.0.5",
     "picocolors": "^1.0.0"
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
-    "@types/css-tree": "^2.0.0",
+    "@types/css-tree": "^2.3.4",
     "@types/csso": "^5.0.4",
     "@types/jest": "^29.5.5",
     "del": "^6.0.0",

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -173,15 +173,12 @@ exports.fn = (_root, params, info) => {
                 node.name = prefixId(prefixGenerator, node.name);
                 return;
               }
-              // @ts-ignore csstree v2 changed this type
               if (node.type === 'Url' && node.value.length > 0) {
                 const prefixed = prefixReference(
                   prefixGenerator,
-                  // @ts-ignore
                   unquote(node.value),
                 );
                 if (prefixed != null) {
-                  // @ts-ignore
                   node.value = prefixed;
                 }
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,10 +976,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/css-tree@npm:*, @types/css-tree@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@types/css-tree@npm:2.0.0"
-  checksum: 52d89f5c52c6ec5feac674a3f28f35994211f26c662cc8718f21ebabad992329e8c810da1e070aa61c49f89e92cd5ef7b460e81de52f0d0f5973618d87ebc3ae
+"@types/css-tree@npm:*, @types/css-tree@npm:^2.3.4":
+  version: 2.3.4
+  resolution: "@types/css-tree@npm:2.3.4"
+  checksum: b06173d3ae048b74e7030cceae01d3d6e5589f7348e8e4b907427f91baeda76807bbde8c5be4c41e22b952268b46edcba7ab96e16efedb2d0b37ce2bf90d1835
   languageName: node
   linkType: hard
 
@@ -1687,7 +1687,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^2.2.1, css-tree@npm:~2.2.0":
+"css-tree@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "css-tree@npm:2.3.1"
+  dependencies:
+    mdn-data: 2.0.30
+    source-map-js: ^1.0.1
+  checksum: 493cc24b5c22b05ee5314b8a0d72d8a5869491c1458017ae5ed75aeb6c3596637dbe1b11dac2548974624adec9f7a1f3a6cf40593dc1f9185eb0e8279543fbc0
+  languageName: node
+  linkType: hard
+
+"css-tree@npm:~2.2.0":
   version: 2.2.1
   resolution: "css-tree@npm:2.2.1"
   dependencies:
@@ -3390,6 +3400,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdn-data@npm:2.0.30":
+  version: 2.0.30
+  resolution: "mdn-data@npm:2.0.30"
+  checksum: d6ac5ac7439a1607df44b22738ecf83f48e66a0874e4482d6424a61c52da5cde5750f1d1229b6f5fa1b80a492be89465390da685b11f97d62b8adcc6e88189aa
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -4429,12 +4446,12 @@ __metadata:
     "@rollup/plugin-commonjs": ^22.0.2
     "@rollup/plugin-node-resolve": ^14.1.0
     "@trysound/sax": 0.2.0
-    "@types/css-tree": ^2.0.0
+    "@types/css-tree": ^2.3.4
     "@types/csso": ^5.0.4
     "@types/jest": ^29.5.5
     commander: ^7.2.0
     css-select: ^5.1.0
-    css-tree: ^2.2.1
+    css-tree: ^2.3.1
     css-what: ^6.1.0
     csso: ^5.0.5
     del: ^6.0.0


### PR DESCRIPTION
Updates `css-tree` and `@types/css-tree`, and removes redundant `ts-ignore` comments now that we have more up-to-date types.