### PR TITLE
fix: collapseGroups does not move attributes atomically

### DIFF
--- a/test/plugins/collapseGroups.17.svg.txt
+++ b/test/plugins/collapseGroups.17.svg.txt
@@ -3,16 +3,22 @@ See issue #1928 for context.
 
 ===
 
-<svg xmlns="http://www.w3.org/2000/svg">
-    <g transform="translate(20,30)" style="fill: red">
-        <rect width="20" height="20" style="fill: blue"/>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88">
+  <filter id="a">
+    <feGaussianBlur stdDeviation="1"/>
+  </filter>
+  <g transform="matrix(0.6875,0,0,0.6875,20.34375,66.34375)" style="filter:url(#a)">
+    <path d="M 33.346591,-83.471591 L -10.744318,-36.471591 L -10.49989,-32.5" style="fill-opacity:1"/>
+  </g>
 </svg>
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg">
-    <g transform="translate(20,30)" style="fill: red">
-        <rect width="20" height="20" style="fill: blue"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88">
+    <filter id="a">
+        <feGaussianBlur stdDeviation="1"/>
+    </filter>
+    <g transform="matrix(0.6875,0,0,0.6875,20.34375,66.34375)" style="filter:url(#a)">
+        <path d="M 33.346591,-83.471591 L -10.744318,-36.471591 L -10.49989,-32.5" style="fill-opacity:1"/>
     </g>
 </svg>

--- a/test/plugins/collapseGroups.17.svg.txt
+++ b/test/plugins/collapseGroups.17.svg.txt
@@ -1,43 +1,18 @@
 Don't collapse group with a single child unless all attributes can be moved to the child.
+See issue #1928 for context.
 
 ===
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <defs>
-        <linearGradient xlink:href="#a" id="c" x1="3.97" x2="3.97" y1=".348" y2="4.34" gradientUnits="userSpaceOnUse"/>
-    </defs>
-    <filter id="b">
-        <feGaussianBlur stdDeviation="1"/>
-    </filter>
-    <symbol viewBox="-9.5 -7 19 14">
-        <g style="filter:url(#b)">
-            <linearGradient id="a" x1="3.97" x2="3.97" y1="2.425" y2="7.55" gradientUnits="userSpaceOnUse">
-                <stop offset="1" style="stop-color:#fff"/>
-            </linearGradient>
-        </g>
-    </symbol>
-    <g transform="matrix(0 -1.2285 -1.2285 0 112.337 268.327)" style="filter:url(#b)">
-        <path d="M.84.348H7.1V5.8H3.344z" style="fill:url(#c)"/>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(20,30)" style="fill: red">
+        <rect width="20" height="20" style="fill: blue"/>
     </g>
 </svg>
 
 @@@
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <defs>
-        <linearGradient xlink:href="#a" id="c" x1="3.97" x2="3.97" y1=".348" y2="4.34" gradientUnits="userSpaceOnUse"/>
-    </defs>
-    <filter id="b">
-        <feGaussianBlur stdDeviation="1"/>
-    </filter>
-    <symbol viewBox="-9.5 -7 19 14">
-        <g style="filter:url(#b)">
-            <linearGradient id="a" x1="3.97" x2="3.97" y1="2.425" y2="7.55" gradientUnits="userSpaceOnUse">
-                <stop offset="1" style="stop-color:#fff"/>
-            </linearGradient>
-        </g>
-    </symbol>
-    <g transform="matrix(0 -1.2285 -1.2285 0 112.337 268.327)" style="filter:url(#b)">
-        <path d="M.84.348H7.1V5.8H3.344z" style="fill:url(#c)"/>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(20,30)" style="fill: red">
+        <rect width="20" height="20" style="fill: blue"/>
     </g>
 </svg>

--- a/test/plugins/collapseGroups.17.svg.txt
+++ b/test/plugins/collapseGroups.17.svg.txt
@@ -1,0 +1,43 @@
+Don't collapse group with a single child unless all attributes can be moved to the child.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <linearGradient xlink:href="#a" id="c" x1="3.97" x2="3.97" y1=".348" y2="4.34" gradientUnits="userSpaceOnUse"/>
+    </defs>
+    <filter id="b">
+        <feGaussianBlur stdDeviation="1"/>
+    </filter>
+    <symbol viewBox="-9.5 -7 19 14">
+        <g style="filter:url(#b)">
+            <linearGradient id="a" x1="3.97" x2="3.97" y1="2.425" y2="7.55" gradientUnits="userSpaceOnUse">
+                <stop offset="1" style="stop-color:#fff"/>
+            </linearGradient>
+        </g>
+    </symbol>
+    <g transform="matrix(0 -1.2285 -1.2285 0 112.337 268.327)" style="filter:url(#b)">
+        <path d="M.84.348H7.1V5.8H3.344z" style="fill:url(#c)"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <linearGradient xlink:href="#a" id="c" x1="3.97" x2="3.97" y1=".348" y2="4.34" gradientUnits="userSpaceOnUse"/>
+    </defs>
+    <filter id="b">
+        <feGaussianBlur stdDeviation="1"/>
+    </filter>
+    <symbol viewBox="-9.5 -7 19 14">
+        <g style="filter:url(#b)">
+            <linearGradient id="a" x1="3.97" x2="3.97" y1="2.425" y2="7.55" gradientUnits="userSpaceOnUse">
+                <stop offset="1" style="stop-color:#fff"/>
+            </linearGradient>
+        </g>
+    </symbol>
+    <g transform="matrix(0 -1.2285 -1.2285 0 112.337 268.327)" style="filter:url(#b)">
+        <path d="M.84.348H7.1V5.8H3.344z" style="fill:url(#c)"/>
+    </g>
+</svg>


### PR DESCRIPTION
In the test case file, before this change, the transform attribute on the group was moved to the child, but the style containing the filter was not moved. This was changing the rendering.

regression.js before fix:

- Mismatched: 214
- Passed: 5308
- Total reduction 764239791 bytes

After fix:

- Mismatched: 201
- Passed: 5321
- Total reduction 764238752 bytes

This removes 13 regression mismatches. Compression of regression files is reduced by 1039 bytes.

Closes #1928