### PR TITLE
fix(makeProgram): specify .mjs and .cjs config files are allowed

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -49,7 +49,7 @@ export default function makeProgram(program) {
     )
     .option(
       '--config <CONFIG>',
-      'Custom config file. Only .js, .mjs, .cjs is supported',
+      'Custom config file, only .js, .mjs, and .cjs is supported',
     )
     .option(
       '--datauri <FORMAT>',

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -47,7 +47,10 @@ export default function makeProgram(program) {
       '-p, --precision <INTEGER>',
       'Set number of digits in the fractional part, overrides plugins params',
     )
-    .option('--config <CONFIG>', 'Custom config file, only .js is supported')
+    .option(
+      '--config <CONFIG>',
+      'Custom config file. Only .js, .mjs, .cjs is supported',
+    )
     .option(
       '--datauri <FORMAT>',
       'Output as Data URI string (base64), URI encoded (enc) or unencoded (unenc)',


### PR DESCRIPTION
Looking at the source code:

https://github.com/svg/svgo/blob/2442f742398f6c40bcf83b5c34e4a71a023adae1/lib/svgo-node.js#L39-L50

it looks to me like not only .js, but also .mjs, and .cjs extensions are allowed in config files. This PR aligns the help text with the actual behavior.