### PR TITLE
chore: use math.hypot

### DIFF
--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -93,9 +93,9 @@ export const applyTransforms = (root, params) => {
         }
 
         const scale = Number(
-          Math.sqrt(
-            matrix.data[0] * matrix.data[0] + matrix.data[1] * matrix.data[1],
-          ).toFixed(transformPrecision),
+          Math.hypot(matrix.data[0], matrix.data[1]).toFixed(
+            transformPrecision,
+          ),
         );
 
         if (stroke && stroke != 'none') {

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -1113,7 +1113,7 @@ function calculateSagitta(data) {
   if (data[3] === 1) return undefined;
   const [rx, ry] = data;
   if (Math.abs(rx - ry) > error) return undefined;
-  const chord = Math.sqrt(data[5] ** 2 + data[6] ** 2);
+  const chord = Math.hypot(data[5], data[6]);
   if (chord > rx * 2) return undefined;
   return rx - Math.sqrt(rx ** 2 - 0.25 * chord ** 2);
 }
@@ -1145,7 +1145,7 @@ function makeLonghand(item, data) {
  * @type {(point1: Point, point2: Point) => number}
  */
 function getDistance(point1, point2) {
-  return Math.sqrt((point1[0] - point2[0]) ** 2 + (point1[1] - point2[1]) ** 2);
+  return Math.hypot(point1[0] - point2[0], point1[1] - point2[1]);
 }
 
 /**


### PR DESCRIPTION
We have some instances where we calculate the hypotenuse from two lengths. After I replaced one of them with `Math.sqrt(Math.pow, Math.pow)` there was discussion that this should be changed back.

I changed back the instance I modified, and changed other instances to also use `Math.hypot` instead.

This should be almost the same thing, except it will now support absurdly large numbers like `1e300` better with negligible cost in performance.

## Related

* https://github.com/svg/svgo/pull/1873#discussion_r1445534565
* https://github.com/svg/svgo/pull/1913#issuecomment-1871354356