### PR TITLE
feat: add editor namespace for Boxy SVG

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -2101,6 +2101,7 @@ export const editorNamespaces = new Set([
   'http://www.serif.com/',
   'http://www.vector.evaxdesign.sk',
   'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  'https://boxy-svg.com',
 ]);
 
 /**


### PR DESCRIPTION
I've added [Boxy SVG](https://boxy-svg.com/)'s namespace to the set of editor namespaces according to https://svgo.dev/docs/plugins/removeEditorsNSData/. Boxy SVG markup looks like this:

```svg
<svg ... xmlns:bx="https://boxy-svg.com">
  ...
</svg>
```