### PR TITLE
chore: use concrete types for generics

### DIFF
--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -41,7 +41,7 @@ type BuiltinPluginOrPreset<Name, Params> = BuiltinPlugin<Name, Params> & {
    * If the plugin is a preset that invokes other plugins, this returns an
    * array of the plugins in the preset in the order that they are invoked.
    */
-  plugins?: Readonly<BuiltinPlugin<unknown, unknown>[]>;
+  plugins?: Readonly<BuiltinPlugin<string, Object>[]>;
 };
 
 /**

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -1,7 +1,7 @@
 import { visit } from '../xast.js';
 
 /**
- * @typedef {import('../svgo').BuiltinPlugin<?, ?>} BuiltinPlugin
+ * @typedef {import('../svgo').BuiltinPlugin<string, Object>} BuiltinPlugin
  * @typedef {import('../svgo').BuiltinPluginOrPreset<?, ?>} BuiltinPreset
  */
 


### PR DESCRIPTION
While consuming the types downstream, it was unhelpful to have `unknown` instead of a more concrete type like `string`. That was a mistake on my part when initially writing it.

I used `unknown` because we don't know what plugin it is, but we do certainly know it has to be a `string` and `object` in any case, so that's more appropriate.