### PR TITLE
chore(ci): add Node.js 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
           - 16


### PR DESCRIPTION
The matrix is getting a little big but better test everything. We could probably just test Node.js 16 on Ubuntu to save some time, or exclude some things. Let me know if you have any suggestions.