### PR TITLE
Add mergeText plugin.

### DIFF
--- a/docs/03-plugins/merge-text.mdx
+++ b/docs/03-plugins/merge-text.mdx
@@ -1,0 +1,15 @@
+---
+title: Merge Text
+svgo:
+  pluginId: mergeText
+---
+
+Merge adjacent `<text>` elements and remove `<tspan>` when it is the only child of a `<text>` element.
+
+If the SVG contains any `<style>` elements, it will not be modified.
+
+`<text>` or `<tspan>` elements which have non-inheritable attributes other than `x` or `y` will not be modified.
+
+## Implementation
+
+- https://github.com/svg/svgo/blob/main/plugins/mergeText.js

--- a/lib/builtin.js
+++ b/lib/builtin.js
@@ -20,6 +20,7 @@ exports.builtin = [
   require('../plugins/mergeStyles.js'),
   require('../plugins/inlineStyles.js'),
   require('../plugins/mergePaths.js'),
+  require('../plugins/mergeText.js'),
   require('../plugins/minifyStyles.js'),
   require('../plugins/moveElemsAttrsToGroup.js'),
   require('../plugins/moveGroupAttrsToElems.js'),

--- a/plugins/mergeText.js
+++ b/plugins/mergeText.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const { inheritableAttrs } = require('./_collections');
+
+/**
+ * @typedef {import('../lib/types').XastElement} XastElement
+ * @typedef {import('../lib/types').XastChild} XastChild
+ */
+
+exports.name = 'mergeText';
+exports.description = 'merges <text> elements and children where possible';
+
+/**
+ * @typedef {{
+ * x:string,
+ * y:string,
+ * attributes:Map<string,string>,
+ * children:XastChild[]
+ * }} TspanData
+ */
+
+/**
+ * @typedef {{
+ * x:string,
+ * y:string,
+ * children:TspanData[],
+ * }
+ * }TextData
+ */
+
+/**
+ * Merge <text> elements and children where possible, and minimize duplication of attributes.
+ *
+ * @author John Kenny
+ *
+ * @type {import('./plugins-types').Plugin<'mergeText'>}
+ */
+
+exports.fn = () => {
+  let deoptimized = false;
+
+  return {
+    element: {
+      enter: (node) => {
+        // Don't collapse if styles are present.
+        if (node.name === 'style' && node.children.length !== 0) {
+          deoptimized = true;
+        }
+      },
+
+      exit: (node) => {
+        if (deoptimized) {
+          return;
+        }
+
+        // See if the node has <text> children.
+        /** @type Map<number,TextData> */
+        const mergeableChildren = new Map();
+        for (let index = 0; index < node.children.length; index++) {
+          const child = node.children[index];
+          if (child.type === 'element' && child.name === 'text') {
+            const mergeData = getMergeData(child);
+            if (mergeData) {
+              mergeableChildren.set(index, mergeData);
+            }
+          }
+        }
+
+        // If nothing to merge, return.
+        if (mergeableChildren.size === 0) {
+          return;
+        }
+
+        // Create new child nodes.
+        /** @type XastChild[] */
+        const newChildren = [];
+        for (let index = 0; index < node.children.length; index++) {
+          if (!mergeableChildren.has(index)) {
+            // This is not a <text> element; do not process.
+            newChildren.push(node.children[index]);
+            continue;
+          }
+          if (mergeableChildren.has(index - 1)) {
+            // The previous child was a mergeable <text> element; assume this one was already merged into it.
+            continue;
+          }
+          // Merge and insert text elements.
+          newChildren.push(mergeTextElements(mergeableChildren, index));
+        }
+
+        // Update children.
+        node.children = newChildren;
+      },
+    },
+  };
+};
+
+/**
+ *
+ * @param {XastElement} textEl
+ * @returns {any}
+ */
+function getMergeData(textEl) {
+  /**@type TextData   */
+  const data = {};
+  /**@type Map<string,string> */
+  const textAttributes = new Map();
+  data.children = [];
+
+  // Gather all <text> attributes.
+  for (const [k, v] of Object.entries(textEl.attributes)) {
+    switch (k) {
+      case 'x':
+      case 'y':
+        data[k] = v;
+        break;
+      default:
+        textAttributes.set(k, v);
+        break;
+    }
+  }
+
+  // Check all children of <text> element.
+  for (const child of textEl.children) {
+    if (child.type === 'text') {
+      if (isWhiteSpace(child.value)) {
+        // Ignore nodes that are all whitespace.
+        continue;
+      }
+    }
+    if (child.type !== 'element' || child.name !== 'tspan') {
+      // Don't transform unless all children are <tspan> elements.
+      return;
+    }
+    for (const tspanChild of child.children) {
+      // Don't transform unless <tspan> has only text nodes and <tspan>s as children.
+      if (tspanChild.type === 'text') {
+        continue;
+      }
+      if (tspanChild.type === 'element' && tspanChild.name === 'tspan') {
+        continue;
+      }
+      return;
+    }
+
+    /** @type TspanData     */
+    const tspanData = {};
+
+    // Copy all <text> attributes to the tspan data.
+    tspanData.attributes = new Map(textAttributes);
+
+    // Merge all <tspan> attributes.
+    for (const [k, v] of Object.entries(child.attributes)) {
+      switch (k) {
+        case 'x':
+        case 'y':
+          tspanData[k] = v;
+          break;
+        default:
+          if (!inheritableAttrs.has(k)) {
+            // Don't transform if <tspan> has unrecognized attributes.
+            return;
+          }
+          tspanData.attributes.set(k, v);
+          break;
+      }
+    }
+
+    // Don't transform unless all children have x and y attributes.
+    if (!tspanData.x || !tspanData.y) {
+      return;
+    }
+
+    tspanData.children = child.children;
+
+    data.children.push(tspanData);
+  }
+
+  return data;
+}
+
+/**
+ *
+ * @param {TspanData[]} tspans
+ * @returns {{}}
+ */
+function getTextAttributes(tspans) {
+  // Figure out what attributes and values we have.
+  const allAttributes = new Map();
+  for (const tspanElement of tspans) {
+    for (const [attName, attValue] of tspanElement.attributes) {
+      let values = allAttributes.get(attName);
+      if (!values) {
+        values = new Map();
+        allAttributes.set(attName, values);
+      }
+      if (!values.has(attValue)) {
+        values.set(attValue, 1);
+      } else {
+        values.set(attValue, values.get(attValue) + 1);
+      }
+    }
+  }
+
+  // Figure out which ones to use as <text> attributes.
+  /** @type Object.<string,string> */
+  const textAttributes = {};
+  for (const [attName, values] of allAttributes) {
+    // Check all values. If there are fewer values than children, at least one child does not have the attribute;
+    // in this case leave attribute off of <text>. Otherwise, set text attribute to the most-used value.
+    let total = 0;
+    let maxCount = 0;
+    let textAttValue;
+    for (const [value, count] of values) {
+      total += count;
+      if (count > maxCount) {
+        maxCount = count;
+        textAttValue = value;
+      }
+    }
+    if (total === tspans.length && textAttValue) {
+      textAttributes[attName] = textAttValue;
+    }
+  }
+
+  return textAttributes;
+}
+
+/**
+ * @param {string} s
+ * @returns {boolean}
+ */
+function isWhiteSpace(s) {
+  return /^\s*$/.test(s);
+}
+
+/**
+ *
+ * @param {Map<number,TextData>} mergeableChildren
+ * @param {number} index
+ * @returns XastElement
+ */
+function mergeTextElements(mergeableChildren, index) {
+  /** @type {XastElement} */
+  const textElement = {
+    type: 'element',
+    name: 'text',
+    attributes: {},
+    children: [],
+  };
+
+  //   Find all child data.
+  const tspans = [];
+  for (; ; index++) {
+    const textData = mergeableChildren.get(index);
+    if (!textData) {
+      break;
+    }
+    tspans.push(...textData.children);
+  }
+
+  // Find the default attributes for the <text> element.
+  textElement.attributes = getTextAttributes(tspans);
+
+  // If there is only one <tspan>, merge content into <text>.
+  if (tspans.length === 1) {
+    const tspanData = tspans[0];
+    textElement.attributes.x = tspanData.x;
+    textElement.attributes.y = tspanData.y;
+    textElement.children = tspanData.children;
+    return textElement;
+  }
+
+  // Generate <tspan> elements.
+  const textChildren = [];
+  for (const tspanData of tspans) {
+    /** @type {XastElement} */
+    const tspanElement = {
+      type: 'element',
+      name: 'tspan',
+      attributes: { x: tspanData.x, y: tspanData.y },
+      children: tspanData.children,
+    };
+
+    // Add any attributes that are different from <text> attributes.
+    for (const [k, v] of tspanData.attributes) {
+      if (textElement.attributes[k] !== v) {
+        tspanElement.attributes[k] = v;
+      }
+    }
+
+    textChildren.push(tspanElement);
+  }
+
+  textElement.children = textChildren;
+  return textElement;
+}

--- a/plugins/plugins-types.d.ts
+++ b/plugins/plugins-types.d.ts
@@ -137,6 +137,7 @@ type DefaultPlugins = {
         };
   };
 
+  mergeText: void;
   moveElemsAttrsToGroup: void;
   moveGroupAttrsToElems: void;
   removeComments: {

--- a/test/plugins/mergeText.01.svg
+++ b/test/plugins/mergeText.01.svg
@@ -1,0 +1,18 @@
+Combine adjacent<text> elements.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <text xml:space="preserve" x="45.869" y="38.606" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <tspan x="45.869" y="38.606">Part one</tspan>
+    </text>
+    <text xml:space="preserve" x="87.151" y="89.826" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <tspan x="87.151" y="89.826">Part two</tspan>
+    </text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <text xml:space="preserve" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35"><tspan x="45.869" y="38.606">Part one</tspan><tspan x="87.151" y="89.826">Part two</tspan></text>
+</svg>

--- a/test/plugins/mergeText.02.svg
+++ b/test/plugins/mergeText.02.svg
@@ -1,0 +1,18 @@
+Combine adjacent<text> elements.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <text>
+        <tspan x="45.869" y="38.606" fill="red">Part one</tspan>
+    </text>
+    <text>
+        <tspan x="87.151" y="89.826" fill="green" stroke-width=".5">Part two</tspan>
+    </text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <text fill="red"><tspan x="45.869" y="38.606">Part one</tspan><tspan x="87.151" y="89.826" fill="green" stroke-width=".5">Part two</tspan></text>
+</svg>

--- a/test/plugins/mergeText.03.svg
+++ b/test/plugins/mergeText.03.svg
@@ -1,0 +1,21 @@
+Don't merge elements with text node children.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 120">
+    <text xml:space="preserve" x="45.869" y="38.606" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <tspan x="45.869" y="38.606">  Part one</tspan>
+    </text>
+    <text xml:space="preserve" x="87.151" y="89.826" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+    xxx<tspan x="87.151" y="89.826">Part two</tspan>ooo
+    </text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 120">
+    <text xml:space="preserve" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35" x="45.869" y="38.606">  Part one</text>
+    <text xml:space="preserve" x="87.151" y="89.826" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+    xxx<tspan x="87.151" y="89.826">Part two</tspan>ooo
+    </text>
+</svg>

--- a/test/plugins/mergeText.04.svg
+++ b/test/plugins/mergeText.04.svg
@@ -1,0 +1,14 @@
+Collapse single <tspan> child of <text>
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan x="64" y="64">this is a test</tspan></text>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve" x="64" y="64">this is a test</text>
+</svg>

--- a/test/plugins/mergeText.05.svg
+++ b/test/plugins/mergeText.05.svg
@@ -1,0 +1,13 @@
+Collapse single <tspan> child of <text>, where single <tspan> has multiple children.
+
+===
+
+<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+ <text x="56.571426" y="93.266411" fill="#0000ff" font-size="3.175px" stroke-width=".26458" xml:space="preserve"><tspan x="56.571426" y="93.266411" stroke-width=".26458">This is <tspan font-family="Arial" font-weight="bold">some</tspan> <tspan fill="#ff0000">text</tspan></tspan></text>
+</svg>
+
+@@@
+
+<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+    <text fill="#0000ff" font-size="3.175px" stroke-width=".26458" xml:space="preserve" x="56.571426" y="93.266411">This is <tspan font-family="Arial" font-weight="bold">some</tspan> <tspan fill="#ff0000">text</tspan></text>
+</svg>

--- a/test/plugins/mergeText.06.svg
+++ b/test/plugins/mergeText.06.svg
@@ -1,0 +1,18 @@
+Do not collapse if styles are present.
+
+===
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px"
+        stroke="#000000" xml:space="preserve"><tspan  x="64" y="64">this is a test</tspan></text>
+		<style>tspan { stroke:red;}</style>
+</svg>
+
+@@@
+
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <text x="64" y="64" fill="none" font-family="Arial" font-size="8px" letter-spacing=".5px" stroke="#000000" xml:space="preserve"><tspan x="64" y="64">this is a test</tspan></text>
+    <style>
+        tspan { stroke:red;}
+    </style>
+</svg>

--- a/test/plugins/mergeText.07.svg
+++ b/test/plugins/mergeText.07.svg
@@ -1,0 +1,20 @@
+Do not collapse if <textPath> present.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <path id="a" fill="none" stroke="#000" stroke-opacity="1" stroke-width=".265" d="M21.788 147.927s129.197-188.062 144.868-1.53"/>
+    <text xml:space="preserve" fill="none" stroke="#000" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <textPath xlink:href="#a"><tspan fill="#f40b0b" font-size="11.289" font-weight="400">this is a test</tspan></textPath>
+    </text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="210mm" height="297mm" viewBox="0 0 210 297">
+    <path id="a" fill="none" stroke="#000" stroke-opacity="1" stroke-width=".265" d="M21.788 147.927s129.197-188.062 144.868-1.53"/>
+    <text xml:space="preserve" fill="none" stroke="#000" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <textPath xlink:href="#a"><tspan fill="#f40b0b" font-size="11.289" font-weight="400">this is a test</tspan></textPath>
+    </text>
+</svg>

--- a/test/plugins/mergeText.08.svg
+++ b/test/plugins/mergeText.08.svg
@@ -1,0 +1,17 @@
+Don't merge elements with <title> children.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 120">
+    <text xml:space="preserve" x="45.869" y="38.606" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <tspan x="45.869" y="38.606"><title>xxx</title>Part one</tspan>
+    </text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 120">
+    <text xml:space="preserve" x="45.869" y="38.606" fill="red" stroke-width=".265" font-family="Sans" font-size="6.35">
+        <tspan x="45.869" y="38.606"><title>xxx</title>Part one</tspan>
+    </text>
+</svg>


### PR DESCRIPTION
Consolidate adjacent `<text>` elements and `<text>` elements with a single `<tspan>` child.

Resolves #964, resolves #1907