### PR TITLE
fix: mergePaths should not merge paths with styles that depend on bounding box

### DIFF
--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -16,29 +16,14 @@ export const description = 'merges multiple paths in one if possible';
 /**
  * @param {XastElement} element
  * @param {ComputedStyles} computedStyle
+ * @param {string} attName
  */
-function elementHasGradientFill(element, computedStyle) {
-  /**
-   * @param {string} str
-   */
-  function hasGradientFill(str) {
-    return Boolean(str) && str.includes('url(');
+function elementHasGradient(element, computedStyle, attName) {
+  const style = computedStyle[attName];
+  if (!style || style.type !== 'static') {
+    return false;
   }
-
-  /**
-   * @param {StaticStyle|DynamicStyle|undefined} style
-   */
-  function hasGradientFillStyle(style) {
-    if (!style || style.type !== 'static') {
-      return false;
-    }
-    return hasGradientFill(style.value);
-  }
-
-  return (
-    hasGradientFill(element.attributes.fill) ||
-    hasGradientFillStyle(computedStyle['fill'])
-  );
+  return style.value && style.value.includes('url(');
 }
 
 /**
@@ -114,7 +99,9 @@ export const fn = (root, params) => {
             computedStyle['marker-start'] ||
             computedStyle['marker-mid'] ||
             computedStyle['marker-end'] ||
-            elementHasGradientFill(child, computedStyle)
+            ['fill', 'filter', 'stroke'].some((attName) =>
+              elementHasGradient(child, computedStyle, attName),
+            )
           ) {
             if (prevPathData) {
               updatePreviousPath(prevChild, prevPathData);

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -14,16 +14,18 @@ export const name = 'mergePaths';
 export const description = 'merges multiple paths in one if possible';
 
 /**
- * @param {XastElement} element
  * @param {ComputedStyles} computedStyle
  * @param {string} attName
+ * @returns {boolean}
  */
-function elementHasURL(element, computedStyle, attName) {
+function elementHasUrl(computedStyle, attName) {
   const style = computedStyle[attName];
-  if (!style || style.type !== 'static') {
-    return false;
+
+  if (style?.type === 'static') {
+    return includesUrlReference(style.value);
   }
-  return style.value && style.value.includes('url(');
+
+  return false;
 }
 
 /**

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -18,7 +18,7 @@ export const description = 'merges multiple paths in one if possible';
  * @param {ComputedStyles} computedStyle
  * @param {string} attName
  */
-function elementHasGradient(element, computedStyle, attName) {
+function elementHasURL(element, computedStyle, attName) {
   const style = computedStyle[attName];
   if (!style || style.type !== 'static') {
     return false;
@@ -99,8 +99,11 @@ export const fn = (root, params) => {
             computedStyle['marker-start'] ||
             computedStyle['marker-mid'] ||
             computedStyle['marker-end'] ||
+            computedStyle['clip-path'] ||
+            computedStyle['mask'] ||
+            computedStyle['mask-image'] ||
             ['fill', 'filter', 'stroke'].some((attName) =>
-              elementHasGradient(child, computedStyle, attName),
+              elementHasURL(child, computedStyle, attName),
             )
           ) {
             if (prevPathData) {

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -9,6 +9,7 @@
 
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 import { path2js, js2path, intersects } from './_path.js';
+import { includesUrlReference } from '../lib/svgo/tools.js';
 
 export const name = 'mergePaths';
 export const description = 'merges multiple paths in one if possible';
@@ -105,7 +106,7 @@ export const fn = (root, params) => {
             computedStyle['mask'] ||
             computedStyle['mask-image'] ||
             ['fill', 'filter', 'stroke'].some((attName) =>
-              elementHasURL(child, computedStyle, attName),
+              elementHasUrl(computedStyle, attName),
             )
           ) {
             if (prevPathData) {

--- a/test/plugins/mergePaths.08.svg.txt
+++ b/test/plugins/mergePaths.08.svg.txt
@@ -1,0 +1,37 @@
+Don't merge paths with a linearGradient fill (issue #1267).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+    <style>
+        path.lg{fill:url(#gradient);}
+    </style>
+    <linearGradient id="gradient">
+        <stop offset="0" stop-color="#ff0000"/>
+        <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+    <path fill="url(#gradient)" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path fill="url(#gradient)" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="fill:url(#gradient)" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="fill:url(#gradient)" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+    <style>
+        path.lg{fill:url(#gradient);}
+    </style>
+    <linearGradient id="gradient">
+        <stop offset="0" stop-color="#ff0000"/>
+        <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+    <path fill="url(#gradient)" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path fill="url(#gradient)" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="fill:url(#gradient)" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="fill:url(#gradient)" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>

--- a/test/plugins/mergePaths.09.svg.txt
+++ b/test/plugins/mergePaths.09.svg.txt
@@ -1,0 +1,37 @@
+Don't merge paths with a linearGradient stroke (issue #1267).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 300 300">
+    <style>
+        path.lg{stroke:url(#gradient);}
+    </style>
+    <linearGradient id="gradient">
+        <stop offset="0" stop-color="#ff0000"/>
+        <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+    <path stroke="url(#gradient)" stroke-width="10" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path stroke="url(#gradient)" stroke-width="10" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="stroke:url(#gradient)" stroke-width="10" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="stroke:url(#gradient)" stroke-width="10" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" stroke-width="10" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" stroke-width="10" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 300 300">
+    <style>
+        path.lg{stroke:url(#gradient);}
+    </style>
+    <linearGradient id="gradient">
+        <stop offset="0" stop-color="#ff0000"/>
+        <stop offset="1" stop-color="#0000ff"/>
+    </linearGradient>
+    <path stroke="url(#gradient)" stroke-width="10" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path stroke="url(#gradient)" stroke-width="10" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="stroke:url(#gradient)" stroke-width="10" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="stroke:url(#gradient)" stroke-width="10" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" stroke-width="10" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" stroke-width="10" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>

--- a/test/plugins/mergePaths.10.svg.txt
+++ b/test/plugins/mergePaths.10.svg.txt
@@ -1,0 +1,35 @@
+Don't merge paths with a filter URL (issue #1267).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 300 300">
+    <style>
+        path.lg{filter:url(#blurMe);}
+    </style>
+    <filter id="blurMe" x=".1">
+        <feGaussianBlur stdDeviation="5"/>
+    </filter>
+    <path filter="url(#blurMe)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path filter="url(#blurMe)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="filter:url(#blurMe)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="filter:url(#blurMe)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 300 300">
+    <style>
+        path.lg{filter:url(#blurMe);}
+    </style>
+    <filter id="blurMe" x=".1">
+        <feGaussianBlur stdDeviation="5"/>
+    </filter>
+    <path filter="url(#blurMe)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path filter="url(#blurMe)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="filter:url(#blurMe)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="filter:url(#blurMe)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+</svg>

--- a/test/plugins/mergePaths.11.svg.txt
+++ b/test/plugins/mergePaths.11.svg.txt
@@ -1,0 +1,39 @@
+Don't merge paths with a clip-path (issue #1267).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 400 400">
+    <style>
+        path.lg{clip-path:url(#myClip);}
+    </style>
+    <clipPath id="myClip" clipPathUnits="objectBoundingBox">
+        <circle cx=".5" cy=".5" r=".5"/>
+    </clipPath>
+    <path clip-path="url(#myClip)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path clip-path="url(#myClip)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="clip-path:url(#myClip)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="clip-path:url(#myClip)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+    <path style="clip-path:circle(25%)" fill="red" d="M 0 300 h 100 v 80 H 0 z"/>
+    <path style="clip-path:circle(25%)" fill="red" d="M 200 300 H 300 v 80 H 200 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 400 400">
+    <style>
+        path.lg{clip-path:url(#myClip);}
+    </style>
+    <clipPath id="myClip" clipPathUnits="objectBoundingBox">
+        <circle cx=".5" cy=".5" r=".5"/>
+    </clipPath>
+    <path clip-path="url(#myClip)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path clip-path="url(#myClip)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="clip-path:url(#myClip)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="clip-path:url(#myClip)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+    <path style="clip-path:circle(25%)" fill="red" d="M 0 300 h 100 v 80 H 0 z"/>
+    <path style="clip-path:circle(25%)" fill="red" d="M 200 300 H 300 v 80 H 200 z"/>
+</svg>

--- a/test/plugins/mergePaths.12.svg.txt
+++ b/test/plugins/mergePaths.12.svg.txt
@@ -1,0 +1,41 @@
+Don't merge paths with a mask (issue #1267).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 400 400">
+    <style>
+        path.lg{mask:url(#mask);}
+    </style>
+    <mask id="mask" maskContentUnits="objectBoundingBox">
+        <rect fill="white" x="0" y="0" width="100%" height="100%"/>
+        <circle fill="black" cx=".5" cy=".5" r=".5"/>
+    </mask>
+    <path mask="url(#mask)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path mask="url(#mask)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="mask:url(#mask)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="mask:url(#mask)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+    <path style="mask-image: linear-gradient(to left top,black, transparent)" fill="red" d="M 0 300 h 100 v 80 H 0 z"/>
+    <path style="mask-image: linear-gradient(to left top,black, transparent)" fill="red" d="M 200 300 H 300 v 80 H 200 z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 400 400">
+    <style>
+        path.lg{mask:url(#mask);}
+    </style>
+    <mask id="mask" maskContentUnits="objectBoundingBox">
+        <rect fill="white" x="0" y="0" width="100%" height="100%"/>
+        <circle fill="black" cx=".5" cy=".5" r=".5"/>
+    </mask>
+    <path mask="url(#mask)" fill="red" d="M 0 0 H 100 V 80 H 0 z"/>
+    <path mask="url(#mask)" fill="red" d="M 200 0 H 300 V 80 H 200 z"/>
+    <path style="mask:url(#mask)" fill="red" d="M 0 100 h 100 v 80 H 0 z"/>
+    <path style="mask:url(#mask)" fill="red" d="M 200 100 H 300 v 80 H 200 z"/>
+    <path class="lg" fill="red" d="M 0 200 h 100 v 80 H 0 z"/>
+    <path class="lg" fill="red" d="M 200 200 H 300 v 80 H 200 z"/>
+    <path style="mask-image: linear-gradient(to left top,black, transparent)" fill="red" d="M 0 300 h 100 v 80 H 0 z"/>
+    <path style="mask-image: linear-gradient(to left top,black, transparent)" fill="red" d="M 200 300 H 300 v 80 H 200 z"/>
+</svg>


### PR DESCRIPTION
This PR fixes the problem raised in issue #1267. The general issue is that merging paths into a single element changes the bounding box, so any style that depends on the bounding box of the element may change behavior. This PR disables merging for any paths that have:

- A fill, filter, or stroke that references a URL.
- A clip-path or mask.

It's possible that there are other scenarios where merging should be disabled, but those above are the only ones that I was able to construct a test case for so far.

With the current regression settings, there is no change in pixel mismatches in the regressions. With the Oxygen files, only one file seems to be affected - scalable/status/weather-few-clouds-night.svg. The clouds were rendered incorrectly in the optimized version before the fix.

Closes #1267