### PR TITLE
test: expand and optimize regression testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
 name: CI
+
 env:
   FORCE_COLOR: 2
   NODE: 20
+
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -26,18 +25,6 @@ jobs:
       - run: yarn install
       - run: yarn lint
       - run: yarn typecheck
-  regression:
-    name: Test regressions
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE }}
-          cache: yarn
-      - run: yarn install
-      - run: yarn playwright install --with-deps chromium
-      - run: yarn test-regression
   test:
     name: ${{ matrix.os }} Node.js ${{ matrix.node-version }}
     strategy:
@@ -61,3 +48,21 @@ jobs:
       - run: yarn playwright install --with-deps chromium
       - run: yarn test
       - run: yarn test-bundles
+  regression:
+    name: Test regressions
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    needs:
+      - lint
+      - test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE }}
+          cache: yarn
+      - run: yarn install
+      - run: yarn playwright install --with-deps chromium
+      - run: yarn test-regression

--- a/test/regression-extract.js
+++ b/test/regression-extract.js
@@ -11,55 +11,169 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const pipeline = util.promisify(stream.pipeline);
 
+/** Files to skip regression testing for due to parsing issues. */
 const exclude = [
   // animated
-  'svg/filters-light-04-f.svg',
-  'svg/filters-composite-05-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-light-04-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-composite-05-f.svg',
   // messed gradients
-  'svg/pservers-grad-18-b.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/pservers-grad-18-b.svg',
   // removing wrapping <g> breaks :first-child pseudo-class
-  'svg/styling-pres-04-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-pres-04-f.svg',
   // rect is converted to path which matches wrong styles
-  'svg/styling-css-08-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-08-f.svg',
   // complex selectors are messed because of converting shapes to paths
-  'svg/struct-use-10-f.svg',
-  'svg/struct-use-11-f.svg',
-  'svg/styling-css-01-b.svg',
-  'svg/styling-css-04-f.svg',
-  // strange artifact breaks inconsistently  breaks regression tests
-  'svg/filters-conv-05-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/struct-use-10-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/struct-use-11-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-01-b.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-04-f.svg',
+  // strange artifact breaks inconsistently breaks regression tests
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-conv-05-f.svg',
+  // broken upon adding dataset and pending fix
+  'svgs/oxygen-icons-5.113.0/scalable/actions/document-print-preview.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/hidef/tools-rip-audio-cd.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/im-ban-kick-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/im-ban-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/irc-close-channel.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/irc-remove-operator.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/irc-unvoice.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/list-add.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/list-remove-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/list-remove.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/mail-send.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/player-volume.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/document-edit-decrypt.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/document-edit-encrypt.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/document-edit-sign.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/document-edit-verify.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/im-ban-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/im-yahoo.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/irc-close-channel.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/irc-remove-operator.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/irc-unvoice.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/list-add-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/16x16/tools-media-optical-burn-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/edit-select-none.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/im-google.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/irc-close-channel.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/list-add-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/mail-receive.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/mixer-cd.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/news-unsubscribe.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/tools-media-optical-burn-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/tools-media-optical-copy.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/22x22/view-time-schedule-baselined-remove.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/documentation.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/edit-table-delete-column.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/edit-table-delete-row.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/im-ban-kick-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/im-ban-user.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/im-google.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/mail-mark-junk.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/tools-media-optical-burn-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/tools-rip-video-dvd.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/view-calendar-birthday.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/view-calendar-holiday.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/view-calendar-special-occasion.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/32x32/view-calendar-wedding-anniversary.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/48x48/im-google.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/small/48x48/tools-media-optical-burn-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/tools-media-optical-burn-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/actions/tools-rip-audio-cd.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/applets/org.kde.plasma.clipboard.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/applets/org.kde.plasma.devicenotifier.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/applets/org.kde.plasma.icontasks.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/applets/org.kde.plasma.kickerdash.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/applets/org.kde.plasma.quicklaunch.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/basket.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/calligraauthor.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/hardware.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/hidef/kmail2.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/hidef/preferences-desktop-locale.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/hwinfo.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/kde-gtk-config.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/kjournal.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/kmail2.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/kmymoney.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/kplato.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/krfb.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/ksudoku.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/okteta.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/picmi.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/preferences-desktop-user-password.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/preferences-system-time.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/16x16/kchart.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/16x16/system-file-manager.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/22x22/basket.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/32x32/preferences-system-windows-move.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/32x32/system-file-manager.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/48x48/kig.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/small/64x64/kplato.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/strigi.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/apps/timevault.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/categories/applications-toys.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/categories/hidef/preferences-system.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/categories/preferences-system.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/audio-card.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/camera-web.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/cpu.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/hidef/input-keyboard.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/hidef/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/input-keyboard.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/scanner.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/16x16/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/16x16/media-optical-data.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/22x22/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/22x22/media-optical-data.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/32x32/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/devices/small/48x48/media-optical-audio.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/application-x-cd-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/application-x-cue.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/application-x-kvtml.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/hidef/application-rtf.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/hidef/application-sxw.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/application-javascript.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/application-pdf.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/application-x-javascript.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/application-x-srt.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/text-css.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/text-plain.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/text-x-changelog.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/22x22/text-x-csharp.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/48x48/application-x-cd-image.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/48x48/application-x-cda.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/48x48/application-x-cue.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/48x48/help.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/64x64/application-x-cue.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/places/small/64x64/folder-tar.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/places/small/64x64/network-server-database.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/places/small/64x64/server-database.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/status/small/22x22/weather-showers-day.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/status/small/32x32/weather-showers-day.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/status/user-busy.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/status/user-online.svg',
+  'svgs/oxygen-icons-5.113.0/scalable/text-formatting.svg',
 ];
 
 /**
  * @param {string} url
  * @param {string} baseDir
- * @param {RegExp} include
  */
-const extractTarGz = async (url, baseDir, include) => {
+const extractTarGz = async (url, baseDir) => {
   const extract = tarStream.extract();
   extract.on('entry', async (header, stream, next) => {
     const name = header.name;
 
     try {
-      if (include == null || include.test(name)) {
-        if (
-          name.endsWith('.svg') &&
-          !exclude.includes(name) &&
-          !name.startsWith('svg/animate-')
-        ) {
-          const file = path.join(baseDir, name);
-          await fs.promises.mkdir(path.dirname(file), { recursive: true });
-          await pipeline(stream, fs.createWriteStream(file));
-        } else if (name.endsWith('.svgz')) {
-          // .svgz -> .svg
-          const file = path.join(baseDir, name.slice(0, -1));
-          await fs.promises.mkdir(path.dirname(file), { recursive: true });
-          await pipeline(
-            stream,
-            zlib.createGunzip(),
-            fs.createWriteStream(file),
-          );
-        }
+      if (
+        name.endsWith('.svg') &&
+        !exclude.includes(name) &&
+        !name.startsWith('svgs/W3C_SVG_11_TestSuite/svg/animate-')
+      ) {
+        const file = path.join(baseDir, header.name);
+        await fs.promises.mkdir(path.dirname(file), { recursive: true });
+        await pipeline(stream, fs.createWriteStream(file));
       }
     } catch (error) {
       console.error(error);
@@ -74,11 +188,10 @@ const extractTarGz = async (url, baseDir, include) => {
 
 (async () => {
   try {
-    console.info('Downloading W3C SVG 1.1 Test Suite and extracting files');
+    console.info('Downloading SVGO Test Suite and extracting files');
     await extractTarGz(
-      'https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz',
-      path.join(__dirname, 'regression-fixtures', 'w3c-svg-11-test-suite'),
-      /^svg\//,
+      'https://svg.github.io/svgo-test-suite/svgo-test-suite.tar.gz',
+      path.join(__dirname, 'regression-fixtures'),
     );
   } catch (error) {
     console.error(error);

--- a/test/regression.js
+++ b/test/regression.js
@@ -56,7 +56,6 @@ const runTests = async (list) => {
     );
     // ignore small aliasing issues
     if (matched <= 4) {
-      console.info(`${name} is passed`);
       passed++;
     } else {
       mismatched++;


### PR DESCRIPTION
## SVGO Test Suite

Expands the regression test task to include KDE's Oxygen Icons.

SVGO is in dire need of better quality assurance, and Oxygen Icons is a good library to use as it has relatively complex SVGs compared to other icon libraries.

This PR is to track progress. We need to fix cases that are broken in Oxygen Icons, and optimize SVGO, tests, and the pipeline so that we can complete the regression tests quicker. Since we started planning this, we've already taken the time down from 23.4 minutes.

Any help to fix tests reported in this PR or improve performance would be very welcome. Performance is particularly valuable right now, as it makes iterating on fixes faster. (Success criteria for performance improvements is that the number of mismatches didn't increase.)

## Regression Action

This also updates the regression action to avoid running it when possible.

In the state it's in right now, it's 18 minutes per build. (Per PR at minimum, but most PRs usually pushed to multiple times, so are multiple builds.) It'd be a lot of wasted computation/energy to run it redundantly.

I've made the following changes:

* Disable concurrency explicitly, canceling previous jobs if a new one is started.
* Only run regression tests if linting and normal tests pass. While it's annoying to run regression tests 1-2 minutes late as a result, with how long the runs are, we don't want to waste resources if the `lint` or `test` job failed anyway.
* No longer runs the actions on `push` to `main`. We should no longer by pushing directly to `main`, so there's no need for this anymore. We only merge from pull requests.

## Broken Tests

See the GitLab repository for [Oxygen Icons](https://invent.kde.org/frameworks/oxygen-icons/-/tree/master/scalable?ref_type=heads) to download the files you're interested in fixing. Also note that files that are reported as broken could be caused by a browser bug or a quirk in our testing methodology.

<details>
<summary>List of files broken after optimization:</summary><br>

* scalable/actions/document-print-preview.svg
* scalable/actions/hidef/tools-rip-audio-cd.svg
* scalable/actions/im-ban-kick-user.svg
* scalable/actions/im-ban-user.svg
* scalable/actions/irc-close-channel.svg
* scalable/actions/irc-remove-operator.svg
* scalable/actions/irc-unvoice.svg
* scalable/actions/list-add.svg
* scalable/actions/list-remove-user.svg
* scalable/actions/list-remove.svg
* scalable/actions/mail-send.svg
* scalable/actions/player-volume.svg
* scalable/actions/small/16x16/document-edit-decrypt.svg
* scalable/actions/small/16x16/document-edit-encrypt.svg
* scalable/actions/small/16x16/document-edit-sign.svg
* scalable/actions/small/16x16/document-edit-verify.svg
* scalable/actions/small/16x16/im-ban-user.svg
* scalable/actions/small/16x16/im-yahoo.svg
* scalable/actions/small/16x16/irc-close-channel.svg
* scalable/actions/small/16x16/irc-remove-operator.svg
* scalable/actions/small/16x16/irc-unvoice.svg
* scalable/actions/small/16x16/list-add-user.svg
* scalable/actions/small/16x16/tools-media-optical-burn-image.svg
* scalable/actions/small/22x22/edit-select-none.svg
* scalable/actions/small/22x22/im-google.svg
* scalable/actions/small/22x22/irc-close-channel.svg
* scalable/actions/small/22x22/list-add-user.svg
* scalable/actions/small/22x22/mail-receive.svg
* scalable/actions/small/22x22/mixer-cd.svg
* scalable/actions/small/22x22/news-unsubscribe.svg
* scalable/actions/small/22x22/tools-media-optical-burn-image.svg
* scalable/actions/small/22x22/tools-media-optical-copy.svg
* scalable/actions/small/22x22/view-time-schedule-baselined-remove.svg
* scalable/actions/small/32x32/documentation.svg
* scalable/actions/small/32x32/edit-table-delete-column.svg
* scalable/actions/small/32x32/edit-table-delete-row.svg
* scalable/actions/small/32x32/im-ban-kick-user.svg
* scalable/actions/small/32x32/im-ban-user.svg
* scalable/actions/small/32x32/im-google.svg
* scalable/actions/small/32x32/mail-mark-junk.svg
* scalable/actions/small/32x32/tools-media-optical-burn-image.svg
* scalable/actions/small/32x32/tools-rip-video-dvd.svg
* scalable/actions/small/32x32/view-calendar-birthday.svg
* scalable/actions/small/32x32/view-calendar-holiday.svg
* scalable/actions/small/32x32/view-calendar-special-occasion.svg
* scalable/actions/small/32x32/view-calendar-wedding-anniversary.svg
* scalable/actions/small/48x48/im-google.svg
* scalable/actions/small/48x48/tools-media-optical-burn-image.svg
* scalable/actions/tools-media-optical-burn-image.svg
* scalable/actions/tools-rip-audio-cd.svg
* scalable/applets/org.kde.plasma.clipboard.svg
* scalable/applets/org.kde.plasma.devicenotifier.svg
* scalable/applets/org.kde.plasma.icontasks.svg
* scalable/applets/org.kde.plasma.kickerdash.svg
* scalable/applets/org.kde.plasma.quicklaunch.svg
* scalable/apps/basket.svg
* scalable/apps/calligraauthor.svg
* scalable/apps/hardware.svg
* scalable/apps/hidef/kmail2.svg
* scalable/apps/hidef/preferences-desktop-locale.svg
* scalable/apps/hwinfo.svg
* scalable/apps/kde-gtk-config.svg
* scalable/apps/kjournal.svg
* scalable/apps/kmail2.svg
* scalable/apps/kmymoney.svg
* scalable/apps/kplato.svg
* scalable/apps/krfb.svg
* scalable/apps/ksudoku.svg
* scalable/apps/okteta.svg
* scalable/apps/picmi.svg
* scalable/apps/preferences-desktop-user-password.svg
* scalable/apps/preferences-system-time.svg
* scalable/apps/small/16x16/kchart.svg
* scalable/apps/small/16x16/system-file-manager.svg
* scalable/apps/small/22x22/basket.svg
* scalable/apps/small/32x32/preferences-system-windows-move.svg
* scalable/apps/small/32x32/system-file-manager.svg
* scalable/apps/small/48x48/kig.svg
* scalable/apps/small/64x64/kplato.svg
* scalable/apps/strigi.svg
* scalable/apps/timevault.svg
* scalable/categories/applications-toys.svg
* scalable/categories/hidef/preferences-system.svg
* scalable/categories/preferences-system.svg
* scalable/devices/audio-card.svg
* scalable/devices/camera-web.svg
* scalable/devices/cpu.svg
* scalable/devices/hidef/input-keyboard.svg
* scalable/devices/hidef/media-optical-audio.svg
* scalable/devices/input-keyboard.svg
* scalable/devices/media-optical-audio.svg
* scalable/devices/scanner.svg
* scalable/devices/small/16x16/media-optical-audio.svg
* scalable/devices/small/16x16/media-optical-data.svg
* scalable/devices/small/22x22/media-optical-audio.svg
* scalable/devices/small/22x22/media-optical-data.svg
* scalable/devices/small/32x32/media-optical-audio.svg
* scalable/devices/small/48x48/media-optical-audio.svg
* scalable/mimetypes/application-x-cd-image.svg
* scalable/mimetypes/application-x-cue.svg
* scalable/mimetypes/application-x-kvtml.svg
* scalable/mimetypes/hidef/application-rtf.svg
* scalable/mimetypes/hidef/application-sxw.svg
* scalable/mimetypes/small/22x22/application-javascript.svg
* scalable/mimetypes/small/22x22/application-pdf.svg
* scalable/mimetypes/small/22x22/application-x-javascript.svg
* scalable/mimetypes/small/22x22/application-x-srt.svg
* scalable/mimetypes/small/22x22/text-css.svg
* scalable/mimetypes/small/22x22/text-plain.svg
* scalable/mimetypes/small/22x22/text-x-changelog.svg
* scalable/mimetypes/small/22x22/text-x-csharp.svg
* scalable/mimetypes/small/48x48/application-x-cd-image.svg
* scalable/mimetypes/small/48x48/application-x-cda.svg
* scalable/mimetypes/small/48x48/application-x-cue.svg
* scalable/mimetypes/small/48x48/help.svg
* scalable/mimetypes/small/64x64/application-x-cue.svg
* scalable/places/small/64x64/folder-tar.svg
* scalable/places/small/64x64/network-server-database.svg
* scalable/places/small/64x64/server-database.svg
* scalable/status/small/22x22/weather-showers-day.svg
* scalable/status/small/32x32/weather-showers-day.svg
* scalable/status/user-busy.svg
* scalable/status/user-online.svg
* scalable/text-formatting.svg

</details>

## Related

* Closes https://github.com/svg/svgo/issues/1363 which calls to expand our regression tests.
* Closes https://github.com/svg/svgo/pull/1414 as our regression test action has effectively a benchmark of its own. Checking the regression test time will now be part of reviewing patches.

## Future

It may be worth collecting more meaningful statistics from our regression tests, as proposed in [Add statistics to regression.js](https://github.com/svg/svgo/pull/1932).