### PR TITLE
chore: use markdown in frontmatter

### DIFF
--- a/docs/03-plugins/addAttributesToSVGElement.mdx
+++ b/docs/03-plugins/addAttributesToSVGElement.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: addAttributesToSVGElement
   parameters:
     attributes:
-      description: Attributes to add to the <code>&lt;svg&gt;</code> element. If key/value pairs are passed, the attributes and added with the paired value. If an array is passed, attributes are added with no key associated with them.
+      description: Attributes to add to the `<svg>` element. If key/value pairs are passed, the attributes and added with the paired value. If an array is passed, attributes are added with no key associated with them.
       default: null
     attribute:
 ---

--- a/docs/03-plugins/addClassesToSVGElement.mdx
+++ b/docs/03-plugins/addClassesToSVGElement.mdx
@@ -4,10 +4,10 @@ svgo:
   pluginId: addClassesToSVGElement
   parameters:
     classNames:
-      description: Adds the specified class names to the outer most <code>&lt;svg&gt;</code> element.
+      description: Adds the specified class names to the outer most `<svg>` element.
       default: null
     className:
-      description: Adds the specified class name to the outer most <code>&lt;svg&gt;</code> element. If <code>classNames</code> is specified, this is ignored.
+      description: Adds the specified class name to the outer most `<svg>` element. If `classNames` is specified, this is ignored.
 ---
 
 Overrides the `class` attribute in the outer most `<svg>` element, omitting duplicates or null classes if found in your configuration.

--- a/docs/03-plugins/cleanupIds.mdx
+++ b/docs/03-plugins/cleanupIds.mdx
@@ -16,7 +16,7 @@ svgo:
       description: Elements with an ID that starts with one of these prefixes will be ignored.
       default: []
     force:
-      description: This plugin normally does nothing if a <code>&lt;script&gt;</code> or <code>&lt;style&gt;</code> element is found. Setting this to true will bypass that behaviour, which may result in destructive changes.
+      description: This plugin normally does nothing if a `<script>` or `<style>` element is found. Setting this to true will bypass that behaviour, which may result in destructive changes.
       default: false
   defaultPlugin: true
 ---

--- a/docs/03-plugins/cleanupListOfValues.mdx
+++ b/docs/03-plugins/cleanupListOfValues.mdx
@@ -10,10 +10,10 @@ svgo:
       description: If to trim leading zeros.
       default: true
     defaultPx:
-      description: If to remove the units when it's <code>px</code>, as this is the default if not specified.
+      description: If to remove the units when it's `px`, as this is the default if not specified.
       default: true
     convertToPx:
-      description: If to convert absolute units like <code>cm</code> and <code>in</code> to <code>px</code>.
+      description: If to convert absolute units like `cm` and `in` to `px`.
       default: true
 ---
 

--- a/docs/03-plugins/cleanupNumericValues.mdx
+++ b/docs/03-plugins/cleanupNumericValues.mdx
@@ -11,10 +11,10 @@ svgo:
       description: If to trim leading zeros.
       default: true
     defaultPx:
-      description: If to remove the units when it's <code>px</code>, as this is the default if not specified.
+      description: If to remove the units when it's `px`, as this is the default if not specified.
       default: true
     convertToPx:
-      description: If to convert absolute units like <code>cm</code> and <code>in</code> to <code>px</code>.
+      description: If to convert absolute units like `cm` and `in` to `px`.
       default: true
 ---
 

--- a/docs/03-plugins/convertColors.mdx
+++ b/docs/03-plugins/convertColors.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     currentColor:
-      description: If to convert all instances of a color to <code>currentcolor</code>. This means to inherit the active foreground color, for example in HTML5 this would be the <a href="https://developer.mozilla.org/docs/Web/CSS/color" target="_blank"><code>color</code></a> property in CSS.
+      description: If to convert all instances of a color to `currentcolor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/docs/Web/CSS/color) property in CSS.
       default: false
     names2hex:
       description: If to convert color names to the hex equivalent.
@@ -14,7 +14,7 @@ svgo:
       description: If to convert RGB colors to the hex equivalent, ignores RGBA.
       default: true
     convertCase:
-      description: Convert all color values to either upper or lower case by setting this to <code>'upper'</code>  or <code>'lower'</code> respectively to improve compression. Set to <code>false</code> to disable this behavior.
+      description: Convert all color values to either upper or lower case by setting this to `'upper'` or `'lower'` respectively to improve compression. Set to `false` to disable this behavior.
       default: 'lower'
     shorthex:
       description: If to convert 6 character hex colors to the 3 character equivalent where possible.

--- a/docs/03-plugins/convertPathData.mdx
+++ b/docs/03-plugins/convertPathData.mdx
@@ -11,7 +11,7 @@ svgo:
       description: If to apply transforms to paths with a stroke.
       default: true
     makeArcs:
-      description: If to convert from curves to arcs when possible. This is an object with two properties, <code>threshold</code> and <code>tolerance</code>.
+      description: If to convert from curves to arcs when possible. This is an object with two properties, `threshold` and `tolerance`.
     straightCurves:
       description: If to convert curve commands that are effectively straight lines to line commands.
       default: true
@@ -22,7 +22,7 @@ svgo:
       description: If to convert regular lines to an explicit horizontal or vertical line where possible.
       default: true
     convertToZ:
-      description: If to convert lines that go to the start to a <code>z</code> command.
+      description: If to convert lines that go to the start to a `z` command.
       default: true
     curveSmoothShorthands:
       description: If to convert curves to smooth curves where possible.
@@ -34,7 +34,7 @@ svgo:
       description: Number of decimal places to round to, using conventional rounding rules.
       default: 5
     smartArcRounding:
-      description: Round the radius of circular arcs when the effective change is under the error. The effective change is determined using the <a href="https://wikipedia.org/wiki/Sagitta_(geometry)" target="_blank">sagitta</a> of the arc.
+      description: Round the radius of circular arcs when the effective change is under the error. The effective change is determined using the [sagitta](https://wikipedia.org/wiki/Sagitta_(geometry)) of the arc.
       default: true
     removeUseless:
       description: Remove redundant path commands that don't draw anything.

--- a/docs/03-plugins/convertShapeToPath.mdx
+++ b/docs/03-plugins/convertShapeToPath.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     convertArcs:
-      description: If to convert <code>&lt;circle&gt;</code> and <code>&lt;ellipse&gt;</code> elements to paths.
+      description: If to convert `<circle>` and `<ellipse>` elements to paths.
       default: false
     floatPrecision:
       description: Number of decimal places to round to, using conventional rounding rules.

--- a/docs/03-plugins/convertStyleToAttrs.mdx
+++ b/docs/03-plugins/convertStyleToAttrs.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: convertStyleToAttrs
   parameters:
     keepImportant:
-      description: If to always keep <a href="https://developer.mozilla.org/docs/Web/CSS/important" target="_blank"><code>!important</code></a> styles.
+      description: If to always keep [`!important`](https://developer.mozilla.org/docs/Web/CSS/important) styles.
       type: boolean
       default: false
 ---

--- a/docs/03-plugins/convertTransform.mdx
+++ b/docs/03-plugins/convertTransform.mdx
@@ -8,7 +8,7 @@ svgo:
       description: Convert transforms to their shorthand alternatives.
       default: true
     degPrecision:
-      description: Number of decimal places to round degrees values to, using conventional rounding rules. Used for <code>rotate</code> and <code>skew</code>.
+      description: Number of decimal places to round degrees values to, using conventional rounding rules. Used for `rotate` and `skew`.
     floatPrecision:
       description: Number of decimal places to round to, using conventional rounding rules.
       default: 3
@@ -16,19 +16,19 @@ svgo:
       description: Number of decimal places to round to, using conventional rounding rules.
       default: 5
     matrixToTransform:
-      description: If decompose matrices into simple transforms. See <a href="https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html" target="_blank">Decomposition of 2D-transform matrices</a> for more context.
+      description: If decompose matrices into simple transforms. See [Decomposition of 2D-transform matrices](https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html) for more context.
       default: true
     shortTranslate:
-      description: If to shorten references to <code>translate</code> with redundant parameters to omit them. i.e. <code>translate(10 0)</code> → <code>translate(10)</code>
+      description: If to shorten references to `translate` with redundant parameters to omit them. i.e. `translate(10 0)` → `translate(10)`
       default: true
     shortScale:
-      description: If to shorten references to <code>scale</code> with redundant parameters to omit them. i.e. <code>scale(2 2)</code> → <code>scale(2)</code>
+      description: If to shorten references to `scale` with redundant parameters to omit them. i.e. `scale(2 2)` → `scale(2)`
       default: true
     shortRotate:
-      description: If to shorten references to <code>rotate</code> with redundant parameters to omit them. i.e. <code>translate(cx cy) rotate(a) translate(-cx -cy)</code> → <code>rotate(a cx cy)</code>
+      description: If to shorten references to `rotate` with redundant parameters to omit them. i.e. `translate(cx cy) rotate(a) translate(-cx -cy)` → `rotate(a cx cy)`
       default: true
     removeUseless:
-      description: If to remove redundant transforms like <code>translate(0)</code>, <code>skewX(0)</code>, or <code>skewY(0)</code>.
+      description: If to remove redundant transforms like `translate(0)`, `skewX(0)`, or `skewY(0)`.
       default: true
     collapseIntoOne:
       description: If to multiply transforms into one.

--- a/docs/03-plugins/inlineStyles.mdx
+++ b/docs/03-plugins/inlineStyles.mdx
@@ -11,7 +11,7 @@ svgo:
       description: If to remove the selector and styles from the stylesheet while inlining the styles. This does not remove selectors that did not match any elements.
       default: true
     useMqs:
-      description: An array of media query conditions to use, such as <code>screen</code>. An empty string signifies all selectors outside of a media query.
+      description: An array of media query conditions to use, such as `screen`. An empty string signifies all selectors outside of a media query.
     usePseudos:
       description: What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo-classes and non-pseudo-elements.
 ---

--- a/docs/03-plugins/mergePaths.mdx
+++ b/docs/03-plugins/mergePaths.mdx
@@ -10,7 +10,7 @@ svgo:
       description: Number of decimal places to round to, using conventional rounding rules.
       default: 3
     noSpaceAfterFlags:
-      description: If to omit spaces after flags. Flags are values that can only be <code>0</code> or <code>1</code> and are used by some path commands, namely <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/d#elliptical_arc_curve" target="_blank"><code>A</code> and <code>a</code></a>.
+      description: If to omit spaces after flags. Flags are values that can only be `0` or `1` and are used by some path commands, namely [`A` and `a`](https://developer.mozilla.org/docs/Web/SVG/Attribute/d#elliptical_arc_curve).
       default: false
 ---
 

--- a/docs/03-plugins/minifyStyles.mdx
+++ b/docs/03-plugins/minifyStyles.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     usage:
-      description: If to collect usage data such as tags, classes, and IDs to pass to CSSO. This is an object with four properties, which are each configured with a boolean, <code>tags</code>, <code>ids</code>, <code>classes</code>, and <code>force</code>. By default, if a script is found this does not pass usage data to CSSO, but this can be overridden with <code>force</code>, which may yield destructive changes.
+      description: If to collect usage data such as tags, classes, and IDs to pass to CSSO. This is an object with four properties, which are each configured with a boolean, `tags`, `ids`, `classes`, and `force`. By default, if a script is found this does not pass usage data to CSSO, but this can be overridden with `force`, which may yield destructive changes.
       default: true
 ---
 

--- a/docs/03-plugins/prefixIds.mdx
+++ b/docs/03-plugins/prefixIds.mdx
@@ -9,10 +9,10 @@ svgo:
     prefix:
       description: Either a string or a function that resolves to a string.
     prefixIds:
-      description: If to prefix <code>id</code> attributes.
+      description: If to prefix `id` attributes.
       default: true
     prefixClassNames:
-      description: If to prefix classes in the <code>class</code> attribute.
+      description: If to prefix classes in the `class` attribute.
       default: true
 ---
 

--- a/docs/03-plugins/removeAttributesBySelector.mdx
+++ b/docs/03-plugins/removeAttributesBySelector.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: removeAttributesBySelector
   parameters:
     selectors:
-      description: An array of objects with two properties, <code>selector</code>, and <code>attributes</code>, which represent a CSS selector and the attributes to remove respectively.
+      description: An array of objects with two properties, `selector`, and `attributes`, which represent a CSS selector and the attributes to remove respectively.
       default: null
 ---
 

--- a/docs/03-plugins/removeAttrs.mdx
+++ b/docs/03-plugins/removeAttrs.mdx
@@ -7,10 +7,10 @@ svgo:
       description: A selector that matches attributes.
       default: null
     elemSeparator:
-      description: The pattern syntax used by this plugin is <code>element:attribute:value</code>, this changes the delimiter from <code>:</code> to another string.
+      description: The pattern syntax used by this plugin is `element:attribute:value`, this changes the delimiter from `:` to another string.
       default: ':'
     preserveCurrentColor:
-      description: If to ignore the attribute when it's set to <code>currentcolor</code>.
+      description: If to ignore the attribute when it's set to `currentcolor`.
       default: false
 ---
 

--- a/docs/03-plugins/removeComments.mdx
+++ b/docs/03-plugins/removeComments.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     preservePatterns:
-      description: An array of regular expressions (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp" target="_blank">RegExp</a> or string). If the comment matches any of these, including partial matches, the comment is preserved. Set to <code>false</code> to disable this behavior and remove comments indiscriminately.
+      description: An array of regular expressions ([RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp) or string). If the comment matches any of these, including partial matches, the comment is preserved. Set to `false` to disable this behavior and remove comments indiscriminately.
       default:
         - '^!'
 ---

--- a/docs/03-plugins/removeDesc.mdx
+++ b/docs/03-plugins/removeDesc.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     removeAny:
-      description: By default, this plugin only removes descriptions that are either empty or contain editor attribution. Enabling this removes the <code>&lt;desc&gt;</code> element indiscriminately.
+      description: By default, this plugin only removes descriptions that are either empty or contain editor attribution. Enabling this removes the `<desc>` element indiscriminately.
       type: boolean
       default: false
 ---

--- a/docs/03-plugins/removeElementsByAttr.mdx
+++ b/docs/03-plugins/removeElementsByAttr.mdx
@@ -7,7 +7,7 @@ svgo:
       description: Remove elements where one of these IDs will be match the element ID.
       default: []
     class:
-      description: Remove elements where the <code>class</code> attribute includes at least one of these classes.
+      description: Remove elements where the `class` attribute includes at least one of these classes.
       default: []
 ---
 

--- a/docs/03-plugins/removeEmptyText.mdx
+++ b/docs/03-plugins/removeEmptyText.mdx
@@ -5,13 +5,13 @@ svgo:
   defaultPlugin: true
   parameters:
     text:
-      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/text" target="_blank"><code>&lt;text&gt;</code></a> elements.
+      description: If to remove empty [`<text>`](https://developer.mozilla.org/docs/Web/SVG/Element/text) elements.
       default: true
     tspan:
-      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tspan" target="_blank"><code>&lt;tspan&gt;</code></a> elements.
+      description: If to remove empty [`<tspan>`](https://developer.mozilla.org/docs/Web/SVG/Element/tspan) elements.
       default: true
     tref:
-      description: If to remove empty <a href="https://developer.mozilla.org/docs/Web/SVG/Element/tref" target="_blank"><code>&lt;tref&gt;</code></a> elements.
+      description: If to remove empty [`<tref>`](https://developer.mozilla.org/docs/Web/SVG/Element/tref) elements.
       default: true
 ---
 

--- a/docs/03-plugins/removeHiddenElems.mdx
+++ b/docs/03-plugins/removeHiddenElems.mdx
@@ -5,49 +5,49 @@ svgo:
   defaultPlugin: true
   parameters:
     isHidden:
-      description: Removes elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/visibility" target="_blank"><code>visibility</code></a> is <code>hidden</code>, unless a child element has <code>visibility</code> set to <code>visible</code>.
+      description: Removes elements where [`visibility`](https://developer.mozilla.org/docs/Web/SVG/Attribute/visibility) is `hidden`, unless a child element has `visibility` set to `visible`.
       default: true
     displayNone:
-      description: Removes elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/display" target="_blank"><code>display</code></a> is <code>none</code>.
+      description: Removes elements where [`display`](https://developer.mozilla.org/docs/Web/SVG/Attribute/display) is `none`.
       default: true
     opacity0:
-      description: Removes element where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/opacity" target="_blank"><code>opacity</code></a> is <code>0</code>.
+      description: Removes element where [`opacity`](https://developer.mozilla.org/docs/Web/SVG/Attribute/opacity) is `0`.
       default: true
     circleR0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/circle" target="_blank"><code>&lt;circle&gt;</code></a> elements with a <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/r" target="_blank">radius</a> of <code>0</code>.
+      description: Removes [`<circle>`](https://developer.mozilla.org/docs/Web/SVG/Element/circle) elements with a [radius](https://developer.mozilla.org/docs/Web/SVG/Attribute/r) of `0`.
       default: true
     ellipseRX0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/ellipse" target="_blank"><code>&lt;ellipse&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/rx" target="_blank"><code>rx</code></a> is <code>0</code>.
+      description: Removes [`<ellipse>`](https://developer.mozilla.org/docs/Web/SVG/Element/ellipse) elements where [`rx`](https://developer.mozilla.org/docs/Web/SVG/Attribute/rx) is `0`.
       default: true
     ellipseRY0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/ellipse" target="_blank"><code>&lt;ellipse&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/ry" target="_blank"><code>ry</code></a> is <code>0</code>.
+      description: Removes [`<ellipse>`](https://developer.mozilla.org/docs/Web/SVG/Element/ellipse) elements where [`ry`](https://developer.mozilla.org/docs/Web/SVG/Attribute/ry) is `0`.
       default: true
     rectWidth0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/rect" target="_blank"><code>&lt;rect&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/width" target="_blank"><code>width</code></a> is <code>0</code>.
+      description: Removes [`<rect>`](https://developer.mozilla.org/docs/Web/SVG/Element/rect) elements where [`width`](https://developer.mozilla.org/docs/Web/SVG/Attribute/width) is `0`.
       default: true
     rectHeight0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/rect" target="_blank"><code>&lt;rect&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/height" target="_blank"><code>height</code></a> is <code>0</code>.
+      description: Removes [`height`](https://developer.mozilla.org/docs/Web/SVG/Element/rect) is `0`.
       default: true
     patternWidth0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/pattern" target="_blank"><code>&lt;pattern&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/width" target="_blank"><code>width</code></a> is <code>0</code>.
+      description: Removes [`width`](https://developer.mozilla.org/docs/Web/SVG/Element/pattern) is `0`.
       default: true
     patternHeight0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/pattern" target="_blank"><code>&lt;pattern&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/width" target="_blank"><code>height</code></a> is <code>0</code>.
+      description: Removes [`height`](https://developer.mozilla.org/docs/Web/SVG/Element/pattern) is `0`.
       default: true
     imageWidth0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/image" target="_blank"><code>&lt;image&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/width" target="_blank"><code>width</code></a> is <code>0</code>.
+      description: Removes [`width`](https://developer.mozilla.org/docs/Web/SVG/Element/image) is `0`.
       default: true
     imageHeight0:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/image" target="_blank"><code>&lt;image&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/width" target="_blank"><code>height</code></a> is <code>0</code>.
+      description: Removes [`height`](https://developer.mozilla.org/docs/Web/SVG/Element/image) is `0`.
       default: true
     pathEmptyD:
-      description: Remove <a href="https://developer.mozilla.org/docs/Web/SVG/Element/path" target="_blank"><code>&lt;path&gt;</code></a> elements where <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/d" target="_blank"><code>d</code></a> is not set or empty. Does not apply for single point paths associated with a <a href="https://developer.mozilla.org/docs/Web/SVG/Element/marker" target="_blank"><code>marker</code></a>.
+      description: Remove [`marker`](https://developer.mozilla.org/docs/Web/SVG/Element/path).
       default: true
     polylineEmptyPoints:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/polyline" target="_blank"><code>&lt;polyline&gt;</code></a> elements with no <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/points" target="_blank">points</a> defined.
+      description: Removes [points](https://developer.mozilla.org/docs/Web/SVG/Element/polyline) defined.
       default: true
     polygonEmptyPoints:
-      description: Removes <a href="https://developer.mozilla.org/docs/Web/SVG/Element/polygon" target="_blank"><code>&lt;polygon&gt;</code></a> elements with no <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/points" target="_blank">points</a> defined.
+      description: Removes [points](https://developer.mozilla.org/docs/Web/SVG/Element/polygon) defined.
       default: true
 ---
 

--- a/docs/03-plugins/removeUnknownsAndDefaults.mdx
+++ b/docs/03-plugins/removeUnknownsAndDefaults.mdx
@@ -14,19 +14,19 @@ svgo:
       description: If to remove attributes that are assigned their default value anyway.
       default: true
     defaultMarkupDeclarations:
-      description: If to remove XML declarations that are assigned their default value. XML declarations are the properties in the <code>&lt;?xml … ?&gt;</code> block at the top of the document.
+      description: If to remove XML declarations that are assigned their default value. XML declarations are the properties in the `<?xml … ?>` block at the top of the document.
       default: true
     uselessOverrides:
       description: If to remove attributes that are being if the same value is being inherited by it's parent element anyway.
       default: true
     keepDataAttrs:
-      description: If to keep <a href="https://developer.mozilla.org/docs/Web/SVG/Attribute/data-*" target="_blank"><code>data-*</code></a> attributes.
+      description: If to keep [`data-*`](https://developer.mozilla.org/docs/Web/SVG/Attribute/data-*) attributes.
       default: true
     keepAriaAttrs:
-      description: If to keep <a href="https://developer.mozilla.org/docs/Web/Accessibility/ARIA" target="_blank">ARIA (Accessible Rich Internet Applications)</a> attributes, used for accessibility. This excludes <code>role</code>, which is managed with the <code>keepRoleAttr</code> parameter.
+      description: If to keep [ARIA (Accessible Rich Internet Applications)](https://developer.mozilla.org/docs/Web/Accessibility/ARIA) attributes, used for accessibility. This excludes `role`, which is managed with the `keepRoleAttr` parameter.
       default: true
     keepRoleAttr:
-      description: If to keep the ARIA <a href="https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Roles" target="_blank"><code>role</code></a> attribute.
+      description: If to keep the ARIA [`role`](https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Roles) attribute.
       default: false
 ---
 

--- a/docs/03-plugins/removeUselessStrokeAndFill.mdx
+++ b/docs/03-plugins/removeUselessStrokeAndFill.mdx
@@ -11,7 +11,7 @@ svgo:
       description: If to remove redundant fills.
       default: true
     removeNone:
-      description: If to remove elements where both the <code>fill</code> and <code>stroke</code> attributes are <code>none</code>.
+      description: If to remove elements where both the `fill` and `stroke` attributes are `none`.
       default: false
 ---
 

--- a/docs/03-plugins/removeXlink.mdx
+++ b/docs/03-plugins/removeXlink.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: removeXlink
   parameters:
     includeLegacy:
-      description: If to update references to XLink in elements that don't support the SVG 2 href attribute, like <code>&lt;filter&gt;</code> and <code>&lt;tref&gt;</code>.
+      description: If to update references to XLink in elements that don't support the SVG 2 href attribute, like `<filter>` and `<tref>`.
       default: false
 ---
 

--- a/docs/03-plugins/sortAttrs.mdx
+++ b/docs/03-plugins/sortAttrs.mdx
@@ -25,7 +25,7 @@ svgo:
         - 'd'
         - 'points'
     xmlnsOrder:
-      description: Set to <code>'front'</code> if XML namespaces should be placed infront of all other attributes.
+      description: Set to `'front'` if XML namespaces should be placed infront of all other attributes.
       default: 'front'
 ---
 


### PR DESCRIPTION
To make maintenance of the documentation more user-friendly, we're adapting the front matter to Markdown at build time in the svgo.dev repository.

This converts all the plugin descriptions, which previously used HTML, to use Markdown instead.