### PR TITLE
fix: add alias of removeScriptElement to removeScripts

### DIFF
--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -5,15 +5,34 @@ import { invokePlugins } from './svgo/plugins.js';
 import { encodeSVGDatauri } from './svgo/tools.js';
 import { VERSION } from './version.js';
 
-const pluginsMap = {};
+/**
+ * @typedef {import('./svgo.js').BuiltinPluginOrPreset<?, ?>} BuiltinPluginOrPreset
+ */
+
+const pluginsMap = new Map();
 for (const plugin of builtin) {
-  pluginsMap[plugin.name] = plugin;
+  pluginsMap.set(plugin.name, plugin);
+}
+
+/**
+ * @param {string} name
+ * @returns {BuiltinPluginOrPreset}
+ */
+function getPlugin(name) {
+  if (name === 'removeScriptElement') {
+    console.warn(
+      'Warning: removeScriptElement has been renamed to removeScripts, please update your SVGO config',
+    );
+    return pluginsMap.get('removeScripts');
+  }
+
+  return pluginsMap.get(name);
 }
 
 const resolvePluginConfig = (plugin) => {
   if (typeof plugin === 'string') {
     // resolve builtin plugin specified as string
-    const builtinPlugin = pluginsMap[plugin];
+    const builtinPlugin = getPlugin(plugin);
     if (builtinPlugin == null) {
       throw Error(`Unknown builtin plugin "${plugin}" specified.`);
     }
@@ -25,13 +44,13 @@ const resolvePluginConfig = (plugin) => {
   }
   if (typeof plugin === 'object' && plugin != null) {
     if (plugin.name == null) {
-      throw Error(`Plugin name should be specified`);
+      throw Error(`Plugin name must be specified`);
     }
     // use custom plugin implementation
     let fn = plugin.fn;
     if (fn == null) {
       // resolve builtin plugin implementation
-      const builtinPlugin = pluginsMap[plugin.name];
+      const builtinPlugin = getPlugin(plugin.name);
       if (builtinPlugin == null) {
         throw Error(`Unknown builtin plugin "${plugin.name}" specified.`);
       }

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,2 +1,2 @@
 /** Version of SVGO. */
-export const VERSION = '4.0.0-rc.0';
+export const VERSION = '4.0.0-rc.1';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@3.8.2",
   "name": "svgo",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0-rc.1",
   "description": "SVGO is a Node.js library and command-line application for optimizing vector images.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Adds an alias to convert `removeScriptElement` to `removeScripts`.

This makes it, so this is less likely to be a breaking change for downstream projects.

The changes to our default plugins are less of an issue because redundant `overrides` don't throw errors, and most downstream projects disabled `removeTitle` and `removeViewBox` already anyway, so that change isn't going to be breaking for them at all.

However, the rename of `removeScriptElement` would produce a fatal crash if an end-user had that in their config for a downstream project. So instead, let's alias it so projects like SVGR, ipx, Docusaurus etc, can upgrade to SVGO v4 without having to increment their major version.