### PR TITLE
feat: add support for `--disable` and `--enable` flags back

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -4,11 +4,22 @@ import { builtin } from './builtin.js';
 import { invokePlugins } from './svgo/plugins.js';
 import { encodeSVGDatauri } from './svgo/tools.js';
 
+/**
+ * @template T {any}
+ * @typedef {import('./types.js').PluginConfig<T>} PluginConfig<T>
+ * @typedef {import('./types.js').PresetConfig} PresetConfig
+ */
+
 const pluginsMap = {};
 for (const plugin of builtin) {
   pluginsMap[plugin.name] = plugin;
 }
 
+/**
+ * @template T {any}
+ * @param {string | PresetConfig| PluginConfig<T>} plugin plugin name or plugin config
+ * @returns {PresetConfig| PluginConfig<T> | null} plugin config or null if plugin was not found
+ */
 const resolvePluginConfig = (plugin) => {
   if (typeof plugin === 'string') {
     // resolve builtin plugin specified as string
@@ -77,10 +88,33 @@ export const optimize = (input, config) => {
         'Warning: plugins list includes null or undefined elements, these will be ignored.',
       );
     }
+
+    const disablePlugins = config.disable;
+    if (disablePlugins != null && !Array.isArray(disablePlugins)) {
+      throw Error('malformed config, `disable` property must be an array.');
+    }
+
+    const enablePlugins = config.enable;
+    if (enablePlugins != null && !Array.isArray(enablePlugins)) {
+      throw Error('malformed config, `enable` property must be an array.');
+    }
+
     const globalOverrides = {};
     if (config.floatPrecision != null) {
       globalOverrides.floatPrecision = config.floatPrecision;
     }
+    const overrides = {};
+    if (disablePlugins != null) {
+      for (const plugin of disablePlugins) {
+        overrides[plugin] = false;
+      }
+    }
+    if (enablePlugins != null) {
+      for (const plugin of enablePlugins) {
+        overrides[plugin] = true;
+      }
+    }
+    globalOverrides.overrides = overrides;
     invokePlugins(ast, info, resolvedPlugins, null, globalOverrides);
     output = stringifySvg(ast, config.js2svg);
     if (output.length < prevResultSize) {

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -76,6 +76,11 @@ export default function makeProgram(program) {
       'Only output error messages, not regular status messages',
     )
     .option('--show-plugins', 'Show available plugins and exit')
+    .option('--disable <PLUGINS...>', 'Disable selected plugins')
+    .option(
+      '--enable <PLUGINS...>',
+      'Enable selected plugins. Takes precedence over `disable`',
+    )
     // used by picocolors internally
     .option('--no-color', 'Output plain text without color')
     .action(action);
@@ -271,6 +276,14 @@ async function action(args, opts, command) {
     var data = decodeSVGDatauri(opts.string);
 
     return processSVGData(config, null, data, output[0]);
+  }
+
+  if (opts.disable) {
+    config.disable = opts.disable;
+  }
+
+  if (opts.enable) {
+    config.enable = opts.enable;
   }
 }
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -111,6 +111,17 @@ export type Plugin<Params> = (
   info: PluginInfo,
 ) => Visitor | null | void;
 
+export type PluginConfig<Params> = {
+  name: string;
+  params: any;
+  fn: Plugin<Params> | null;
+};
+
+export type PresetConfig = {
+  name: string;
+  plugins: PluginConfig<any>[];
+};
+
 export type Specificity = [number, number, number];
 
 export type StylesheetDeclaration = {


### PR DESCRIPTION
Closes #1356
Closes #1622

In https://github.com/svg/svgo/issues/1622#issuecomment-971440346 we read:

> I consider adding it back at some point but it should be able to work with presets somehow. This is still need to be figured out.

I believe that by using globalOverrides, we can make it very easily, but I must admit, this was the first time I've worked with this code, so I might have missed something.

I did test the code though and it disabled the plugins I wanted when using CLI, so at the very least we're getting somewhere.

I've also increased JSDoc coverage here, mainly for my own sanity when working with these arrays of plugins. Hope you don't mind that scope creep :)