### PR TITLE
docs: minor restructure and rewording

### DIFF
--- a/docs/03-plugins/cleanupListOfValues.mdx
+++ b/docs/03-plugins/cleanupListOfValues.mdx
@@ -17,6 +17,4 @@ svgo:
       default: true
 ---
 
-# Cleanup List of Values
-
 Rounds numeric values in attributes, such as those found in [`viewBox`](https://developer.mozilla.org/docs/Web/SVG/Attribute/viewBox), [`enable-background`](https://developer.mozilla.org/docs/Web/SVG/Attribute/enable-background), and [`points`](https://developer.mozilla.org/docs/Web/SVG/Attribute/points).

--- a/docs/03-plugins/removeEmptyContainers.mdx
+++ b/docs/03-plugins/removeEmptyContainers.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
 ---
 
-Remove container elements in the document that have no children or meaningful attributes.
+Remove container elements in the document that have no children or meaningful attributes, excluding the `<svg>` element which is ignored.
 
 A container, as defined in the [SVG specifications](https://www.w3.org/TR/SVG11/intro.html#TermContainerElement), is an SVG element that can have graphical child elements. Container elements include:
 
@@ -20,5 +20,3 @@ A container, as defined in the [SVG specifications](https://www.w3.org/TR/SVG11/
 - [`<svg>`](https://developer.mozilla.org/docs/Web/SVG/Element/svg)
 - [`<switch>`](https://developer.mozilla.org/docs/Web/SVG/Element/switch)
 - [`<symbol>`](https://developer.mozilla.org/docs/Web/SVG/Element/symbol)
-
-Despite the `<svg>` element being a container element, they are not ignored by this plugin.

--- a/docs/03-plugins/removeXMLNS.mdx
+++ b/docs/03-plugins/removeXMLNS.mdx
@@ -10,7 +10,7 @@ It's recommended to use this plugin if you intend to inline SVGs into an HTML do
 
 :::tip
 
-This plugin pairs well with the [removeXlink](/docs/plugins/removeXlink/) plugin. Remove XLink drops XLink namespaces and migrates references to them to the modern equivalent, supported by SVG 2 and inline an HTML document. When using this, it's recommended to enable Remove XLink too.
+This plugin pairs well with the [removeXlink](/docs/plugins/removeXlink/) plugin, which drops XLink namespaces and migrates references the modern equivalent, supported by SVG 2 and inline an HTML document. When using removeXMLNS, it's recommended to enable removeXlink too.
 
 :::
 


### PR DESCRIPTION
Just a few more chores while going through the documentation.

* cleanupListOfValues was missed when we removed inline titles from each documentation page. This removes the heading.
* For removeEmptyContainers, mention that the `<svg>` is ignored sooner, and correct the wording.
* In removeXMLNS, be explicit instead of using "this", and use consistent plugin names, i.e. `removeXlink`, not `Remove XLink`.