### PR TITLE
fix: fixed Config definition for node

### DIFF
--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -1,6 +1,6 @@
-import { VERSION, Config, optimize, builtinPlugins } from './svgo';
+import { Config } from './svgo';
 
-export { VERSION, optimize, builtinPlugins };
+export * from './svgo';
 
 /**
  * If you write a tool on top of svgo you might need a way to load svgo config.


### PR DESCRIPTION
Re export `Config` definition for node module.

![image](https://github.com/svg/svgo/assets/1730277/ec856c77-595a-4862-9d90-5622f4901506)
