### PR TITLE
Fixed bug in removeHiddenElems

### DIFF
--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -131,7 +131,8 @@ exports.fn = (root, params) => {
     element: {
       enter: (node, parentNode) => {
         // transparent non-rendering elements still apply where referenced
-        if (nonRendering.has(node.name) || node.name === 'defs') {
+        if (nonRendering.has(node.name)) {
+          nonRenderedNodes.set(node, parentNode);
           return visitSkip;
         }
         const computedStyle = computeStyle(stylesheet, node);
@@ -439,7 +440,7 @@ exports.fn = (root, params) => {
         }
 
         for (const [node, parentNode] of allDefs.entries()) {
-          if (canRemoveNonRenderingNode(node)) {
+          if (node.children.length === 0) {
             detachNodeFromParent(node, parentNode);
           }
         }

--- a/test/plugins/removeHiddenElems.16.svg
+++ b/test/plugins/removeHiddenElems.16.svg
@@ -1,0 +1,23 @@
+Don't remove used symbols.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <symbol>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold" />
+        </linearGradient>
+    </symbol>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <symbol>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold"/>
+        </linearGradient>
+    </symbol>
+</svg>

--- a/test/plugins/removeHiddenElems.16.svg
+++ b/test/plugins/removeHiddenElems.16.svg
@@ -1,4 +1,4 @@
-Don't remove used symbols.
+Don't remove non-rendering elements if children have IDs. 
 
 ===
 

--- a/test/plugins/removeHiddenElems.17.svg
+++ b/test/plugins/removeHiddenElems.17.svg
@@ -1,0 +1,23 @@
+Don't remove used symbols.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <g>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold" />
+        </linearGradient>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="url(#a)" width="64" height="64"/>
+    <g>
+        <linearGradient id="a">
+            <stop offset="5%" stop-color="gold"/>
+        </linearGradient>
+    </g>
+</svg>

--- a/test/plugins/removeHiddenElems.18.svg
+++ b/test/plugins/removeHiddenElems.18.svg
@@ -1,4 +1,4 @@
-XXXXXXXXX
+Preserve <defs> with referenced path.
 
 ===
 

--- a/test/plugins/removeHiddenElems.18.svg
+++ b/test/plugins/removeHiddenElems.18.svg
@@ -1,0 +1,23 @@
+XXXXXXXXX
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="test-body-content">
+        <defs>
+            <path id="reference" d="M240 1h239v358H240z"/>
+        </defs>
+        <use xlink:href="#reference" id="use" fill="gray" onclick="test(evt)"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="test-body-content">
+        <defs>
+            <path id="reference" d="M240 1h239v358H240z"/>
+        </defs>
+        <use xlink:href="#reference" id="use" fill="gray" onclick="test(evt)"/>
+    </g>
+</svg>


### PR DESCRIPTION
This change removes non-rendering nodes only if they have no referenced children.

This fix is part of the solution to removing the media-flash.svg mismatches in test-regression. On its own, this fix resolves 8 mismatches in test-regression. In conjunction with PR #1923 this fix resolves 14 mismatches in test-regression.

**Further Discussion**
This plugin has some code that seems like it needs to be removed, but maybe I'm missing something. In addition to the usual return of the visitor functions, this plugin has an explicit call to visit(), with different code than what is in the return value. That causes the tree to be traversed twice, and the `<symbol>` element was being removed in both sets of code. I removed the code in the explicit call to visit(), but there is still code in the visit() call that removes elements with opacity=0. This seems weird because:
- traversing the tree twice seems inefficient
- removing the elements based on what is in a `<style>` element seems contradictory to what happens in the visitor function that is returned by the plugin (where optimization is disabled in the presence of a `<style>` element)

So the code I submitted fixes the referenced issue, but it seems like this plugin should also be changed by:
- removing the explicit call to visit()
- changing the expected behavior of removeHiddenElems.02.svg so that the source file is not changed

Is there a good reason for the code to have the explicit call to visit()?

Closes #1924 