### PR TITLE
fix: output to new directory if trailing slash

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -15,13 +15,13 @@ const regSVGFile = /\.svg$/i;
 /**
  * Synchronously check if path is a directory. Tolerant to errors like ENOENT.
  *
- * @param {string} path
+ * @param {string} filePath
  */
-export function checkIsDir(path) {
+export function checkIsDir(filePath) {
   try {
-    return fs.lstatSync(path).isDirectory();
+    return fs.lstatSync(filePath).isDirectory();
   } catch (e) {
-    return false;
+    return filePath.endsWith(path.sep);
   }
 }
 


### PR DESCRIPTION
Previously, SVGO would crash if the output location had a trailing slash and the location didn't exist.

This should be behaving the same as when the directory did exist, and putting the optimized file with the same name inside that directory.

This fixes that behavior, so we'll treat this as if the user wants to create that directory and output the optimized SVG to a file with the same name in that directory.

See my comment in #1675 for more context:

* https://github.com/svg/svgo/pull/1675#discussion_r1459295954

## Related

* Closes https://github.com/svg/svgo/pull/1675