### PR TITLE
fix(convertPathData): preserve vertex for markers only path

### DIFF
--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -212,7 +212,7 @@ const applyMatrixToPathData = (pathData, matrix) => {
     }
 
     // horizontal lineto (x)
-    // convert to lineto to handle two-dimentional transforms
+    // convert to lineto to handle two-dimensional transforms
     if (command === 'H') {
       command = 'L';
       args = [args[0], cursor[1]];
@@ -223,7 +223,7 @@ const applyMatrixToPathData = (pathData, matrix) => {
     }
 
     // vertical lineto (y)
-    // convert to lineto to handle two-dimentional transforms
+    // convert to lineto to handle two-dimensional transforms
     if (command === 'V') {
       command = 'L';
       args = [cursor[0], args[0]];

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -172,10 +172,13 @@ export const fn = (root, params) => {
               computedStyle['stroke-linejoin'].value === 'round'
             : true;
 
-          var data = path2js(node);
+          let data = path2js(node);
 
           // TODO: get rid of functions returns
           if (data.length) {
+            const includesVertices = data.some(
+              (item) => item.command !== 'm' && item.command !== 'M',
+            );
             convertToRelative(data);
 
             data = filters(data, newParams, {
@@ -186,6 +189,23 @@ export const fn = (root, params) => {
 
             if (utilizeAbsolute) {
               data = convertToMixed(data, newParams);
+            }
+
+            const hasMarker =
+              node.attributes['marker-start'] != null ||
+              node.attributes['marker-end'] != null;
+            const isMarkersOnlyPath =
+              hasMarker &&
+              includesVertices &&
+              data.every(
+                (item) => item.command === 'm' || item.command === 'M',
+              );
+
+            if (isMarkersOnlyPath) {
+              data.push({
+                command: 'z',
+                args: [],
+              });
             }
 
             // @ts-ignore

--- a/test/plugins/convertPathData.37.svg.txt
+++ b/test/plugins/convertPathData.37.svg.txt
@@ -1,0 +1,30 @@
+Must preserve vertex for markers only path for consistent rendering across clients.
+Must not add vertices if markers only path did not have commands other than M/m anyway.
+
+See: https://github.com/svg/svgo/issues/1493
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9">
+    <marker id="a" stroke="red" viewBox="0 0 5 5">
+        <circle cx="2" cy="2" r="1"/>
+    </marker>
+    <marker id="b" stroke="green" viewBox="0 0 5 5">
+        <circle cx="2" cy="2" r="0.5"/>
+    </marker>
+    <path marker-start="url(#a)" d="M5 5h0"/>
+    <path marker-start="url(#b)" d="M5 5"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9">
+    <marker id="a" stroke="red" viewBox="0 0 5 5">
+        <circle cx="2" cy="2" r="1"/>
+    </marker>
+    <marker id="b" stroke="green" viewBox="0 0 5 5">
+        <circle cx="2" cy="2" r="0.5"/>
+    </marker>
+    <path marker-start="url(#a)" d="M5 5z"/>
+    <path marker-start="url(#b)" d="M5 5"/>
+</svg>


### PR DESCRIPTION
If we get a markers only path, for example:

```xml
<path marker-start="url(#a)" marker-end="url(#b)" d="M5 5h0"/>
```

(The path only serves to draw the referenced markers.)

We ensure it always has an extra vertex if it had multiple vertices before optimization. If it did not have multiple vertices, for example it was `M`/`m` commands only, then it has the same behavior as before.

See my comment on the related issue for more info:

* https://github.com/svg/svgo/issues/1493#issuecomment-1974136452

In short, clients consistently render the marker only when a command other than `M` or `m` are used in the path data. If this is removed, in some clients the markers are no longer rendered.

It's unclear from the spec what the intended behavior is, but across all clients, rendering is impacted when no additional vertices are in the path.

## Related

* Closes https://github.com/svg/svgo/issues/1493