### PR TITLE
fix(convertTransform): fix scale and rotate on skew + refactors

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { removeLeadingZero } = require('./svgo/tools');
+const { removeLeadingZero, toFixed } = require('./svgo/tools');
 
 /**
  * @typedef {import('./types').PathDataItem} PathDataItem
@@ -250,8 +250,7 @@ exports.parsePathData = parsePathData;
  */
 const roundAndStringify = (number, precision) => {
   if (precision != null) {
-    const ratio = 10 ** precision;
-    number = Math.round(number * ratio) / ratio;
+    number = toFixed(number, precision);
   }
 
   return {

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -229,3 +229,17 @@ const findReferences = (attribute, value) => {
   return results.map((body) => decodeURI(body));
 };
 exports.findReferences = findReferences;
+
+/**
+ * Does the same as {@link Number.toFixed} but without casting
+ * the return value to a string.
+ *
+ * @param {number} num
+ * @param {number} precision
+ * @returns {number}
+ */
+const toFixed = (num, precision) => {
+  const pow = 10 ** precision;
+  return Math.round(num * pow) / pow;
+};
+exports.toFixed = toFixed;

--- a/plugins/_transforms.js
+++ b/plugins/_transforms.js
@@ -2,140 +2,8 @@
 
 const { toFixed } = require('../lib/svgo/tools');
 
-const regTransformTypes = /matrix|translate|scale|rotate|skewX|skewY/;
-const regTransformSplit =
-  /\s*(matrix|translate|scale|rotate|skewX|skewY)\s*\(\s*(.+?)\s*\)[\s,]*/;
-const regNumericValues = /[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g;
-
 /**
  * @typedef {{ name: string, data: number[] }} TransformItem
- */
-
-/**
- * Convert transform string to JS representation.
- *
- * @type {(transformString: string) => TransformItem[]}
- */
-exports.transform2js = (transformString) => {
-  // JS representation of the transform data
-  /**
-   * @type {TransformItem[]}
-   */
-  const transforms = [];
-  // current transform context
-  /**
-   * @type {?TransformItem}
-   */
-  let current = null;
-  // split value into ['', 'translate', '10 50', '', 'scale', '2', '', 'rotate', '-45', '']
-  for (const item of transformString.split(regTransformSplit)) {
-    var num;
-    if (item) {
-      // if item is a translate function
-      if (regTransformTypes.test(item)) {
-        // then collect it and change current context
-        current = { name: item, data: [] };
-        transforms.push(current);
-        // else if item is data
-      } else {
-        // then split it into [10, 50] and collect as context.data
-        while ((num = regNumericValues.exec(item))) {
-          num = Number(num);
-          if (current != null) {
-            current.data.push(num);
-          }
-        }
-      }
-    }
-  }
-  // return empty array if broken transform (no data)
-  return current == null || current.data.length == 0 ? [] : transforms;
-};
-
-/**
- * Multiply transforms into one.
- *
- * @type {(transforms: TransformItem[]) => TransformItem}
- */
-exports.transformsMultiply = (transforms) => {
-  // convert transforms objects to the matrices
-  const matrixData = transforms.map((transform) => {
-    if (transform.name === 'matrix') {
-      return transform.data;
-    }
-    return transformToMatrix(transform);
-  });
-  // multiply all matrices into one
-  const matrixTransform = {
-    name: 'matrix',
-    data:
-      matrixData.length > 0 ? matrixData.reduce(multiplyTransformMatrices) : [],
-  };
-  return matrixTransform;
-};
-
-/**
- * math utilities in radians.
- */
-const mth = {
-  /**
-   * @type {(deg: number) => number}
-   */
-  rad: (deg) => {
-    return (deg * Math.PI) / 180;
-  },
-
-  /**
-   * @type {(rad: number) => number}
-   */
-  deg: (rad) => {
-    return (rad * 180) / Math.PI;
-  },
-
-  /**
-   * @type {(deg: number) => number}
-   */
-  cos: (deg) => {
-    return Math.cos(mth.rad(deg));
-  },
-
-  /**
-   * @type {(val: number, floatPrecision: number) => number}
-   */
-  acos: (val, floatPrecision) => {
-    return Number(mth.deg(Math.acos(val)).toFixed(floatPrecision));
-  },
-
-  /**
-   * @type {(deg: number) => number}
-   */
-  sin: (deg) => {
-    return Math.sin(mth.rad(deg));
-  },
-
-  /**
-   * @type {(val: number, floatPrecision: number) => number}
-   */
-  asin: (val, floatPrecision) => {
-    return Number(mth.deg(Math.asin(val)).toFixed(floatPrecision));
-  },
-
-  /**
-   * @type {(deg: number) => number}
-   */
-  tan: (deg) => {
-    return Math.tan(mth.rad(deg));
-  },
-
-  /**
-   * @type {(val: number, floatPrecision: number) => number}
-   */
-  atan: (val, floatPrecision) => {
-    return Number(mth.deg(Math.atan(val)).toFixed(floatPrecision));
-  },
-};
-
-/**
  * @typedef {{
  *   convertToShorts: boolean,
  *   floatPrecision: number,
@@ -151,27 +19,164 @@ const mth = {
  * }} TransformParams
  */
 
+const transformTypes = new Set([
+  'matrix',
+  'rotate',
+  'scale',
+  'skewX',
+  'skewY',
+  'translate',
+]);
+
+const regTransformSplit =
+  /\s*(matrix|translate|scale|rotate|skewX|skewY)\s*\(\s*(.+?)\s*\)[\s,]*/;
+const regNumericValues = /[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g;
+
 /**
- * Decompose matrix into simple transforms. See
- * https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html
+ * Convert transform string to JS representation.
  *
- * @type {(transform: TransformItem, params: TransformParams) => TransformItem[]}
+ * @param {string} transformString
+ * @returns {TransformItem[]} Object representation of transform, or an empty array if it was malformed.
+ */
+exports.transform2js = (transformString) => {
+  /** @type {TransformItem[]} */
+  const transforms = [];
+  /** @type {?TransformItem} */
+  let currentTransform = null;
+
+  // split value into ['', 'translate', '10 50', '', 'scale', '2', '', 'rotate', '-45', '']
+  for (const item of transformString.split(regTransformSplit)) {
+    if (!item) {
+      continue;
+    }
+
+    if (transformTypes.has(item)) {
+      currentTransform = { name: item, data: [] };
+      transforms.push(currentTransform);
+    } else {
+      let num;
+      // then split it into [10, 50] and collect as context.data
+      while ((num = regNumericValues.exec(item))) {
+        num = Number(num);
+        if (currentTransform != null) {
+          currentTransform.data.push(num);
+        }
+      }
+    }
+  }
+
+  return currentTransform == null || currentTransform.data.length == 0
+    ? []
+    : transforms;
+};
+
+/**
+ * Multiply transforms into one.
+ *
+ * @param {TransformItem[]} transforms
+ * @returns {TransformItem}
+ */
+exports.transformsMultiply = (transforms) => {
+  const matrixData = transforms.map((transform) => {
+    if (transform.name === 'matrix') {
+      return transform.data;
+    }
+    return transformToMatrix(transform);
+  });
+
+  const matrixTransform = {
+    name: 'matrix',
+    data:
+      matrixData.length > 0 ? matrixData.reduce(multiplyTransformMatrices) : [],
+  };
+
+  return matrixTransform;
+};
+
+/**
+ * Math utilities in radians.
+ */
+const mth = {
+  /**
+   * @param {number} deg
+   * @returns {number}
+   */
+  rad: (deg) => {
+    return (deg * Math.PI) / 180;
+  },
+
+  /**
+   * @param {number} rad
+   * @returns {number}
+   */
+  deg: (rad) => {
+    return (rad * 180) / Math.PI;
+  },
+
+  /**
+   * @param {number} deg
+   * @returns {number}
+   */
+  cos: (deg) => {
+    return Math.cos(mth.rad(deg));
+  },
+
+  /**
+   * @param {number} val
+   * @param {number} floatPrecision
+   * @returns {number}
+   */
+  acos: (val, floatPrecision) => {
+    return toFixed(mth.deg(Math.acos(val)), floatPrecision);
+  },
+
+  /**
+   * @param {number} deg
+   * @returns {number}
+   */
+  sin: (deg) => {
+    return Math.sin(mth.rad(deg));
+  },
+
+  /**
+   * @param {number} val
+   * @param {number} floatPrecision
+   * @returns {number}
+   */
+  asin: (val, floatPrecision) => {
+    return toFixed(mth.deg(Math.asin(val)), floatPrecision);
+  },
+
+  /**
+   * @param {number} deg
+   * @returns {number}
+   */
+  tan: (deg) => {
+    return Math.tan(mth.rad(deg));
+  },
+
+  /**
+   * @param {number} val
+   * @param {number} floatPrecision
+   * @returns {number}
+   */
+  atan: (val, floatPrecision) => {
+    return toFixed(mth.deg(Math.atan(val)), floatPrecision);
+  },
+};
+
+/**
+ * Decompose matrix into simple transforms.
+ *
+ * @param {TransformItem} transform
+ * @param {TransformParams} params
+ * @returns {TransformItem[]}
+ * @see https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html
  */
 exports.matrixToTransform = (transform, params) => {
-  let floatPrecision = params.floatPrecision;
-  let data = transform.data;
-  let transforms = [];
-  let sx = Number(
-    Math.hypot(data[0], data[1]).toFixed(params.transformPrecision),
-  );
-  let sy = Number(
-    ((data[0] * data[3] - data[1] * data[2]) / sx).toFixed(
-      params.transformPrecision,
-    ),
-  );
-  let colsSum = data[0] * data[2] + data[1] * data[3];
-  let rowsSum = data[0] * data[1] + data[2] * data[3];
-  let scaleBefore = rowsSum != 0 || sx == sy;
+  const floatPrecision = params.floatPrecision;
+  const data = transform.data;
+  const transforms = [];
 
   // [..., ..., ..., ..., tx, ty] → translate(tx, ty)
   if (data[4] || data[5]) {
@@ -180,6 +185,15 @@ exports.matrixToTransform = (transform, params) => {
       data: data.slice(4, data[5] ? 6 : 5),
     });
   }
+
+  let sx = toFixed(Math.hypot(data[0], data[1]), params.transformPrecision);
+  let sy = toFixed(
+    (data[0] * data[3] - data[1] * data[2]) / sx,
+    params.transformPrecision,
+  );
+  const colsSum = data[0] * data[2] + data[1] * data[3];
+  const rowsSum = data[0] * data[1] + data[2] * data[3];
+  const scaleBefore = rowsSum !== 0 || sx === sy;
 
   // [sx, 0, tan(a)·sy, sy, 0, 0] → skewX(a)·scale(sx, sy)
   if (!data[1] && data[2]) {
@@ -199,7 +213,7 @@ exports.matrixToTransform = (transform, params) => {
 
     // [sx·cos(a), sx·sin(a), sy·-sin(a), sy·cos(a), x, y] → rotate(a[, cx, cy])·(scale or skewX) or
     // [sx·cos(a), sy·sin(a), sx·-sin(a), sy·cos(a), x, y] → scale(sx, sy)·rotate(a[, cx, cy]) (if !scaleBefore)
-  } else if (!colsSum || (sx == 1 && sy == 1) || !scaleBefore) {
+  } else if (!colsSum || (sx === 1 && sy === 1) || !scaleBefore) {
     if (!scaleBefore) {
       sx = Math.hypot(data[0], data[2]);
       sy = Math.hypot(data[1], data[3]);
@@ -215,16 +229,18 @@ exports.matrixToTransform = (transform, params) => {
       ) {
         sy = -sy;
       }
-      
+
       transforms.push({ name: 'scale', data: [sx, sy] });
     }
-    var angle = Math.min(Math.max(-1, data[0] / sx), 1),
-      rotate = [
-        mth.acos(angle, floatPrecision) *
-          ((scaleBefore ? 1 : sy) * data[1] < 0 ? -1 : 1),
-      ];
+    const angle = Math.min(Math.max(-1, data[0] / sx), 1);
+    const rotate = [
+      mth.acos(angle, floatPrecision) *
+        ((scaleBefore ? 1 : sy) * data[1] < 0 ? -1 : 1),
+    ];
 
-    if (rotate[0]) transforms.push({ name: 'rotate', data: rotate });
+    if (rotate[0]) {
+      transforms.push({ name: 'rotate', data: rotate });
+    }
 
     if (rowsSum && colsSum)
       transforms.push({
@@ -235,15 +251,15 @@ exports.matrixToTransform = (transform, params) => {
     // rotate(a, cx, cy) can consume translate() within optional arguments cx, cy (rotation point)
     if (rotate[0] && (data[4] || data[5])) {
       transforms.shift();
-      var cos = data[0] / sx,
-        sin = data[1] / (scaleBefore ? sx : sy),
-        x = data[4] * (scaleBefore ? 1 : sy),
-        y = data[5] * (scaleBefore ? 1 : sx),
-        denom =
-          (Math.pow(1 - cos, 2) + Math.pow(sin, 2)) *
-          (scaleBefore ? 1 : sx * sy);
-      rotate.push(((1 - cos) * x - sin * y) / denom);
-      rotate.push(((1 - cos) * y + sin * x) / denom);
+      const oneOverCos = 1 - data[0] / sx;
+      const sin = data[1] / (scaleBefore ? sx : sy);
+      const x = data[4] * (scaleBefore ? 1 : sy);
+      const y = data[5] * (scaleBefore ? 1 : sx);
+      const denom = (oneOverCos ** 2 + sin ** 2) * (scaleBefore ? 1 : sx * sy);
+      rotate.push(
+        (oneOverCos * x - sin * y) / denom,
+        (oneOverCos * y + sin * x) / denom,
+      );
     }
 
     // Too many transformations, return original matrix if it isn't just a scale/translate
@@ -251,11 +267,12 @@ exports.matrixToTransform = (transform, params) => {
     return [transform];
   }
 
-  if ((scaleBefore && (sx != 1 || sy != 1)) || !transforms.length)
+  if ((scaleBefore && (sx != 1 || sy != 1)) || !transforms.length) {
     transforms.push({
       name: 'scale',
       data: sx == sy ? [sx] : [sx, sy],
     });
+  }
 
   return transforms;
 };

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -9,7 +9,7 @@ const { visit } = require('../lib/xast.js');
 const { pathElems } = require('./_collections.js');
 const { path2js, js2path } = require('./_path.js');
 const { applyTransforms } = require('./applyTransforms.js');
-const { cleanupOutData } = require('../lib/svgo/tools');
+const { cleanupOutData, toFixed } = require('../lib/svgo/tools');
 
 exports.name = 'convertPathData';
 exports.description =
@@ -1002,16 +1002,6 @@ function getIntersection(coords) {
   ) {
     return cross;
   }
-}
-
-/**
- * Does the same as `Number.prototype.toFixed` but without casting
- * the return value to a string.
- * @type {(num: number, precision: number) => number}
- */
-function toFixed(num, precision) {
-  const pow = 10 ** precision;
-  return Math.round(num * pow) / pow;
 }
 
 /**

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -482,7 +482,7 @@ function filters(
         // check if next curves are fitting the arc
         for (
           var j = index;
-          (next = path[++j]) && 'cs'.includes(next.command);
+          (next = path[++j]) && (next.command === 'c' || next.command === 's');
 
         ) {
           var nextData = next.args;

--- a/test/plugins/_transforms.test.js
+++ b/test/plugins/_transforms.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { matrixToTransform } = require('../../plugins/_transforms');
+
+/**
+ * @typedef {import('../../plugins/_transforms').TransformParams} TransformParams
+ */
+
+/** @type {TransformParams} */
+const params = {
+  floatPrecision: 3,
+  transformPrecision: 5,
+  matrixToTransform: true,
+  shortTranslate: true,
+  shortScale: true,
+  shortRotate: true,
+  removeUseless: true,
+  collapseIntoOne: true,
+  leadingZero: true,
+  negativeExtraSpace: false,
+  convertToShorts: true,
+};
+
+/**
+ * Some tests live here instead of in test SVGs because the output
+ * is longer, so SVGO doesn't actually use it.
+ */
+describe('should correctly simplify transforms', () => {
+  it('matrix(0, -1, 99, 0, 0, 0)', () => {
+    const matrix = {
+      name: 'matrix',
+      data: [0, -1, 99, 0, 0, 0],
+    };
+
+    expect(matrixToTransform(matrix, params)).toStrictEqual([
+      {
+        name: 'scale',
+        data: [99, 1],
+      },
+      {
+        name: 'rotate',
+        data: [-90],
+      },
+    ]);
+  });
+
+  it('matrix(0, 1, 1, 0, 0, 0)', () => {
+    const matrix = {
+      name: 'matrix',
+      data: [0, 1, 1, 0, 0, 0],
+    };
+
+    expect(matrixToTransform(matrix, params)).toStrictEqual([
+      {
+        name: 'scale',
+        data: [1, -1],
+      },
+      {
+        name: 'rotate',
+        data: [-90],
+      },
+    ]);
+  });
+});

--- a/test/plugins/convertTransform.05.svg
+++ b/test/plugins/convertTransform.05.svg
@@ -1,4 +1,4 @@
-Correctly optimize transform scales negative sx and sy.
+Correctly optimize transform with same sign non-zero shears and.
 
 ===
 

--- a/test/plugins/convertTransform.05.svg
+++ b/test/plugins/convertTransform.05.svg
@@ -1,0 +1,13 @@
+Correctly optimize transform scales negative sx and sy.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="-45" y="-77" height="3" width="8" transform="matrix(0,-1,-1,0,0,0)" />
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+    <rect x="-45" y="-77" height="3" width="8" transform="scale(1 -1)rotate(90)"/>
+</svg>


### PR DESCRIPTION
I have divided this pull request into two commits, if you want to review it, please look at one commit at a time:

1. Functional changes relevant to the bug being fixed
2. Various refactors

When we encounter a transform matrix with both shears (`a B C d e f`) set or unset, we conditionally invert `sx` and `sy`. This is needed most of the time to preserve the original sign (`+/-`) of scales (`A b c D e f`) since this gets lost after squaring in `Math.hypot`.

The previous implementation lead us to make conversions like the following, which are both wrong:

| Matrix | Expected | Actual | Notes |
|---|---|---|---|
| `matrix(0 -1 -1 0 0 0)` | `scale(1 -1)rotate(90)` | `rotate(-90)`
| `matrix(0 1 1 0 0 0)` | `matrix(0 1 1 0 0 0)` | `rotate(90)` | The decomposed matrix is `scale(1 -1)rotate(-90)`, but that's long, so we scrap it. |

While looking into matrix decomposition, my understanding is that if `b` and `c` have the same sign (positive / negative), this effectively rotates and inverts `sy` (negative vertical scaling), even if `a` and `d` weren't explicitly set. We ignore positive `d` values because in this block, if `b` and `c` are non-zero and have the same sign, and `a` and `d` are non-zero, they should have opposite signs, so we can imply that we've already inverted `sx` and will update the rotation. That's done so we can define a shorter transform and keep rotations to 2 digits only.

i.e. `rotate(-135)scale(1.4 -1.4)` vs `scale(-1.4 1.4)rotate(-45)`

Anyone with more experience in math and applying or decomposing transformation matrices would be very welcome to chime in.

> … Frederic Wang's website puts the scale for `matrix(0 -1 -1 0 0 0)` inside/after, like `rotate(-90) scale(1,-1)`, but we set scaleBefore to false and put the scale outside/first.
> \* The fact that "before" is vague makes things more confusing. Is "before" defined as coming first in the string, or as applying first to the object as it's innermost?
>
> — https://github.com/svg/svgo/pull/1892#issuecomment-1867730588

Answering this here, as I now have more context. We do an optimization on top of the algorithm used on Frederic Wang's website to try to keep rotations to 2 digits. For example, where they would return `rotation(-135)scale(…)` we'll make it `scale(…)rotation(-45)` and invert the scales appropriately, which saves 1 byte. We just weren't doing the inversions correctly in some cases.

## Refactors

Use `toFixed` when comparing scales (`A b c D e f`). This makes the output more consistent. For example, all the following transforms should yield the same output, but if the calculated matrix has a value like `1e-6` then it failed to meet the condition before:

* `matrix(0, -1, -1, 0, 0, 0)`
* `scale(1 -1)rotate(90)`
* `scale(-1 1)rotate(-90)`

Since our stringless `toFixed` method has been migrated to a utility anyway, I've updated some instances of `Number(string.toFixed(num))` to use it to avoid all the casting.

Renames `significantDigits` to `numberOfDigits` because that's what it is, not that number of significant digits.

Uses a `Set` to match transformation names instead of a regular expression for performance.

---

This takes us down from 255 failing tests in the SVGO Test Suite (proposed regression tests) down to 172 and finishes in 19.3 minutes. I've also confirmed it only resolves tests and does not break others. 🎉

## Related

Discussed here:

* https://github.com/svg/svgo/pull/1892#issuecomment-1867490522

Background on sign issues in the past:

* https://github.com/svg/svgo/commit/9b848273826b99984e986d487953b3e5c70dceea
* https://github.com/svg/svgo/commit/eeeb67d5a8cc18168027064088312f25e8eac823
