### PR TITLE
chore!: Update commander to v11

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -6,6 +6,10 @@ import { encodeSVGDatauri, decodeSVGDatauri } from './tools.js';
 import { loadConfig, optimize } from '../svgo-node.js';
 import { builtin } from '../builtin.js';
 
+/**
+ * @typedef {import('commander').Command} Command
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkgPath = path.join(__dirname, '../../package.json');
 const PKG = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
@@ -25,14 +29,15 @@ export function checkIsDir(filePath) {
   }
 }
 
+/**
+ * @param {Command} program
+ */
 export default function makeProgram(program) {
   program
     .name(PKG.name)
-    .description(PKG.description, {
-      INPUT: 'Alias to --input',
-    })
+    .description(PKG.description)
     .version(PKG.version, '-v, --version')
-    .arguments('[INPUT...]')
+    .argument('[INPUT...]', 'Alias to --input')
     .option('-i, --input <INPUT...>', 'Input files, "-" for STDIN')
     .option('-s, --string <STRING>', 'Input SVG data string')
     .option(

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     ]
   },
   "dependencies": {
-    "commander": "^7.2.0",
+    "commander": "^11.1.0",
     "css-select": "^5.1.0",
     "css-tree": "^2.3.1",
     "css-what": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,17 +1685,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "commander@npm:11.1.0"
+  checksum: fd1a8557c6b5b622c89ecdfde703242ab7db3b628ea5d1755784c79b8e7cb0d74d65b4a262289b533359cd58e1bfc0bf50245dfbcd2954682a6f367c828b79ef
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
-  languageName: node
-  linkType: hard
-
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
   languageName: node
   linkType: hard
 
@@ -4506,7 +4506,7 @@ __metadata:
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.11
     "@types/sax": ^1.2.7
-    commander: ^7.2.0
+    commander: ^11.1.0
     cross-env: ^7.0.3
     css-select: ^5.1.0
     css-tree: ^2.3.1


### PR DESCRIPTION
Commander v11 requires Node.js 16 so this should probably be merged after #2002 and the other PRs.

Please note that this bumps many major versions. I checked commander's release notes, but this could definitely use some more eyes for any breaking changes that might affect svgo.

Ping me when needed for a rebase.