### PR TITLE
chore: enable more coverage reporters

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
   "jest": {
     "coveragePathIgnorePatterns": [
       "fixtures"
+    ],
+    "coverageReporters": [
+      "html",
+      "lcov",
+      "text"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
This makes it easy to see the HTML report with all the info