### PR TITLE
chore: export default and named packages

### DIFF
--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -1,6 +1,6 @@
-import { Config, optimize } from './svgo';
+import { VERSION, Config, optimize } from './svgo';
 
-export { optimize };
+export { VERSION, optimize };
 
 /**
  * If you write a tool on top of svgo you might need a way to load svgo config.

--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -74,3 +74,9 @@ export const optimize = (input, config) => {
     },
   });
 };
+
+export default {
+  VERSION,
+  loadConfig,
+  optimize,
+};

--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -100,3 +100,8 @@ export const optimize = (input, config) => {
     data: output,
   };
 };
+
+export default {
+  VERSION,
+  optimize,
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,6 +39,7 @@ export default [
     output: {
       file: './dist/svgo-node.cjs',
       format: 'cjs',
+      exports: 'named',
     },
     external: ['os', 'fs', 'url', 'path', ...Object.keys(PKG.dependencies)],
     onwarn(warning) {


### PR DESCRIPTION
Makes two minor changes.

1. Include `VERSION` in the type definition, this was missed before.
2. Make it so SVGO exports both default and named exports.

For more context on exports, this ensures a more consistent API between CJS and ESM, see the following:

```js
// default.mjs
import SVGO from 'svgo'; // not possible before
console.log(SVGO.VERSION); // 4.0.0-rc-1

// destruct.mjs
import { VERSION } from 'svgo';
console.log(VERSION);  // 4.0.0-rc-1

// default.cjs
const SVGO = require('svgo');
console.log(SVGO.VERSION);  // 4.0.0-rc-1

// destruct.cjs
const { VERSION } = require('svgo');
console.log(VERSION); // 4.0.0-rc-1

// browser.mjs
import SVGO from 'svgo/browser';
console.log(SVGO.VERSION); // 4.0.0-rc-1
```