### PR TITLE
Fix/to fixed precision

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -225,14 +225,34 @@ export const findReferences = (attribute, value) => {
 };
 
 /**
+ * @param {number} num
+ * @returns {number}
+ */
+const getDecimalCount = (num) => {
+  const string = num.toString();
+  const [coefficient, exponent] = string.split('e-');
+  const exponentDecimals = exponent | 0;
+  if (!coefficient.includes('.')) return exponentDecimals;
+  const coefficientDecimals = coefficient.split('.')[1].length;
+  return coefficientDecimals + exponentDecimals;
+};
+
+/**
  * Does the same as {@link Number.toFixed} but without casting
- * the return value to a string.
+ * the return value to a string and correctly fix numbers
+ * like 21.0565 to 21.057 when precision is 3.
  *
  * @param {number} num
  * @param {number} precision
  * @returns {number}
  */
 export const toFixed = (num, precision) => {
+  if (Number.isInteger(num)) return num;
+
+  // prevent returning more digits than originally given
+  const decimalCount = getDecimalCount(num);
+  if (decimalCount <= precision) return num;
+
   const pow = 10 ** precision;
   return Math.round(num * pow) / pow;
 };

--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -12,7 +12,7 @@ import {
 import { referencesProps, attrsGroupsDefaults } from './_collections.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 
-import { removeLeadingZero, includesUrlReference } from '../lib/svgo/tools.js';
+import { removeLeadingZero, includesUrlReference, toFixed } from '../lib/svgo/tools.js';
 
 /**
  * @typedef {PathDataItem[]} PathData
@@ -92,11 +92,8 @@ export const applyTransforms = (root, params) => {
           return;
         }
 
-        const scale = Number(
-          Math.hypot(matrix.data[0], matrix.data[1]).toFixed(
-            transformPrecision,
-          ),
-        );
+        const scale = toFixed(Math.hypot(matrix.data[0], matrix.data[1]),
+          transformPrecision);
 
         if (stroke && stroke != 'none') {
           if (!params.applyTransformsStroked) {

--- a/plugins/cleanupListOfValues.js
+++ b/plugins/cleanupListOfValues.js
@@ -1,4 +1,4 @@
-import { removeLeadingZero } from '../lib/svgo/tools.js';
+import { removeLeadingZero, toFixed } from '../lib/svgo/tools.js';
 
 export const name = 'cleanupListOfValues';
 export const description = 'rounds list of values to the fixed precision';
@@ -53,7 +53,7 @@ export const fn = (_root, params) => {
       // if attribute value matches regNumericValues
       if (match) {
         // round it to the fixed precision
-        let num = Number(Number(match[1]).toFixed(floatPrecision));
+        let num = toFixed(Number(match[1]), floatPrecision);
         /**
          * @type {any}
          */
@@ -65,9 +65,8 @@ export const fn = (_root, params) => {
 
         // convert absolute values to pixels
         if (convertToPx && units && units in absoluteLengths) {
-          const pxNum = Number(
-            (absoluteLengths[units] * Number(match[1])).toFixed(floatPrecision),
-          );
+          const pxNum = toFixed(absoluteLengths[units] * Number(match[1]),
+            floatPrecision);
 
           if (pxNum.toString().length < match[0].length) {
             num = pxNum;

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -1,4 +1,4 @@
-import { removeLeadingZero } from '../lib/svgo/tools.js';
+import { removeLeadingZero, toFixed } from '../lib/svgo/tools.js';
 
 export const name = 'cleanupNumericValues';
 export const description =
@@ -43,7 +43,7 @@ export const fn = (_root, params) => {
               const num = Number(value);
               return Number.isNaN(num)
                 ? value
-                : Number(num.toFixed(floatPrecision));
+                : toFixed(num, floatPrecision);
             })
             .join(' ');
         }
@@ -59,7 +59,7 @@ export const fn = (_root, params) => {
           // if attribute value matches regNumericValues
           if (match) {
             // round it to the fixed precision
-            let num = Number(Number(match[1]).toFixed(floatPrecision));
+            let num = toFixed(Number(match[1]), floatPrecision);
             /**
              * @type {any}
              */
@@ -71,11 +71,8 @@ export const fn = (_root, params) => {
 
             // convert absolute values to pixels
             if (convertToPx && units !== '' && units in absoluteLengths) {
-              const pxNum = Number(
-                (absoluteLengths[units] * Number(match[1])).toFixed(
-                  floatPrecision,
-                ),
-              );
+              const pxNum = toFixed(absoluteLengths[units] * Number(match[1]),
+                floatPrecision);
               if (pxNum.toString().length < match[0].length) {
                 num = pxNum;
                 units = 'px';


### PR DESCRIPTION
This PR resolves https://github.com/svg/svgo/issues/1944

Currently the method meant to reduce the amount of decimals (lib/tools/toFixed) sometimes increases the amount of decimals due to float handling in JavaScript. This PR addresses this by checking the original amount of decimals and comparing it to the requested precision. If it already meets the precision requested, it will simply return the original number.