### PR TITLE
fix(mergePaths): use a default floatPrecision

### DIFF
--- a/docs/03-plugins/merge-paths.mdx
+++ b/docs/03-plugins/merge-paths.mdx
@@ -8,7 +8,7 @@ svgo:
       default: false
     floatPrecision:
       description: Number of decimal places to round to, using conventional rounding rules.
-      default: null
+      default: 3
     noSpaceAfterFlags:
       description: If to omit spaces after flags. Flags are values that can only be <code>0</code> or <code>1</code> and are used by some path commands, namely <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/d#elliptical_arc_curve" target="_blank"><code>A</code> and <code>a</code></a>.
       default: false

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -20,7 +20,7 @@ export const description = 'merges multiple paths in one if possible';
 export const fn = (root, params) => {
   const {
     force = false,
-    floatPrecision,
+    floatPrecision = 3,
     noSpaceAfterFlags = false, // a20 60 45 0 1 30 20 → a20 60 45 0130 20
   } = params;
   const stylesheet = collectStylesheet(root);


### PR DESCRIPTION
Right now all plugins use a default floatPrecision except for mergePaths. This means that if another plugin doesn't round the paths internally, the whole precision leaks out.

We fix this by setting it to 3 by default. This closes #1944, and also probably helps with size reduction.

TODO: figure out a test case (feel free to suggest one)