### PR TITLE
Fix/prefix ids sameline comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 .DS_Store
 .vscode
 *.log
+.*.sw?

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,11 @@ coverage
 .DS_Store
 .vscode
 *.log
-.*.sw?
+
+# https://github.com/github/gitignore/blob/main/Global/Vim.gitignore
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -183,7 +183,6 @@ export const fn = (_root, params, info) => {
             });
 
             child.value = csstree.generate(cssAst);
-            return;
           }
         }
 

--- a/test/plugins/prefixIds.13.svg.txt
+++ b/test/plugins/prefixIds.13.svg.txt
@@ -1,0 +1,23 @@
+Prefix IDs should apply to all nodes in styles, namely when styles are split
+into multiple nodes due to XML comments.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <style>
+    <!-- uwu -->
+    #a13 {} <!-- xyz -->
+    #b13 {}
+  </style>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+    <style>
+<!--uwu-->
+        #prefixIds_13_svg_txt__a13{}
+<!--xyz-->
+        #prefixIds_13_svg_txt__b13{}
+    </style>
+</svg>


### PR DESCRIPTION
https://github.com/svg/svgo/issues/1941

Fix prefixing classes on same line as a comment

Before, this worked:
```
<style>
.cls-1 {}
<!-- foo -->
.cls-2 {}
</style>
```

but this failed:
```
<style>
.cls-1 {} <!-- foo -->
.cls-2 {}
</style>
```

.cls-1 would be prefixed, but .cls-2 and subsquent classes would not.

The root cause is an empty return that was missed during a refactor to
switch from forEach() with a lambda to a for () loop.

Add a new test to cover this case.