### PR TITLE
chore: add cross-env and rimraf so that tests work everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,14 +85,14 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=4 --coverage",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=4 --coverage",
     "lint": "eslint --ignore-path .gitignore . && prettier --check . --ignore-path .gitignore",
     "fix": "eslint --ignore-path .gitignore --fix . && prettier --write . --ignore-path .gitignore",
     "typecheck": "tsc",
     "generate-bundles": "rollup -c",
     "test-bundles": "yarn generate-bundles && node ./test/svgo.cjs && node ./test/browser.js",
-    "test-regression": "node ./test/regression-extract.js && NO_DIFF=1 node ./test/regression.js",
-    "prepublishOnly": "rm -rf dist && yarn generate-bundles",
+    "test-regression": "node ./test/regression-extract.js && cross-env NO_DIFF=1 node ./test/regression.js",
+    "prepublishOnly": "rimraf dist && yarn generate-bundles",
     "qa": "yarn lint && yarn typecheck && yarn test && yarn test-bundles && yarn test-regression"
   },
   "jest": {
@@ -117,6 +117,7 @@
     "@types/csso": "^5.0.4",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.11",
+    "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "node-fetch": "^2.7.0",
@@ -124,6 +125,7 @@
     "playwright": "^1.44.0",
     "pngjs": "^7.0.0",
     "prettier": "^3.2.5",
+    "rimraf": "^3.0.2",
     "rollup": "^4.17.2",
     "tar-stream": "^3.1.7",
     "typescript": "^5.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,7 +1735,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4508,6 +4520,7 @@ __metadata:
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.11
     commander: ^7.2.0
+    cross-env: ^7.0.3
     css-select: ^5.1.0
     css-tree: ^2.3.1
     css-what: ^6.1.0
@@ -4520,6 +4533,7 @@ __metadata:
     playwright: ^1.44.0
     pngjs: ^7.0.0
     prettier: ^3.2.5
+    rimraf: ^3.0.2
     rollup: ^4.17.2
     tar-stream: ^3.1.7
     typescript: ^5.4.5


### PR DESCRIPTION
Without this tests fail on Windows cmd (CI works because by default it's using bash)

Requires #1986 and #1987.