### PR TITLE
fix: plugins typescript import

### DIFF
--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -1,6 +1,6 @@
-import { Config } from './svgo';
+import { Config } from './svgo.d';
 
-export * from './svgo';
+export * from './svgo.d';
 
 /**
  * If you write a tool on top of svgo you might need a way to load svgo config.

--- a/lib/svgo-node.d.ts
+++ b/lib/svgo-node.d.ts
@@ -1,6 +1,6 @@
-import { Config } from './svgo.d';
+import type { Config } from './svgo.d.ts';
 
-export * from './svgo.d';
+export type * from './svgo.d.ts';
 
 /**
  * If you write a tool on top of svgo you might need a way to load svgo config.


### PR DESCRIPTION
Hi, tried to upgrade to v4.0 rc, seems like typescript dont see the `svgo.d.ts` import.
![CleanShot 2024-06-09 at 21 26 09@2x](https://github.com/svg/svgo/assets/5851280/178fdb1e-d3cb-49ee-aac2-5ad3717f4254)

Work if changed to:
```ts
import type { Config } from './svgo.d.ts';

export type * from './svgo.d.ts';
```

My tsconfig:
```json
{
    "compilerOptions": {
      "esModuleInterop": true,
      "skipLibCheck": true,
      "target": "es2022",
      "allowJs": true,
      "resolveJsonModule": true,
      "moduleDetection": "force",
      "isolatedModules": true,
      "verbatimModuleSyntax": true,
      "strict": false,
      "noUncheckedIndexedAccess": true,
      "noImplicitOverride": true,
      "module": "NodeNext",
      "sourceMap": true,
      "lib": ["es2022"],
      "outDir": "dist"
    }
  }
```

Is something wrong on my end or it should be explicit imported?