### PR TITLE
chore: Update the README docs to suggest svgo.config.mjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ svgo --help
 
 SVGO has a plugin architecture. You can read more about all plugins in [Plugins | SVGO Documentation](https://svgo.dev/docs/plugins/), and the default plugins in [Preset Default | SVGO Documentation](https://svgo.dev/docs/preset-default/).
 
-SVGO reads the configuration from `svgo.config.js` or the `--config path/to/config.js` command-line option. Some other parameters can be configured though command-line options too.
+SVGO reads the configuration from `svgo.config.mjs` or the `--config path/to/config.mjs` command-line option. Some other parameters can be configured though command-line options too.
 
-**`svgo.config.js`**
+**`svgo.config.mjs`**
 
 ```js
 export default {
@@ -80,7 +80,7 @@ export default {
 
 Instead of configuring SVGO from scratch, you can tweak the default preset to suit your needs by configuring or disabling the respective plugin.
 
-**`svgo.config.js`**
+**`svgo.config.mjs`**
 
 ```js
 export default {
@@ -109,7 +109,7 @@ You can find a list of the default plugins in the order they run in [Preset Defa
 
 You can also specify custom plugins:
 
-**`svgo.config.js`**
+**`svgo.config.mjs`**
 
 ```js
 import importedPlugin from './imported-plugin';
@@ -152,7 +152,7 @@ const optimizedSvgString = result.data;
 
 ### loadConfig
 
-If you write a tool on top of SVGO you may want to resolve the `svgo.config.js` file.
+If you write a tool on top of SVGO you may want to resolve the `svgo.config.mjs` file.
 
 ```js
 import { loadConfig } from 'svgo';


### PR DESCRIPTION
When running svgo with a custom config named svgo.config.js on node 20.11.0. It fails to load the config file with the following error:

```
./svgo.config.js:1
export default {
^^^^^^

SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:77:18)
    at wrapSafe (node:internal/modules/cjs/loader:1288:20)
    at Module._compile (node:internal/modules/cjs/loader:1340:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at cjsLoader (node:internal/modules/esm/translators:356:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:305:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
```

Renaming it to `.mjs` makes node process it properly