### PR TITLE
Fixed bug in removeUselessDefs

### DIFF
--- a/plugins/removeUselessDefs.js
+++ b/plugins/removeUselessDefs.js
@@ -21,7 +21,11 @@ exports.fn = () => {
   return {
     element: {
       enter: (node, parentNode) => {
-        if (node.name === 'defs') {
+        if (
+          node.name === 'defs' ||
+          (elemsGroups.nonRendering.has(node.name) &&
+            node.attributes.id == null)
+        ) {
           /**
            * @type {XastElement[]}
            */
@@ -38,11 +42,6 @@ exports.fn = () => {
             });
           }
           node.children = usefulNodes;
-        } else if (
-          elemsGroups.nonRendering.has(node.name) &&
-          node.attributes.id == null
-        ) {
-          detachNodeFromParent(node, parentNode);
         }
       },
     },

--- a/test/plugins/removeUselessDefs.04.svg
+++ b/test/plugins/removeUselessDefs.04.svg
@@ -1,0 +1,23 @@
+Don't remove used symbols.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <symbol>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold" />
+        </linearGradient>
+    </symbol>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <symbol>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold"/>
+        </linearGradient>
+    </symbol>
+</svg>

--- a/test/plugins/removeUselessDefs.04.svg
+++ b/test/plugins/removeUselessDefs.04.svg
@@ -1,4 +1,4 @@
-Don't remove used symbols.
+Don't remove non-rendering elements if children have IDs.
 
 ===
 

--- a/test/plugins/removeUselessDefs.05.svg
+++ b/test/plugins/removeUselessDefs.05.svg
@@ -1,0 +1,23 @@
+Don't remove used symbols.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <g>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold" />
+        </linearGradient>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <g>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold"/>
+        </linearGradient>
+    </g>
+</svg>


### PR DESCRIPTION
This change applies the same logic used to process `<def>` elements to all non-rendering elements (i.e. preserve referenced children, and only delete the parent if no children remain).

This fix is part of the solution to removing the media-flash.svg mismatches in test-regression. This fix alone does not change the number of regression mismatches.

Closes #1922.