### PR TITLE
[docs] fix transposition of preset-default

### DIFF
--- a/docs/02-preset-default.mdx
+++ b/docs/02-preset-default.mdx
@@ -71,7 +71,7 @@ module.exports = {
 };
 ```
 
-Alternatively, you can also drop `default-preset` entirely, and configure your own plugin pipeline from scratch, with only the desirable plugins:
+Alternatively, you can also drop `preset-default` entirely, and configure your own plugin pipeline from scratch, with only the desirable plugins:
 
 ```js
 module.exports = {


### PR DESCRIPTION
`preset-default` was transposed to `default-preset` in the docs. This PR fixes it.