### PR TITLE
fix(convertPathData): fix q control point behavior when item is removed

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -394,7 +394,6 @@ function filters(
 
   path = path.filter(function (item, index, path) {
     const qControlPoint = prevQControlPoint;
-    prevQControlPoint = undefined;
 
     let command = item.command;
     let data = item.args;
@@ -895,6 +894,8 @@ function filters(
         // @ts-ignore
         prevQControlPoint = item.coords;
       }
+    } else {
+      prevQControlPoint = undefined;
     }
     prev = item;
     return true;

--- a/test/plugins/convertPathData.36.svg.txt
+++ b/test/plugins/convertPathData.36.svg.txt
@@ -1,0 +1,15 @@
+Should process/optimize q correctly even if useless commands in between.
+
+See: https://github.com/svg/svgo/issues/1926
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 20">
+  <path d="M-6.3 9.9q.7-4.5.2-5-.5-.5-1.5-.5l0 0q-.4 0-2 .3"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 20">
+    <path d="M-6.3 9.9q.7-4.5.2-5t-1.5-.5q-.4 0-2 .3"/>
+</svg>


### PR DESCRIPTION
fix #1926 by only resetting the control point if an item is included
realistically this should be fine as it'll still get reset on move commands, and likely if a command is dropped the control point stayed the same

there's another issue with how in the case `M0 0Q10 0 10 10Q10 10 10 10T20 20`, convertPathData should convert `T` to longhand and update the control point before dropping the useless command (changing the control point), but that's out of scope for this PR. (if my thinking is correct, i can't think of any cases where converting from q to t is affected by this behavior)