### PR TITLE
chore: migrate to upstream sax

### DIFF
--- a/.yarn/patches/sax-npm-1.4.1-503b1923cb.patch
+++ b/.yarn/patches/sax-npm-1.4.1-503b1923cb.patch
@@ -1,0 +1,125 @@
+diff --git a/lib/sax.js b/lib/sax.js
+index 122ad8e5a478339d56fc86d00d21c5d142739f0e..2557c46482ff651026436cc6c7142ebfe68ddfc5 100644
+--- a/lib/sax.js
++++ b/lib/sax.js
+@@ -1,8 +1,6 @@
+ ;(function (sax) { // wrapper for non-node envs
+   sax.parser = function (strict, opt) { return new SAXParser(strict, opt) }
+   sax.SAXParser = SAXParser
+-  sax.SAXStream = SAXStream
+-  sax.createStream = createStream
+ 
+   // When we pass the MAX_BUFFER_LENGTH position, start checking for buffer overruns.
+   // When we check, schedule the next check for MAX_BUFFER_LENGTH - (max(buffer lengths)),
+@@ -164,111 +162,6 @@
+     flush: function () { flushBuffers(this) }
+   }
+ 
+-  var Stream
+-  try {
+-    Stream = require('stream').Stream
+-  } catch (ex) {
+-    Stream = function () {}
+-  }
+-  if (!Stream) Stream = function () {}
+-
+-  var streamWraps = sax.EVENTS.filter(function (ev) {
+-    return ev !== 'error' && ev !== 'end'
+-  })
+-
+-  function createStream (strict, opt) {
+-    return new SAXStream(strict, opt)
+-  }
+-
+-  function SAXStream (strict, opt) {
+-    if (!(this instanceof SAXStream)) {
+-      return new SAXStream(strict, opt)
+-    }
+-
+-    Stream.apply(this)
+-
+-    this._parser = new SAXParser(strict, opt)
+-    this.writable = true
+-    this.readable = true
+-
+-    var me = this
+-
+-    this._parser.onend = function () {
+-      me.emit('end')
+-    }
+-
+-    this._parser.onerror = function (er) {
+-      me.emit('error', er)
+-
+-      // if didn't throw, then means error was handled.
+-      // go ahead and clear error, so we can write again.
+-      me._parser.error = null
+-    }
+-
+-    this._decoder = null
+-
+-    streamWraps.forEach(function (ev) {
+-      Object.defineProperty(me, 'on' + ev, {
+-        get: function () {
+-          return me._parser['on' + ev]
+-        },
+-        set: function (h) {
+-          if (!h) {
+-            me.removeAllListeners(ev)
+-            me._parser['on' + ev] = h
+-            return h
+-          }
+-          me.on(ev, h)
+-        },
+-        enumerable: true,
+-        configurable: false
+-      })
+-    })
+-  }
+-
+-  SAXStream.prototype = Object.create(Stream.prototype, {
+-    constructor: {
+-      value: SAXStream
+-    }
+-  })
+-
+-  SAXStream.prototype.write = function (data) {
+-    if (typeof Buffer === 'function' &&
+-      typeof Buffer.isBuffer === 'function' &&
+-      Buffer.isBuffer(data)) {
+-      if (!this._decoder) {
+-        var SD = require('string_decoder').StringDecoder
+-        this._decoder = new SD('utf8')
+-      }
+-      data = this._decoder.write(data)
+-    }
+-
+-    this._parser.write(data.toString())
+-    this.emit('data', data)
+-    return true
+-  }
+-
+-  SAXStream.prototype.end = function (chunk) {
+-    if (chunk && chunk.length) {
+-      this.write(chunk)
+-    }
+-    this._parser.end()
+-    return true
+-  }
+-
+-  SAXStream.prototype.on = function (ev, handler) {
+-    var me = this
+-    if (!me._parser['on' + ev] && streamWraps.indexOf(ev) !== -1) {
+-      me._parser['on' + ev] = function () {
+-        var args = arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments)
+-        args.splice(0, 0, ev)
+-        me.emit.apply(me, args)
+-      }
+-    }
+-
+-    return Stream.prototype.on.call(me, ev, handler)
+-  }
+-
+   // this really needs to be replaced with character classes.
+   // XML allows all manner of ridiculous numbers and digits.
+   var CDATA = '[CDATA['

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,7 +12,7 @@
  */
 
 // @ts-ignore sax will be replaced with something else later
-import SAX from '@trysound/sax';
+import SAX from 'sax';
 import { textElems } from '../plugins/_collections.js';
 
 class SvgoParserError extends Error {
@@ -80,6 +80,7 @@ const config = {
   lowercase: true,
   xmlns: true,
   position: true,
+  unparsedEntities: true,
 };
 
 /**
@@ -114,9 +115,6 @@ export const parseSvg = (data, from) => {
     current.children.push(node);
   };
 
-  /**
-   * @type {(doctype: string) => void}
-   */
   sax.ondoctype = (doctype) => {
     /**
      * @type {XastDoctype}
@@ -141,9 +139,6 @@ export const parseSvg = (data, from) => {
     }
   };
 
-  /**
-   * @type {(data: { name: string, body: string }) => void}
-   */
   sax.onprocessinginstruction = (data) => {
     /**
      * @type {XastInstruction}
@@ -156,9 +151,6 @@ export const parseSvg = (data, from) => {
     pushToContent(node);
   };
 
-  /**
-   * @type {(comment: string) => void}
-   */
   sax.oncomment = (comment) => {
     /**
      * @type {XastComment}
@@ -170,9 +162,6 @@ export const parseSvg = (data, from) => {
     pushToContent(node);
   };
 
-  /**
-   * @type {(cdata: string) => void}
-   */
   sax.oncdata = (cdata) => {
     /**
      * @type {XastCdata}
@@ -184,9 +173,6 @@ export const parseSvg = (data, from) => {
     pushToContent(node);
   };
 
-  /**
-   * @type {(data: { name: string, attributes: Record<string, { value: string }>}) => void}
-   */
   sax.onopentag = (data) => {
     /**
      * @type {XastElement}
@@ -205,9 +191,6 @@ export const parseSvg = (data, from) => {
     stack.push(element);
   };
 
-  /**
-   * @type {(text: string) => void}
-   */
   sax.ontext = (text) => {
     if (current.type === 'element') {
       // prevent trimming of meaningful whitespace inside textual tags
@@ -238,14 +221,12 @@ export const parseSvg = (data, from) => {
     current = stack[stack.length - 1];
   };
 
-  /**
-   * @type {(e: any) => void}
-   */
   sax.onerror = (e) => {
+    const reason = e.message.split('\n')[0];
     const error = new SvgoParserError(
-      e.reason,
-      e.line + 1,
-      e.column,
+      reason,
+      sax.line + 1,
+      sax.column,
       data,
       from,
     );

--- a/package.json
+++ b/package.json
@@ -101,13 +101,13 @@
     ]
   },
   "dependencies": {
-    "@trysound/sax": "0.2.0",
     "commander": "^7.2.0",
     "css-select": "^5.1.0",
     "css-tree": "^2.3.1",
     "css-what": "^6.1.0",
     "csso": "^5.0.5",
-    "picocolors": "^1.0.0"
+    "picocolors": "^1.0.0",
+    "sax": "^1.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",
@@ -118,6 +118,7 @@
     "@types/csso": "^5.0.4",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.11",
+    "@types/sax": "^1.2.7",
     "cross-env": "^7.0.3",
     "eslint": "^9.3.0",
     "globals": "^14.0.0",
@@ -130,5 +131,8 @@
     "rollup": "^4.17.2",
     "tar-stream": "^3.1.7",
     "typescript": "^5.4.5"
+  },
+  "resolutions": {
+    "sax@^1.4.1": "patch:sax@npm%3A1.4.1#./.yarn/patches/sax-npm-1.4.1-503b1923cb.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,13 +1062,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trysound/sax@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@trysound/sax@npm:0.2.0"
-  checksum: 11226c39b52b391719a2a92e10183e4260d9651f86edced166da1d95f39a0a1eaa470e44d14ac685ccd6d3df7e2002433782872c0feeb260d61e80f21250e65c
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -1190,6 +1183,15 @@ __metadata:
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
   checksum: 61c2cad2499ffc8eab36e3b773945d337d848d3ac6b7b0a87c805ba814bc838ef2f262fc0f109bfd8d2e0898ff8bd80ad1025f9ff64f1f71d3d4294c9f14e5f6
+  languageName: node
+  linkType: hard
+
+"@types/sax@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@types/sax@npm:1.2.7"
+  dependencies:
+    "@types/node": "*"
+  checksum: 7ece5fbb5d9c8fc76ab0de2f99d705edf92f18e701d4f9d9b0647275e32eb65e656c1badf9dfaa12f4e1ff3e250561c8c9cfe79e8b5f33dd1417ac0f1804f6cc
   languageName: node
   linkType: hard
 
@@ -1476,12 +1478,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "braces@npm:3.0.2"
+"braces@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
   dependencies:
-    fill-range: ^7.0.1
-  checksum: e2a8e769a863f3d4ee887b5fe21f63193a891c68b612ddb4b68d82d1b5f3ff9073af066c343e9867a393fe4c2555dcb33e89b937195feb9c1613d259edfcd459
+    fill-range: ^7.1.1
+  checksum: b95aa0b3bd909f6cd1720ffcf031aeaf46154dd88b4da01f9a1d3f7ea866a79eba76a6d01cbc3c422b2ee5cdc39a4f02491058d5df0d7bf6e6a162a832df1f69
   languageName: node
   linkType: hard
 
@@ -2226,12 +2228,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fill-range@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "fill-range@npm:7.0.1"
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
   dependencies:
     to-regex-range: ^5.0.1
-  checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  checksum: b4abfbca3839a3d55e4ae5ec62e131e2e356bf4859ce8480c64c4876100f4df292a63e5bb1618e1d7460282ca2b305653064f01654474aa35c68000980f17798
   languageName: node
   linkType: hard
 
@@ -3458,12 +3460,12 @@ __metadata:
   linkType: hard
 
 "micromatch@npm:^4.0.4":
-  version: 4.0.5
-  resolution: "micromatch@npm:4.0.5"
+  version: 4.0.7
+  resolution: "micromatch@npm:4.0.7"
   dependencies:
-    braces: ^3.0.2
+    braces: ^3.0.3
     picomatch: ^2.3.1
-  checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
+  checksum: 3cde047d70ad80cf60c787b77198d680db3b8c25b23feb01de5e2652205d9c19f43bd81882f69a0fd1f0cde6a7a122d774998aad3271ddb1b8accf8a0f480cf7
   languageName: node
   linkType: hard
 
@@ -4186,6 +4188,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:1.4.1":
+  version: 1.4.1
+  resolution: "sax@npm:1.4.1"
+  checksum: 3ad64df16b743f0f2eb7c38ced9692a6d924f1cd07bbe45c39576c2cf50de8290d9d04e7b2228f924c7d05fecc4ec5cf651423278e0c7b63d260c387ef3af84a
+  languageName: node
+  linkType: hard
+
+"sax@patch:sax@npm%3A1.4.1#./.yarn/patches/sax-npm-1.4.1-503b1923cb.patch::locator=svgo%40workspace%3A.":
+  version: 1.4.1
+  resolution: "sax@patch:sax@npm%3A1.4.1#./.yarn/patches/sax-npm-1.4.1-503b1923cb.patch::version=1.4.1&hash=ad106d&locator=svgo%40workspace%3A."
+  checksum: 511be280ca9f1d474466aa165a7e6b50fc70e2de2f263462f60358a9f0661cf36c8f334234813e438d61676374e7aa551a6c81bcecb763e3d3914e2f627a8a51
+  languageName: node
+  linkType: hard
+
 "semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -4485,11 +4501,11 @@ __metadata:
     "@rollup/plugin-commonjs": ^25.0.7
     "@rollup/plugin-node-resolve": ^15.2.3
     "@rollup/plugin-terser": ^0.4.4
-    "@trysound/sax": 0.2.0
     "@types/css-tree": ^2.3.7
     "@types/csso": ^5.0.4
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.11
+    "@types/sax": ^1.2.7
     commander: ^7.2.0
     cross-env: ^7.0.3
     css-select: ^5.1.0
@@ -4506,6 +4522,7 @@ __metadata:
     prettier: ^3.2.5
     rimraf: ^5.0.7
     rollup: ^4.17.2
+    sax: ^1.4.1
     tar-stream: ^3.1.7
     typescript: ^5.4.5
   bin:


### PR DESCRIPTION
Migrates from our [~~maintained~~ unmaintained fork of sax-js](https://github.com/svg/sax) to [upstream](https://github.com/isaacs/sax-js).

While sax-js is not actively maintained, it has received some updates which has allowed it to catch up with our fork, and has more bug fixes in it. I've also made contributions to sax-js myself to get here.

* https://github.com/isaacs/sax-js/pull/266
* https://github.com/isaacs/sax-js/pull/267
* https://github.com/isaacs/sax-js/pull/268
* https://github.com/isaacs/sax-js/pull/272

There is one change we needed that was not merged upstream, but instead we apply a patch via Yarn in this repository. This is acceptable in this case as the change only impacts the browser bundle, which is our job to generate, and contains the change to `lib/sax.js` in the following commit:

* https://github.com/svg/sax/commit/ef73722fe727de166b3e9ec14a8234b81a7f68df

## Related

* Fixes https://github.com/svg/svgo/issues/879
* Closes https://github.com/svg/svgo/pull/1301 (supersedes)
* https://github.com/svg/svgo/issues/678 - Sax has a new option which allows us to support unquoted attributes while in strict mode. I'm just not certain if we want to use this option, or if we should continue to throw errors in this case. Feedback welcome!