### PR TITLE
chore: Improve Jest tests with more precise assertions

### DIFF
--- a/lib/path.test.js
+++ b/lib/path.test.js
@@ -8,55 +8,55 @@ const { parsePathData, stringifyPathData } = require('./path.js');
 
 describe('parse path data', () => {
   it('should allow spaces between commands', () => {
-    expect(parsePathData('M0 10 L \n\r\t20 30')).toEqual([
+    expect(parsePathData('M0 10 L \n\r\t20 30')).toStrictEqual([
       { command: 'M', args: [0, 10] },
       { command: 'L', args: [20, 30] },
     ]);
   });
   it('should allow spaces and commas between arguments', () => {
-    expect(parsePathData('M0 , 10 L 20 \n\r\t30,40,50')).toEqual([
+    expect(parsePathData('M0 , 10 L 20 \n\r\t30,40,50')).toStrictEqual([
       { command: 'M', args: [0, 10] },
       { command: 'L', args: [20, 30] },
       { command: 'L', args: [40, 50] },
     ]);
   });
   it('should forbid commas before commands', () => {
-    expect(parsePathData(', M0 10')).toEqual([]);
+    expect(parsePathData(', M0 10')).toStrictEqual([]);
   });
   it('should forbid commas between commands', () => {
-    expect(parsePathData('M0,10 , L 20,30')).toEqual([
+    expect(parsePathData('M0,10 , L 20,30')).toStrictEqual([
       { command: 'M', args: [0, 10] },
     ]);
   });
   it('should forbid commas between command name and argument', () => {
-    expect(parsePathData('M0,10 L,20,30')).toEqual([
+    expect(parsePathData('M0,10 L,20,30')).toStrictEqual([
       { command: 'M', args: [0, 10] },
     ]);
   });
   it('should forbid multiple commas in a row', () => {
-    expect(parsePathData('M0 , , 10')).toEqual([]);
+    expect(parsePathData('M0 , , 10')).toStrictEqual([]);
   });
   it('should stop when unknown char appears', () => {
-    expect(parsePathData('M0 10 , L 20 #40')).toEqual([
+    expect(parsePathData('M0 10 , L 20 #40')).toStrictEqual([
       { command: 'M', args: [0, 10] },
     ]);
   });
   it('should stop when not enough arguments', () => {
-    expect(parsePathData('M0 10 L 20 L 30 40')).toEqual([
+    expect(parsePathData('M0 10 L 20 L 30 40')).toStrictEqual([
       { command: 'M', args: [0, 10] },
     ]);
   });
   it('should stop if moveto not the first command', () => {
-    expect(parsePathData('L 10 20')).toEqual([]);
-    expect(parsePathData('10 20')).toEqual([]);
+    expect(parsePathData('L 10 20')).toStrictEqual([]);
+    expect(parsePathData('10 20')).toStrictEqual([]);
   });
   it('should stop on invalid scientific notation', () => {
-    expect(parsePathData('M 0 5e++1 L 0 0')).toEqual([
+    expect(parsePathData('M 0 5e++1 L 0 0')).toStrictEqual([
       { command: 'M', args: [0, 5] },
     ]);
   });
   it('should stop on invalid numbers', () => {
-    expect(parsePathData('M ...')).toEqual([]);
+    expect(parsePathData('M ...')).toStrictEqual([]);
   });
   it('should handle arcs', () => {
     expect(
@@ -71,7 +71,7 @@ describe('parse path data', () => {
           l 50,-25
         `,
       ),
-    ).toEqual([
+    ).toStrictEqual([
       { command: 'M', args: [600, 350] },
       { command: 'l', args: [50, -25] },
       { command: 'a', args: [25, 25, -30, 0, 1, 50, -25] },
@@ -96,7 +96,7 @@ describe('stringify path data', () => {
           { command: 'H', args: [50] },
         ],
       }),
-    ).toEqual('M0 0h10 20 30H40 50');
+    ).toBe('M0 0h10 20 30H40 50');
   });
   it('should not combine sequence of moveto', () => {
     expect(
@@ -108,7 +108,7 @@ describe('stringify path data', () => {
           { command: 'm', args: [40, 50] },
         ],
       }),
-    ).toEqual('M0 0M10 10m20 30m40 50');
+    ).toBe('M0 0M10 10m20 30m40 50');
   });
   it('should combine moveto and sequence of lineto', () => {
     expect(
@@ -122,7 +122,7 @@ describe('stringify path data', () => {
           { command: 'L', args: [10, 10] },
         ],
       }),
-    ).toEqual('m0 0 10 10M0 0l10 10M0 0 10 10');
+    ).toBe('m0 0 10 10M0 0l10 10M0 0 10 10');
     expect(
       stringifyPathData({
         pathData: [
@@ -130,7 +130,7 @@ describe('stringify path data', () => {
           { command: 'L', args: [10, 10] },
         ],
       }),
-    ).toEqual('M0 0 10 10');
+    ).toBe('M0 0 10 10');
   });
   it('should avoid space before first, negative and decimals', () => {
     expect(
@@ -142,7 +142,7 @@ describe('stringify path data', () => {
           { command: 'L', args: [7, 0.8] },
         ],
       }),
-    ).toEqual('M0-1.2.3 4 5-.6 7 .8');
+    ).toBe('M0-1.2.3 4 5-.6 7 .8');
   });
   it('should configure precision', () => {
     /**
@@ -159,13 +159,13 @@ describe('stringify path data', () => {
         pathData,
         precision: 3,
       }),
-    ).toEqual('M0-1.988.3 3.142-.3-3.142 100 200');
+    ).toBe('M0-1.988.3 3.142-.3-3.142 100 200');
     expect(
       stringifyPathData({
         pathData,
         precision: 0,
       }),
-    ).toEqual('M0-2 0 3 0-3 100 200');
+    ).toBe('M0-2 0 3 0-3 100 200');
   });
   it('allows to avoid spaces after arc flags', () => {
     /**
@@ -182,12 +182,12 @@ describe('stringify path data', () => {
         pathData,
         disableSpaceAfterFlags: false,
       }),
-    ).toEqual('M0 0A50 50 10 1 0 .2 20a50 50 10 1 0 .2 20 50 50 10 1 0 .2 20');
+    ).toBe('M0 0A50 50 10 1 0 .2 20a50 50 10 1 0 .2 20 50 50 10 1 0 .2 20');
     expect(
       stringifyPathData({
         pathData,
         disableSpaceAfterFlags: true,
       }),
-    ).toEqual('M0 0A50 50 10 10.2 20a50 50 10 10.2 20 50 50 10 10.2 20');
+    ).toBe('M0 0A50 50 10 10.2 20a50 50 10 10.2 20 50 50 10 10.2 20');
   });
 });

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -58,31 +58,35 @@ it('collects styles', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'class'))).toEqual({
-    fill: { type: 'static', inherited: false, value: 'red' },
-  });
-  expect(computeStyle(stylesheet, getElementById(root, 'two-classes'))).toEqual(
+  expect(computeStyle(stylesheet, getElementById(root, 'class'))).toStrictEqual(
     {
-      fill: { type: 'static', inherited: false, value: 'green' },
-      stroke: { type: 'static', inherited: false, value: 'black' },
+      fill: { type: 'static', inherited: false, value: 'red' },
     },
   );
-  expect(computeStyle(stylesheet, getElementById(root, 'attribute'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'two-classes')),
+  ).toStrictEqual({
+    fill: { type: 'static', inherited: false, value: 'green' },
+    stroke: { type: 'static', inherited: false, value: 'black' },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'attribute')),
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
   expect(
     computeStyle(stylesheet, getElementById(root, 'inline-style')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'grey' },
   });
-  expect(computeStyle(stylesheet, getElementById(root, 'inheritance'))).toEqual(
-    {
-      fill: { type: 'static', inherited: true, value: 'yellow' },
-    },
-  );
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'inheritance')),
+  ).toStrictEqual({
+    fill: { type: 'static', inherited: true, value: 'yellow' },
+  });
   expect(
     computeStyle(stylesheet, getElementById(root, 'nested-inheritance')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: true, value: 'blue' },
   });
 });
@@ -107,12 +111,12 @@ it('prioritizes different kinds of styles', () => {
   const stylesheet = collectStylesheet(root);
   expect(
     computeStyle(stylesheet, getElementById(root, 'complex-selector')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'red' },
   });
   expect(
     computeStyle(stylesheet, getElementById(root, 'override-selector')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
   expect(
@@ -120,12 +124,12 @@ it('prioritizes different kinds of styles', () => {
       stylesheet,
       getElementById(root, 'attribute-over-inheritance'),
     ),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'orange' },
   });
   expect(
     computeStyle(stylesheet, getElementById(root, 'style-rule-over-attribute')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
   expect(
@@ -133,7 +137,7 @@ it('prioritizes different kinds of styles', () => {
       stylesheet,
       getElementById(root, 'inline-style-over-style-rule'),
     ),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
 });
@@ -153,7 +157,7 @@ it('prioritizes important styles', () => {
   const stylesheet = collectStylesheet(root);
   expect(
     computeStyle(stylesheet, getElementById(root, 'complex-selector')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
@@ -161,7 +165,7 @@ it('prioritizes important styles', () => {
       stylesheet,
       getElementById(root, 'style-rule-over-inline-style'),
     ),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
@@ -169,7 +173,7 @@ it('prioritizes important styles', () => {
       stylesheet,
       getElementById(root, 'inline-style-over-style-rule'),
     ),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'purple' },
   });
 });
@@ -195,23 +199,29 @@ it('treats at-rules and pseudo-classes as dynamic styles', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'media-query')),
+  ).toStrictEqual({
+    fill: { type: 'dynamic', inherited: false },
+  });
+  expect(computeStyle(stylesheet, getElementById(root, 'hover'))).toStrictEqual(
     {
       fill: { type: 'dynamic', inherited: false },
     },
   );
-  expect(computeStyle(stylesheet, getElementById(root, 'hover'))).toEqual({
-    fill: { type: 'dynamic', inherited: false },
-  });
-  expect(computeStyle(stylesheet, getElementById(root, 'inherited'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'inherited')),
+  ).toStrictEqual({
     fill: { type: 'dynamic', inherited: true },
   });
   expect(
     computeStyle(stylesheet, getElementById(root, 'inherited-overriden')),
-  ).toEqual({
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
-  expect(computeStyle(stylesheet, getElementById(root, 'static'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'static')),
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'black' },
   });
 });
@@ -234,17 +244,19 @@ it('considers <style> media attribute', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'media-query'))).toEqual(
-    {
-      fill: { type: 'dynamic', inherited: false },
-    },
-  );
   expect(
-    computeStyle(stylesheet, getElementById(root, 'kinda-static')),
-  ).toEqual({
+    computeStyle(stylesheet, getElementById(root, 'media-query')),
+  ).toStrictEqual({
     fill: { type: 'dynamic', inherited: false },
   });
-  expect(computeStyle(stylesheet, getElementById(root, 'static'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'kinda-static')),
+  ).toStrictEqual({
+    fill: { type: 'dynamic', inherited: false },
+  });
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'static')),
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'blue' },
   });
 });
@@ -267,15 +279,19 @@ it('ignores <style> with invalid type', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'valid-type'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'valid-type')),
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'red' },
   });
-  expect(computeStyle(stylesheet, getElementById(root, 'empty-type'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'empty-type')),
+  ).toStrictEqual({
     fill: { type: 'static', inherited: false, value: 'green' },
   });
   expect(
     computeStyle(stylesheet, getElementById(root, 'invalid-type')),
-  ).toEqual({});
+  ).toStrictEqual({});
 });
 
 it('ignores keyframes atrule', () => {
@@ -301,7 +317,9 @@ it('ignores keyframes atrule', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'element'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'element')),
+  ).toStrictEqual({
     animation: {
       type: 'static',
       inherited: false,
@@ -330,7 +348,9 @@ it('ignores @-webkit-keyframes atrule', () => {
       </svg>
     `);
   const stylesheet = collectStylesheet(root);
-  expect(computeStyle(stylesheet, getElementById(root, 'element'))).toEqual({
+  expect(
+    computeStyle(stylesheet, getElementById(root, 'element')),
+  ).toStrictEqual({
     animation: {
       type: 'static',
       inherited: false,

--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -23,8 +23,7 @@ describeLF('with LF line-endings', () => {
       </svg>
     `;
     const { data } = optimize(svg);
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
@@ -42,8 +41,7 @@ describeLF('with LF line-endings', () => {
     const { data } = optimize(svg, {
       js2svg: { pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
@@ -61,8 +59,7 @@ describeLF('with LF line-endings', () => {
     const { data } = optimize(svg, {
       js2svg: { eol: 'crlf', pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
@@ -80,8 +77,7 @@ describeCRLF('with CRLF line-endings', () => {
       </svg>
     `;
     const { data } = optimize(svg);
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
@@ -99,8 +95,7 @@ describeCRLF('with CRLF line-endings', () => {
     const { data } = optimize(svg, {
       js2svg: { pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
@@ -118,8 +113,7 @@ describeCRLF('with CRLF line-endings', () => {
     const { data } = optimize(svg, {
       js2svg: { eol: 'lf', pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
@@ -130,27 +124,31 @@ describe('loadConfig', () => {
   const fixtures = path.join(cwd, './test/fixtures/config-loader');
 
   test('loads by absolute path', async () => {
-    expect(await loadConfig(path.join(fixtures, 'one/two/config.js'))).toEqual({
+    expect(
+      await loadConfig(path.join(fixtures, 'one/two/config.js')),
+    ).toStrictEqual({
       plugins: [],
     });
   });
 
   test('loads by relative path to cwd', async () => {
     const config = await loadConfig('one/two/config.js', fixtures);
-    expect(config).toEqual({ plugins: [] });
+    expect(config).toStrictEqual({ plugins: [] });
   });
 
   test('searches in cwd and up', async () => {
-    expect(await loadConfig(null, path.join(fixtures, 'one/two'))).toEqual({
+    expect(
+      await loadConfig(null, path.join(fixtures, 'one/two')),
+    ).toStrictEqual({
       plugins: [],
     });
     expect(
       await loadConfig(null, path.join(cwd, './test/fixtures/missing')),
-    ).toEqual(null);
-    expect(await loadConfig(null, path.join(fixtures, 'mjs'))).toEqual({
+    ).toBeNull();
+    expect(await loadConfig(null, path.join(fixtures, 'mjs'))).toStrictEqual({
       plugins: ['mjs'],
     });
-    expect(await loadConfig(null, path.join(fixtures, 'cjs'))).toEqual({
+    expect(await loadConfig(null, path.join(fixtures, 'cjs'))).toStrictEqual({
       plugins: ['cjs'],
     });
   });

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -109,8 +109,7 @@ describe('allow to configure EOL', () => {
     const { data } = optimize(svg, {
       js2svg: { eol: 'lf', pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
@@ -128,8 +127,7 @@ describe('allow to configure EOL', () => {
     const { data } = optimize(svg, {
       js2svg: { eol: 'crlf', pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\r\n  <circle cx="60" cy="60" r="50" fill="red"/>\r\n</svg>\r\n',
     );
   });
@@ -147,8 +145,7 @@ describe('allow to configure EOL', () => {
     const { data } = optimize(svg, {
       js2svg: { eol: 'invalid', pretty: true, indent: 2 },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
@@ -166,8 +163,7 @@ describe('allow to configure final newline', () => {
       </svg>
     `;
     const { data } = optimize(svg, { js2svg: { eol: 'lf' } });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>',
     );
   });
@@ -185,8 +181,7 @@ describe('allow to configure final newline', () => {
     const { data } = optimize(svg, {
       js2svg: { finalNewline: true, eol: 'lf' },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120"><circle cx="60" cy="60" r="50" fill="red"/></svg>\n',
     );
   });
@@ -204,8 +199,7 @@ describe('allow to configure final newline', () => {
     const { data } = optimize(svg, {
       js2svg: { finalNewline: true, pretty: true, indent: 2, eol: 'lf' },
     });
-    // using toEqual because line endings matter in these tests
-    expect(data).toEqual(
+    expect(data).toBe(
       '<svg viewBox="0 0 120 120">\n  <circle cx="60" cy="60" r="50" fill="red"/>\n</svg>\n',
     );
   });
@@ -275,12 +269,12 @@ test('provides informative error in result', () => {
   try {
     optimize(svg, { path: 'test.svg' });
   } catch (error) {
-    expect(error.name).toEqual('SvgoParserError');
-    expect(error.message).toEqual('test.svg:2:33: Unquoted attribute value');
-    expect(error.reason).toEqual('Unquoted attribute value');
-    expect(error.line).toEqual(2);
-    expect(error.column).toEqual(33);
-    expect(error.source).toEqual(svg);
+    expect(error.name).toBe('SvgoParserError');
+    expect(error.message).toBe('test.svg:2:33: Unquoted attribute value');
+    expect(error.reason).toBe('Unquoted attribute value');
+    expect(error.line).toBe(2);
+    expect(error.column).toBe(33);
+    expect(error.source).toBe(svg);
   }
 });
 
@@ -294,7 +288,7 @@ test('provides code snippet in rendered error', () => {
     optimize(svg, { path: 'test.svg' });
   } catch (error) {
     expect(error.toString())
-      .toEqual(`SvgoParserError: test.svg:2:29: Unquoted attribute value
+      .toBe(`SvgoParserError: test.svg:2:29: Unquoted attribute value
 
   1 | <svg viewBox="0 0 120 120">
 > 2 |   <circle fill="#ff0000" cx=60.444444" cy="60" r="50"/>
@@ -324,7 +318,7 @@ test('supports errors without path', () => {
     optimize(svg);
   } catch (error) {
     expect(error.toString())
-      .toEqual(`SvgoParserError: <input>:11:29: Unquoted attribute value
+      .toBe(`SvgoParserError: <input>:11:29: Unquoted attribute value
 
    9 |   <circle/>
   10 |   <circle/>
@@ -346,7 +340,7 @@ test('slices long line in error code snippet', () => {
     optimize(svg);
   } catch (error) {
     expect(error.toString())
-      .toEqual(`SvgoParserError: <input>:2:211: Invalid attribute name
+      .toBe(`SvgoParserError: <input>:2:211: Invalid attribute name
 
   1 | …-0.dtd" viewBox="0 0 230 120">
 > 2 | …7.334 250.955 222.534t579.555 155.292z stroke-width="1.5" fill="red" strok…
@@ -377,8 +371,8 @@ test('multipass option should trigger plugins multiple times', () => {
     },
   };
   const { data } = optimize(svg, { multipass: true, plugins: [testPlugin] });
-  expect(list).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  expect(data).toEqual(`<svg id="klmnopqrstuvwxyz"/>`);
+  expect(list).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  expect(data).toBe(`<svg id="klmnopqrstuvwxyz"/>`);
 });
 
 test('encode as datauri', () => {

--- a/lib/xast.test.js
+++ b/lib/xast.test.js
@@ -43,7 +43,7 @@ test('visit enters into nodes', () => {
       },
     },
   });
-  expect(entered).toEqual([
+  expect(entered).toStrictEqual([
     'root',
     'element:g',
     'element:rect',
@@ -70,7 +70,7 @@ test('visit exits from nodes', () => {
       },
     },
   });
-  expect(exited).toEqual([
+  expect(exited).toStrictEqual([
     'element:rect',
     'element:circle',
     'element:g',
@@ -95,8 +95,8 @@ test('visit skips entering children if node is detached', () => {
       },
     },
   });
-  expect(entered).toEqual(['g', 'ellipse']);
-  expect(ast).toEqual(root([x('ellipse')]));
+  expect(entered).toStrictEqual(['g', 'ellipse']);
+  expect(ast).toStrictEqual(root([x('ellipse')]));
 });
 
 test('visit skips entering children when symbol is passed', () => {
@@ -115,8 +115,8 @@ test('visit skips entering children when symbol is passed', () => {
       },
     },
   });
-  expect(entered).toEqual(['g', 'ellipse']);
-  expect(ast).toEqual(
+  expect(entered).toStrictEqual(['g', 'ellipse']);
+  expect(ast).toStrictEqual(
     root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]),
   );
 });

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -47,7 +47,7 @@ test('accepts svg as input stream', async () => {
   proc.stdin.write('<svg><title>stdin</title></svg>');
   proc.stdin.end();
   const stdout = await waitStdout(proc);
-  expect(stdout).toEqual('<svg/>');
+  expect(stdout).toBe('<svg/>');
 });
 
 test('accepts svg as string', async () => {
@@ -58,7 +58,7 @@ test('accepts svg as string', async () => {
     { cwd: __dirname },
   );
   const stdout = await waitStdout(proc);
-  expect(stdout).toEqual('<svg/>');
+  expect(stdout).toBe('<svg/>');
 });
 
 test('accepts svg as filename', async () => {
@@ -72,7 +72,7 @@ test('accepts svg as filename', async () => {
     path.join(__dirname, 'output/single.svg'),
     'utf-8',
   );
-  expect(output).toEqual('<svg/>');
+  expect(output).toBe('<svg/>');
 });
 
 test('output as stream when "-" is specified', async () => {
@@ -82,7 +82,7 @@ test('output as stream when "-" is specified', async () => {
     { cwd: __dirname },
   );
   const stdout = await waitStdout(proc);
-  expect(stdout).toEqual('<svg/>');
+  expect(stdout).toBe('<svg/>');
 });
 
 test('should exit with 1 code on syntax error', async () => {
@@ -101,9 +101,9 @@ test('should exit with 1 code on syntax error', async () => {
       });
     }),
   ]);
-  expect(code).toEqual(1);
+  expect(code).toBe(1);
   expect(stderr)
-    .toEqual(`SvgoParserError: invalid.svg:2:27: Unquoted attribute value
+    .toBe(`SvgoParserError: invalid.svg:2:27: Unquoted attribute value
 
   1 | <svg>
 > 2 |   <rect x="0" y="0" width=10" height="20" />

--- a/test/plugins/_index.test.js
+++ b/test/plugins/_index.test.js
@@ -41,9 +41,9 @@ describe('plugins tests', function () {
               js2svg: { pretty: true },
             });
             lastResultData = result.data;
-            expect(result.error).not.toEqual(expect.anything());
+            expect(result.error).not.toStrictEqual(expect.anything());
             //FIXME: results.data has a '\n' at the end while it should not
-            expect(normalize(result.data)).toEqual(should);
+            expect(normalize(result.data)).toStrictEqual(should);
           }
         });
       });

--- a/test/plugins/prefixIds.test.js
+++ b/test/plugins/prefixIds.test.js
@@ -8,17 +8,17 @@ test('should extract prefix from path basename', () => {
     optimize(svg, {
       plugins: ['prefixIds'],
     }).data,
-  ).toEqual(`<svg id="prefix__my-id"/>`);
+  ).toBe(`<svg id="prefix__my-id"/>`);
   expect(
     optimize(svg, {
       plugins: ['prefixIds'],
       path: 'input.svg',
     }).data,
-  ).toEqual(`<svg id="input_svg__my-id"/>`);
+  ).toBe(`<svg id="input_svg__my-id"/>`);
   expect(
     optimize(svg, {
       plugins: ['prefixIds'],
       path: 'path/to/input.svg',
     }).data,
-  ).toEqual(`<svg id="input_svg__my-id"/>`);
+  ).toBe(`<svg id="input_svg__my-id"/>`);
 });

--- a/test/svg2js/_index.test.js
+++ b/test/svg2js/_index.test.js
@@ -22,7 +22,7 @@ describe('svg2js', function () {
 
     describe('root', function () {
       it('should exist', function () {
-        expect(root).toEqual(expect.anything());
+        expect(root).toStrictEqual(expect.anything());
       });
 
       it('should be an instance of Object', function () {
@@ -45,7 +45,7 @@ describe('svg2js', function () {
     });
 
     it('the first node should be instruction', () => {
-      expect(root.children[0]).toEqual({
+      expect(root.children[0]).toStrictEqual({
         type: 'instruction',
         name: 'xml',
         value: 'version="1.0" encoding="utf-8"',
@@ -53,7 +53,7 @@ describe('svg2js', function () {
     });
 
     it('the second node should be comment', () => {
-      expect(root.children[1]).toEqual({
+      expect(root.children[1]).toStrictEqual({
         type: 'comment',
         value:
           'Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)',
@@ -61,7 +61,7 @@ describe('svg2js', function () {
     });
 
     it('the third node should be doctype', () => {
-      expect(root.children[2]).toEqual({
+      expect(root.children[2]).toStrictEqual({
         type: 'doctype',
         name: 'svg',
         data: {
@@ -73,7 +73,7 @@ describe('svg2js', function () {
 
     describe('name', function () {
       it('should have property name: "svg"', function () {
-        expect(root.children[3]).toEqual(
+        expect(root.children[3]).toStrictEqual(
           expect.objectContaining({
             name: 'svg',
           }),
@@ -83,7 +83,7 @@ describe('svg2js', function () {
 
     describe('children', function () {
       it('should exist', function () {
-        expect(root.children[3].children).toEqual(expect.anything());
+        expect(root.children[3].children).toStrictEqual(expect.anything());
       });
 
       it('should be an instance of Array', function () {
@@ -98,7 +98,7 @@ describe('svg2js', function () {
     describe('text nodes', function () {
       it('should contain preserved whitespace', function () {
         const textNode = root.children[3].children[1].children[0].children[1];
-        expect(textNode.children[0].value).toEqual('  test  ');
+        expect(textNode.children[0].value).toBe('  test  ');
       });
     });
   });

--- a/test/svgo/_index.test.js
+++ b/test/svgo/_index.test.js
@@ -24,16 +24,16 @@ describe('svgo', () => {
       plugins: [],
       js2svg: { pretty: true, indent: 2 },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should handle plugins order properly', async () => {
     const [original, expected] = await parseFixture('plugins-order.svg');
     const result = optimize(original, { path: 'input.svg' });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should handle empty svg tag', async () => {
     const result = optimize('<svg />', { path: 'input.svg' });
-    expect(result.data).toEqual('<svg/>');
+    expect(result.data).toBe('<svg/>');
   });
   it('should preserve style specificity over attributes', async () => {
     const [original, expected] = await parseFixture('style-specificity.svg');
@@ -41,7 +41,7 @@ describe('svgo', () => {
       path: 'input.svg',
       js2svg: { pretty: true },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should inline entities', async () => {
     const [original, expected] = await parseFixture('entities.svg');
@@ -50,7 +50,7 @@ describe('svgo', () => {
       plugins: [],
       js2svg: { pretty: true },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should preserve whitespaces between tspan tags', async () => {
     const [original, expected] = await parseFixture('whitespaces.svg');
@@ -58,7 +58,7 @@ describe('svgo', () => {
       path: 'input.svg',
       js2svg: { pretty: true },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should preserve "to" keyframe selector', async () => {
     const [original, expected] = await parseFixture('keyframe-selectors.svg');
@@ -66,14 +66,14 @@ describe('svgo', () => {
       path: 'input.svg',
       js2svg: { pretty: true },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should not trim whitespace at start and end of pre element', async () => {
     const [original, expected] = await parseFixture('pre-element.svg');
     const result = optimize(original, {
       path: 'input.svg',
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
   it('should not add whitespace in pre element', async () => {
     const [original, expected] = await parseFixture('pre-element-pretty.svg');
@@ -81,6 +81,6 @@ describe('svgo', () => {
       path: 'input.svg',
       js2svg: { pretty: true },
     });
-    expect(normalize(result.data)).toEqual(expected);
+    expect(normalize(result.data)).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
Avoid type coercion for assertions by using toBe, toBeNull, and toStrictEqual.

These matchers are documented at:

- https://jestjs.io/docs/expect#tobevalue
- https://jestjs.io/docs/expect#tostrictequalvalue
- https://jestjs.io/docs/expect#tobenull