### PR TITLE
fix(convertColors): accept commaless rgb

### DIFF
--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -6,7 +6,7 @@ export const description =
   'converts colors: rgb() to #rrggbb and #rrggbb to #rgb';
 
 const rNumber = '([+-]?(?:\\d*\\.\\d+|\\d+\\.?)%?)';
-const rComma = '\\s*,\\s*|\\s+';
+const rComma = '(?:\\s*,\\s*|\\s+)';
 const regRGB = new RegExp(
   '^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$',
 );

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -6,7 +6,7 @@ export const description =
   'converts colors: rgb() to #rrggbb and #rrggbb to #rgb';
 
 const rNumber = '([+-]?(?:\\d*\\.\\d+|\\d+\\.?)%?)';
-const rComma = '\\s*,\\s*';
+const rComma = '\\s*,\\s*|\\s*';
 const regRGB = new RegExp(
   '^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$',
 );

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -6,7 +6,7 @@ export const description =
   'converts colors: rgb() to #rrggbb and #rrggbb to #rgb';
 
 const rNumber = '([+-]?(?:\\d*\\.\\d+|\\d+\\.?)%?)';
-const rComma = '\\s*,\\s*|\\s*';
+const rComma = '\\s*,\\s*|\\s+';
 const regRGB = new RegExp(
   '^rgb\\(\\s*' + rNumber + rComma + rNumber + rComma + rNumber + '\\s*\\)$',
 );

--- a/test/plugins/convertColors.01.svg.txt
+++ b/test/plugins/convertColors.01.svg.txt
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
     <g color="black"/>
     <g color="BLACK"/>
+    <path fill="rgb(64 64 64)"/>
     <path fill="rgb(64, 64, 64)"/>
     <path fill="rgb(86.27451%,86.666667%,87.058824%)"/>
     <path fill="rgb(-255,100,500)"/>
@@ -11,6 +12,7 @@
 <svg xmlns="http://www.w3.org/2000/svg">
     <g color="#000"/>
     <g color="#000"/>
+    <path fill="#404040"/>
     <path fill="#404040"/>
     <path fill="#dcddde"/>
     <path fill="#0064ff"/>


### PR DESCRIPTION
Commaless `rgb(0 0 0)` is now allowed by browsers, and using commas is considered [legacy](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb#legacy_syntax_comma-separated_values). This allows the convertColors plugin to parse and convert these colors, even making SVGs more compatible.