### PR TITLE
chore: add type property required for custom plugin example

### DIFF
--- a/docs/04-plugins-api.mdx
+++ b/docs/04-plugins-api.mdx
@@ -34,6 +34,7 @@ The following JavaScript shows all of the types of nodes you can implement a cal
 const myPlugin = {
   name: 'pluginName',
   description: 'A plugin that does a lot of nothing.',
+  type: 'visitor',
   fn: () => {
     return {
       root: {


### PR DESCRIPTION
The existing custom plugin example has no effect. you must add the type "visitor" in order for the enter and exit behavior to run.