### PR TITLE
fix: removeHiddenElems - treat <path> with opacity:0 as non-rendering node.

### DIFF
--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -143,6 +143,10 @@ export const fn = (root, params) => {
           computedStyle.opacity.type === 'static' &&
           computedStyle.opacity.value === '0'
         ) {
+          if (node.name === 'path') {
+            nonRenderedNodes.set(node, parentNode);
+            return visitSkip;
+          }
           removeElement(node, parentNode);
         }
       },

--- a/test/plugins/removeHiddenElems.19.svg.txt
+++ b/test/plugins/removeHiddenElems.19.svg.txt
@@ -1,0 +1,28 @@
+Preserve referenced path, even when path has opacity=0.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <path id="path2" d="M200 200 l50 -300" style="opacity:0"/>
+    </defs>
+    <text style="font-size:24px;">
+        <textPath xlink:href="#path2">
+        this is path 2
+        </textPath>
+    </text>
+    <path id="path1" d="M200 200 l50 -300" style="opacity:0"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <path id="path2" d="M200 200 l50 -300" style="opacity:0"/>
+    </defs>
+    <text style="font-size:24px;">
+        <textPath xlink:href="#path2">
+        this is path 2
+        </textPath>
+    </text>
+</svg>


### PR DESCRIPTION
removeHiddenElems was removing all `<path>` elements with opacity:0. If the path was referenced by a `<textPath>`, this caused the text to disappear.

This resolves 10 regression errors:

```
svgs/oxygen-icons-5.113.0/scalable/apps/digikam.svg     pass
svgs/oxygen-icons-5.113.0/scalable/apps/showfoto.svg    pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/16x16/digikam.svg pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/16x16/showfoto.svg        pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/22x22/digikam.svg pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/22x22/showfoto.svg        pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/32x32/digikam.svg pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/32x32/showfoto.svg        pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/48x48/digikam.svg pass
svgs/oxygen-icons-5.113.0/scalable/apps/small/48x48/showfoto.svg        pass
``` 