### PR TITLE
Check for filter in style as well as attribute.

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -104,7 +104,7 @@ const parseStylesheet = (css, dynamic) => {
 /**
  * @type {(css: string) => StylesheetDeclaration[]}
  */
-const parseStyleDeclarations = (css) => {
+export const parseStyleDeclarations = (css) => {
   /** @type {StylesheetDeclaration[]} */
   const declarations = [];
   const ast = csstree.parse(css, {

--- a/lib/style.js
+++ b/lib/style.js
@@ -104,7 +104,7 @@ const parseStylesheet = (css, dynamic) => {
 /**
  * @type {(css: string) => StylesheetDeclaration[]}
  */
-export const parseStyleDeclarations = (css) => {
+const parseStyleDeclarations = (css) => {
   /** @type {StylesheetDeclaration[]} */
   const declarations = [];
   const ast = csstree.parse(css, {

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -71,7 +71,7 @@ export const fn = (root) => {
           node.children.length === 1
         ) {
           const firstChild = node.children[0];
-          let nodeHasFilter = node.attributes.filter ? true : false;
+          let nodeHasFilter = !!node.attributes.filter;
           if (!nodeHasFilter && node.attributes.style) {
             if (computeStyle(stylesheet, node)['filter']) {
               nodeHasFilter = true;

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -1,3 +1,4 @@
+import { parseStyleDeclarations } from '../lib/style.js';
 import { inheritableAttrs, elemsGroups } from './_collections.js';
 
 /**
@@ -68,11 +69,16 @@ export const fn = () => {
           node.children.length === 1
         ) {
           const firstChild = node.children[0];
+          let nodeHasFilter = node.attributes.filter ? true : false;
+          if (!nodeHasFilter && node.attributes.style) {
+            const styles = parseStyleDeclarations(node.attributes.style);
+            nodeHasFilter = styles.some((e) => e.name === 'filter');
+          }
           // TODO untangle this mess
           if (
             firstChild.type === 'element' &&
             firstChild.attributes.id == null &&
-            node.attributes.filter == null &&
+            !nodeHasFilter &&
             (node.attributes.class == null ||
               firstChild.attributes.class == null) &&
             ((node.attributes['clip-path'] == null &&

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -1,4 +1,4 @@
-import { parseStyleDeclarations } from '../lib/style.js';
+import { computeStyle, collectStylesheet } from '../lib/style.js';
 import { inheritableAttrs, elemsGroups } from './_collections.js';
 
 /**
@@ -51,7 +51,9 @@ const hasAnimatedAttr = (node, name) => {
  *
  * @type {import('./plugins-types.js').Plugin<'collapseGroups'>}
  */
-export const fn = () => {
+export const fn = (root) => {
+  const stylesheet = collectStylesheet(root);
+
   return {
     element: {
       exit: (node, parentNode) => {
@@ -71,8 +73,9 @@ export const fn = () => {
           const firstChild = node.children[0];
           let nodeHasFilter = node.attributes.filter ? true : false;
           if (!nodeHasFilter && node.attributes.style) {
-            const styles = parseStyleDeclarations(node.attributes.style);
-            nodeHasFilter = styles.some((e) => e.name === 'filter');
+            if (computeStyle(stylesheet, node)['filter']) {
+              nodeHasFilter = true;
+            }
           }
           // TODO untangle this mess
           if (

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -71,12 +71,9 @@ export const fn = (root) => {
           node.children.length === 1
         ) {
           const firstChild = node.children[0];
-          let nodeHasFilter = !!node.attributes.filter;
-          if (!nodeHasFilter && node.attributes.style) {
-            if (computeStyle(stylesheet, node)['filter']) {
-              nodeHasFilter = true;
-            }
-          }
+          const nodeHasFilter = !!(
+            node.attributes.filter || computeStyle(stylesheet, node).filter
+          );
           // TODO untangle this mess
           if (
             firstChild.type === 'element' &&

--- a/test/plugins/collapseGroups.18.svg.txt
+++ b/test/plugins/collapseGroups.18.svg.txt
@@ -1,0 +1,45 @@
+Don't collapse groups if outer group has filter (as style or attribute).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <clipPath id="a">
+        <circle cx="25" cy="15" r="10"/>
+    </clipPath>
+    <filter id="b">
+        <feColorMatrix type="saturate"/>
+    </filter>
+    <g filter="url(#b)">
+        <g clip-path="url(#a)">
+            <circle cx="30" cy="10" r="10" fill="yellow" id="c1"/>
+        </g>
+    </g>
+    <g style="filter:url(#b)">
+        <g clip-path="url(#a)">
+            <circle cx="20" cy="10" r="10" fill="blue" id="c2"/>
+        </g>
+    </g>
+    <circle cx="25" cy="15" r="10" stroke="black" stroke-width=".1" fill="none"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <clipPath id="a">
+        <circle cx="25" cy="15" r="10"/>
+    </clipPath>
+    <filter id="b">
+        <feColorMatrix type="saturate"/>
+    </filter>
+    <g filter="url(#b)">
+        <g clip-path="url(#a)">
+            <circle cx="30" cy="10" r="10" fill="yellow" id="c1"/>
+        </g>
+    </g>
+    <g style="filter:url(#b)">
+        <g clip-path="url(#a)">
+            <circle cx="20" cy="10" r="10" fill="blue" id="c2"/>
+        </g>
+    </g>
+    <circle cx="25" cy="15" r="10" stroke="black" stroke-width=".1" fill="none"/>
+</svg>


### PR DESCRIPTION
collapseGroups was not detecting a filter when it was in a style rather than an attribute.

This change resolves one regression mismatch (svgs/oxygen-icons-5.113.0/scalable/mimetypes/small/64x64/image-x-adobe-dng.svg) and reduces pixel mismatches by 67.

This type of problem seems like it is probably widespread (including in the same conditional in this plugin, where it is looking for a clip-path). I didn't see any tools to query the style attribute in a standard way. The solution in this PR is not going to scale well - it seems like it would be desirable to have a standardized, efficient way to query/change the style attribute - maybe it's there and I'm missing it?


















