### PR TITLE
fix: removeHiddenElems is not idempotent

### DIFF
--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -476,6 +476,7 @@ export const fn = (root, params) => {
             ] of nonRenderedNodes.entries()) {
               if (canRemoveNonRenderingNode(nonRenderedNode)) {
                 detachNodeFromParent(nonRenderedNode, nonRenderedParent);
+                nonRenderedNodes.delete(nonRenderedNode);
 
                 // For any elements referenced by the just-deleted node and its children, remove the node from the list of referencing nodes.
                 const deletedReferenceNodes =

--- a/test/plugins/removeHiddenElems.20.svg.txt
+++ b/test/plugins/removeHiddenElems.20.svg.txt
@@ -1,0 +1,24 @@
+Remove all unreferenced elements which are only referenced by other unreferenced elements.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <clipPath clipPathUnits="userSpaceOnUse" id="clipPath3889">
+            <path d="M200 200 l50 -300" style="fill:url(#linearGradient3893)"/>
+        </clipPath>
+        <linearGradient xlink:href="#linearGradient6131" id="linearGradient3893" gradientUnits="userSpaceOnUse" gradientTransform="scale(2)" x1="86" y1="93" x2="95" y2="102" />
+        <linearGradient id="linearGradient6131">
+            <stop id="stop6133" offset="0" style="stop-color:#fcfcfc;stop-opacity:1" />
+            <stop id="stop6137" offset="1" style="stop-color:#cecbcb;stop-opacity:1" />
+        </linearGradient>
+    </defs>
+    <path d="M200 200 l50 -300" />
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path d="M200 200 l50 -300"/>
+</svg>


### PR DESCRIPTION
removeHiddenElems was only removing the last of a chain of unreferenced elements - e.g., if a is referenced by b is referenced by c, and all are otherwise unreferenced, only c will be removed.

There is no change in regression mismatches or pixel mismatches. Total file compression in single-pass mode is increased by 19,540,048 bytes (2.5%). With the previous version, one link in the chain would be removed with each pass in multi-pass mode.

