### PR TITLE
chore: freeze plugin arrays

### DIFF
--- a/lib/builtin.js
+++ b/lib/builtin.js
@@ -53,7 +53,7 @@ import * as reusePaths from '../plugins/reusePaths.js';
 import * as sortAttrs from '../plugins/sortAttrs.js';
 import * as sortDefsChildren from '../plugins/sortDefsChildren.js';
 
-export const builtin = [
+export const builtin = Object.freeze([
   presetDefault,
   addAttributesToSVGElement,
   addClassesToSVGElement,
@@ -70,9 +70,9 @@ export const builtin = [
   convertShapeToPath,
   convertStyleToAttrs,
   convertTransform,
-  mergeStyles,
   inlineStyles,
   mergePaths,
+  mergeStyles,
   minifyStyles,
   moveElemsAttrsToGroup,
   moveGroupAttrsToElems,
@@ -108,4 +108,4 @@ export const builtin = [
   reusePaths,
   sortAttrs,
   sortDefsChildren,
-];
+]);

--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -34,21 +34,26 @@ type BuiltinPlugin<Name, Params> = {
   fn: Plugin<Params>;
 };
 
+type BuiltinPluginOrPreset<Name, Params> = BuiltinPlugin<Name, Params> & {
+  /** If the plugin is itself a preset that invokes other plugins. */
+  isPreset: true | undefined;
+  /**
+   * If the plugin is a preset that invokes other plugins, this returns an
+   * array of the plugins in the preset in the order that they are invoked.
+   */
+  plugins?: Readonly<BuiltinPlugin<unknown, unknown>[]>;
+};
+
 /**
  * Plugins that are bundled with SVGO. This includes plugin presets, and plugins
  * that are not enabled by default.
  */
 export declare const builtinPlugins: Array<
   {
-    [Name in keyof PluginsParams]: BuiltinPlugin<Name, PluginsParams[Name]> & {
-      /** If the plugin is itself a preset that invokes other plugins. */
-      isPreset: true | undefined;
-      /**
-       * If the plugin is a preset that invokes other plugins, this returns an
-       * array of the plugins in the preset in the order that they are invoked.
-       */
-      plugins?: BuiltinPlugin<unknown, unknown>[];
-    };
+    [Name in keyof PluginsParams]: BuiltinPluginOrPreset<
+      Name,
+      PluginsParams[Name]
+    >;
   }[keyof PluginsParams]
 >;
 

--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -529,7 +529,6 @@ function checkWriteFileError(input, output, data, error) {
 /** Show list of available plugins with short description. */
 function showAvailablePlugins() {
   const list = builtin
-    .sort((a, b) => a.name.localeCompare(b.name))
     .map((plugin) => ` [ ${colors.green(plugin.name)} ] ${plugin.description}`)
     .join('\n');
   console.log('Currently available plugins:\n' + list);

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -1,6 +1,11 @@
 import { visit } from '../xast.js';
 
 /**
+ * @typedef {import('../svgo').BuiltinPlugin<?, ?>} BuiltinPlugin
+ * @typedef {import('../svgo').BuiltinPluginOrPreset<?, ?>} BuiltinPreset
+ */
+
+/**
  * Plugins engine.
  *
  * @module plugins
@@ -31,11 +36,15 @@ export const invokePlugins = (
   }
 };
 
+/**
+ * @param {{ name: string, plugins: BuiltinPlugin[] }} arg0
+ * @returns {BuiltinPreset}
+ */
 export const createPreset = ({ name, plugins }) => {
   return {
     name,
     isPreset: true,
-    plugins,
+    plugins: Object.freeze(plugins),
     fn: (ast, params, info) => {
       const { floatPrecision, overrides } = params;
       const globalOverrides = {};


### PR DESCRIPTION
Call `Object.freeze` on `builtinPlugins` and the `plugins` property of presets, so the arrays/pipelines can not be modified from outside the package.