### PR TITLE
Fixed V3.3.0 Common JS missing loadConfig and optimize exports

### DIFF
--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -1,0 +1,17 @@
+import { Config, optimize } from './svgo';
+
+export { optimize };
+
+/**
+ * If you write a tool on top of svgo you might need a way to load svgo config.
+ *
+ * You can also specify relative or absolute path and customize current working directory.
+ */
+export declare function loadConfig(
+  configFile: string,
+  cwd?: string
+): Promise<Config>;
+export declare function loadConfig(
+  configFile?: null,
+  cwd?: string
+): Promise<Config | null>;

--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -9,9 +9,9 @@ export { optimize };
  */
 export declare function loadConfig(
   configFile: string,
-  cwd?: string
+  cwd?: string,
 ): Promise<Config>;
 export declare function loadConfig(
   configFile?: null,
-  cwd?: string
+  cwd?: string,
 ): Promise<Config | null>;

--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -54,17 +54,3 @@ type Output = {
 
 /** The core of SVGO */
 export declare function optimize(input: string, config?: Config): Output;
-
-/**
- * If you write a tool on top of svgo you might need a way to load svgo config.
- *
- * You can also specify relative or absolute path and customize current working directory.
- */
-export declare function loadConfig(
-  configFile: string,
-  cwd?: string,
-): Promise<Config>;
-export declare function loadConfig(
-  configFile?: null,
-  cwd?: string,
-): Promise<Config | null>;

--- a/package.json
+++ b/package.json
@@ -52,14 +52,16 @@
   },
   "main": "./lib/svgo-node.js",
   "bin": "./bin/svgo.js",
-  "types": "./lib/svgo.d.ts",
+  "types": "./lib/svgo-node.d.ts",
   "exports": {
     ".": {
       "import": "./lib/svgo-node.js",
-      "require": "./dist/svgo-node.cjs"
+      "require": "./dist/svgo-node.cjs",
+      "types": "./lib/svgo-node.d.ts"
     },
     "./browser": {
-      "import": "./dist/svgo.browser.js"
+      "import": "./dist/svgo.browser.js",
+      "types": "./lib/svgo.d.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -64,6 +64,16 @@
       "types": "./lib/svgo.d.ts"
     }
   },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./lib/svgo-node.d.ts"
+      ],
+      "browser": [
+        "./lib/svgo.d.ts"
+      ]
+    }
+  },
   "files": [
     "bin",
     "lib",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,13 @@
   "bin": "./bin/svgo.js",
   "types": "./lib/svgo.d.ts",
   "exports": {
-    "require": "./dist/svgo-node.cjs",
-    "default": "./lib/svgo-node.js"
+    ".": {
+      "import": "./lib/svgo-node.js",
+      "require": "./dist/svgo-node.cjs"
+    },
+    "./browser": {
+      "import": "./dist/svgo.browser.js"
+    }
   },
   "files": [
     "bin",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ const terserOptions = {
 
 export default [
   {
-    input: './lib/svgo.js',
+    input: './lib/svgo-node.js',
     output: {
       file: './dist/svgo-node.cjs',
       format: 'cjs',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,7 @@ export default [
       file: './dist/svgo-node.cjs',
       format: 'cjs',
     },
-    external: Object.keys(PKG.dependencies),
+    external: ['os', 'fs', 'url', 'path', ...Object.keys(PKG.dependencies)],
     onwarn(warning) {
       throw Error(warning.toString());
     },

--- a/test/svgo.cjs
+++ b/test/svgo.cjs
@@ -23,7 +23,7 @@ const expected = `<svg xmlns="http://www.w3.org/2000/svg">
 const runTest = () => {
   const result = optimize(fixture, {
     plugins: [],
-    js2svg: { pretty: true, indent: 2 },
+    js2svg: { pretty: true, indent: 2, eol: 'lf' },
   });
   const actual = result.data;
 

--- a/test/svgo.cjs
+++ b/test/svgo.cjs
@@ -1,4 +1,4 @@
-const { optimize } = require('../dist/svgo-node.cjs');
+const { loadConfig, optimize } = require('../dist/svgo-node.cjs');
 const assert = require('assert');
 
 const fixture = `<svg xmlns="http://www.w3.org/2000/svg">
@@ -28,6 +28,7 @@ const runTest = () => {
   const actual = result.data;
 
   assert.equal(actual, expected);
+  assert.notEqual(loadConfig, undefined);
 };
 
 runTest();


### PR DESCRIPTION
esm
```ts
import { loadConfig, optimize } from 'svgo';
```

cjs
```ts
const { loadConfig, optimize } = require('svgo');
```

browser
```ts
import { optimize } from 'svgo/browser';
```