### PR TITLE
fix: <a> element not parsed as text

### DIFF
--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -1,0 +1,32 @@
+import { parseSvg } from './parser.js';
+import { stringifySvg } from './stringifier.js';
+
+const input = `<svg xmlns="http://www.w3.org/2000/svg">
+<text x="10" y="35" xml:space="preserve">
+    <a href="x">
+this is a test
+    </a>
+</text>
+<text x="10" y="35" xml:space="preserve">
+    <tspan>
+this is a test
+    </tspan>
+</text>
+</svg>`;
+
+const expected = `<svg xmlns="http://www.w3.org/2000/svg"><text x="10" y="35" xml:space="preserve">
+    <a href="x">
+this is a test
+    </a>
+</text><text x="10" y="35" xml:space="preserve">
+    <tspan>
+this is a test
+    </tspan>
+</text></svg>`;
+
+test('a text preserved', () => {
+  const parsed = parseSvg(input);
+  const actual = stringifySvg(parsed, {});
+
+  expect(actual).toBe(expected);
+});

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -55,6 +55,7 @@ export const elemsGroups = {
     'symbol',
   ]),
   textContent: new Set([
+    'a',
     'altGlyph',
     'altGlyphDef',
     'altGlyphItem',

--- a/plugins/removeScriptElement.js
+++ b/plugins/removeScriptElement.js
@@ -51,7 +51,10 @@ export const fn = () => {
             }
 
             const index = parentNode.children.indexOf(node);
-            parentNode.children.splice(index, 1, ...node.children);
+            const usefulChildren = node.children.filter(
+              (child) => !(child.type === 'text' && /\s*/.test(child.value)),
+            );
+            parentNode.children.splice(index, 1, ...usefulChildren);
 
             // TODO remove legacy parentNode in v4
             for (const child of node.children) {

--- a/test/plugins/removeEmptyContainers.06.svg.txt
+++ b/test/plugins/removeEmptyContainers.06.svg.txt
@@ -19,7 +19,7 @@ systemLanguage.
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
         <a transform="translate(0,-5)" href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
-            <text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text>
-        </a>
+      <text text-anchor="middle" font-size="10px" x="50%" y="100%">Viewer does not support full SVG 1.1</text>
+    </a>
     </switch>
 </svg>

--- a/test/plugins/removeScriptElement.03.svg.txt
+++ b/test/plugins/removeScriptElement.03.svg.txt
@@ -12,6 +12,6 @@ Does not remove normal links, and does remove event attributes.
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <a href="https://yewtu.be/watch?v=dQw4w9WgXcQ">
-        <text y="10">uwu</text>
-    </a>
+    <text y="10">uwu</text>
+  </a>
 </svg>

--- a/test/plugins/removeXlink.03.svg.txt
+++ b/test/plugins/removeXlink.03.svg.txt
@@ -12,8 +12,7 @@ to title node.
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
-    <a target="_blank" href="https://duckduckgo.com">
-        <title>DuckDuckGo Homepage</title>
-        <text x="0" y="10">uwu</text>
-    </a>
+    <a target="_blank" href="https://duckduckgo.com"><title>DuckDuckGo Homepage</title>
+    <text x="0" y="10">uwu</text>
+  </a>
 </svg>


### PR DESCRIPTION
`<a>` elements should be parsed the same as `<tspan>`, etc. This change adds `<a>` to the textContent collection. It also adds a test file for the parser, updates the expected results for several test cases, and changes the removeScriptElement plugin to remove empty text nodes contained by removed `<a>` elements.

To see the problem visually, optimize the following file with default SVGO settings and view both input and output files:

```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
    <text x="10" y="20">this is a test</text>
    <text x="10" y="35" xml:space="preserve">
        <a href="https://svgwg.org/svg2-draft/linking.html#Links">
this is a test   
        </a>
    </text>
</svg>
```

Before the fix, the second line is shifted from the correct position after being optimized.