### PR TITLE
fix: don't insert 0 at start or end of attribute if whitespace

### DIFF
--- a/docs/03-plugins/cleanupNumericValues.mdx
+++ b/docs/03-plugins/cleanupNumericValues.mdx
@@ -18,4 +18,4 @@ svgo:
       default: true
 ---
 
-Rounds numeric values, and removes the unit when it's `px` as this is the default.
+Rounds numeric values, removes the unit when it's `px` as this is the default, and removes redundant spaces around and between numbers.

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -39,6 +39,7 @@ export const fn = (_root, params) => {
         if (node.attributes.viewBox != null) {
           const nums = node.attributes.viewBox.split(/\s,?\s*|,\s*/g);
           node.attributes.viewBox = nums
+            .filter((value) => value.length != 0)
             .map((value) => {
               const num = Number(value);
               return Number.isNaN(num)
@@ -54,7 +55,7 @@ export const fn = (_root, params) => {
             continue;
           }
 
-          const match = value.match(regNumericValues);
+          const match = regNumericValues.exec(value);
 
           // if attribute value matches regNumericValues
           if (match) {

--- a/test/plugins/cleanupNumericValues.03.svg.txt
+++ b/test/plugins/cleanupNumericValues.03.svg.txt
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox=" 0 0      150 100 "/>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 100"/>


### PR DESCRIPTION
### Docs

Updates the documentation to clarify explicitly that the plugin impacts whitespace. Internally, it's because we parse all numbers in the attribute into an array, then rewrite it back.

### Bug Fix

I also fix a bug that I discovered while testing the issue reported. When an attribute like `"  0   0  150 100  "` comes up, SVGO inserts a `0` to the start and end of the attribute, completely changing the meaning.

This was because when we do the split, the array we get back starts with an empty string and ends with an empty string, which were then converted to `0`, resulting in `"0 0 0 150 100 0"` instead of `"0 0 150 100"`.

```js
seth@seth-pc-tux:~$ node
Welcome to Node.js v20.11.0.
Type ".help" for more information.
> Number("")
0
```

Now we filter them out before parsing.

### Performance

Just applying a recommendation from SonarLint, use `RegExp#exec` instead of `String#match`. 

### Related

* Closes https://github.com/svg/svgo/issues/1968