### PR TITLE
chores: amend version strings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,8 +25,8 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
 
-- SVGO Version [e.g. 2.0.3]
-- NodeJs Version [e.g 14.0.4]
+- SVGO Version [e.g. 3.3.2]
+- NodeJs Version [e.g 16.16.0]
 - OS: [e.g. iOS]
 
 **Additional context**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ See: [SECURITY.md](./SECURITY.md)
 ### Requirements
 
 - [Git](https://git-scm.com/)
-- [Node.js 14](https://nodejs.org/) or later
+- [Node.js 20](https://nodejs.org/) or later
 
 ### Getting Started
 

--- a/docs/01-index.mdx
+++ b/docs/01-index.mdx
@@ -11,7 +11,7 @@ SVG files, especially those exported from vector editors, usually contain a lot 
 
 ### System Requirements
 
-- [Node.js 14](https://nodejs.org/) or later
+- [Node.js 16](https://nodejs.org/) or later
 
 <Tabs>
   <TabItem value="npm" label="npm" default>


### PR DESCRIPTION
Trivial PR that amends version strings in the documentation.

* In the bug report template, to use more recent versions as placeholders.
* In CONTRIBUTING.md, it has the wrong version before. Node v20 is needed to contribute.
* In docs/01-index.mdx, to reflect that we dropped support for v14 in https://github.com/svg/svgo/pull/2002