### PR TITLE
fix: stringifyPathData needs space before scientific notation.

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -285,9 +285,7 @@ const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
       result += roundedStr;
     } else if (
       !Number.isInteger(previous) &&
-      rounded != 0 &&
-      rounded < 1 &&
-      rounded > -1
+      !'0123456789'.includes(roundedStr[0])
     ) {
       // remove space before decimal with zero whole
       // only when previous number is also decimal

--- a/lib/path.js
+++ b/lib/path.js
@@ -283,10 +283,7 @@ const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
     } else if (i === 0 || rounded < 0) {
       // avoid space before first and negative numbers
       result += roundedStr;
-    } else if (
-      !Number.isInteger(previous) &&
-      !isDigit(roundedStr[0])
-    ) {
+    } else if (!Number.isInteger(previous) && !isDigit(roundedStr[0])) {
       // remove space before decimal with zero whole
       // only when previous number is also decimal
       result += roundedStr;

--- a/lib/path.js
+++ b/lib/path.js
@@ -285,7 +285,7 @@ const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
       result += roundedStr;
     } else if (
       !Number.isInteger(previous) &&
-      !'0123456789'.includes(roundedStr[0])
+      !isDigit(roundedStr[0])
     ) {
       // remove space before decimal with zero whole
       // only when previous number is also decimal

--- a/lib/path.test.js
+++ b/lib/path.test.js
@@ -142,6 +142,17 @@ describe('stringify path data', () => {
       }),
     ).toBe('M0-1.2.3 4 5-.6 7 .8');
   });
+  it('should have a space before scientific notation', () => {
+    expect(
+      stringifyPathData({
+        pathData: [
+          { command: 'M', args: [0.1, 1e-7] },
+          { command: 'L', args: [2, 2] },
+        ],
+        precision: 7,
+      }),
+    ).toBe('M.1 1e-7 2 2');
+  });
   it('should configure precision', () => {
     /**
      * @type {PathDataItem[]}


### PR DESCRIPTION
stringifyPathData was not adding a space before numbers which used scientific notation.

This fix does not change the results of regression tests using the current value of floatPrecision: 4 (125 failures, 3794 pixel differences), but when run at floatPrecision:7, failures are reduced from 164 to 93, and pixel mismatches reduced from 32,058 to 3,233.