### PR TITLE
chore: improve types for custom plugin

### DIFF
--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -4,9 +4,10 @@ import type {
   BuiltinsWithRequiredParams,
 } from '../plugins/plugins-types.js';
 
-type CustomPlugin = {
+type CustomPlugin<T = any> = {
   name: string;
-  fn: Plugin<void>;
+  fn: Plugin<T>;
+  params?: T;
 };
 
 type PluginConfig =

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -109,7 +109,7 @@ export type Plugin<Params> = (
   root: XastRoot,
   params: Params,
   info: PluginInfo,
-) => null | Visitor;
+) => Visitor | null | void;
 
 export type Specificity = [number, number, number];
 


### PR DESCRIPTION
Follow up to another PR where the contributor is no longer responsive, but suggestions were made.

This improves the types for custom plugins to better suit the actual structures in SVGO.

## Related

* Closes https://github.com/svg/svgo/pull/1738 (supersedes)