### PR TITLE
Add statistics to regression.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 test/regression-fixtures
 test/regression-diffs
 test/cli/output
+tmp
 coverage
 .DS_Store
 .vscode

--- a/test/regression.js
+++ b/test/regression.js
@@ -19,8 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const width = 960;
 const height = 720;
 
-const FILE_PATTERN = new RegExp('media-flash');
-// const FILE_PATTERN = new RegExp('.*');
+const FILE_PATTERN = new RegExp('.*');
 let configFileName;
 const DEFAULT_CONFIG = {
   floatPrecision: 4,


### PR DESCRIPTION
I've been using regression.js a lot locally to test the Oxygen icons and W3C files, both to isolate problems and to verify that my changes aren't having any unintended side effects.

These changes should have no impact on the regressions being run as part of CI.

Changes to regression.js:

- Record statistics during test run (input file length, optimized file length).
- Write a timestamped .tsv file to tmp directory at end of run (for each file, show pass/fail, orig length, optimized length, reduction in size).
- Show total reduction in file size on console at end of tests.
- Added some configuration constants. Eventually I would like to make these command line options. I've been using this file to track down the regression errors with the Oxygen icons and it's very helpful to be able to run the regressions on a subset of files and/or with alternate configurations.

Added tmp to .gitignore
