### PR TITLE
chore(addAttributesToSVGElement): fix typoes in docs

### DIFF
--- a/docs/03-plugins/addAttributesToSVGElement.mdx
+++ b/docs/03-plugins/addAttributesToSVGElement.mdx
@@ -4,7 +4,7 @@ svgo:
   pluginId: addAttributesToSVGElement
   parameters:
     attributes:
-      description: Attributes to add to the `<svg>` element. If key/value pairs are passed, the attributes and added with the paired value. If an array is passed, attributes are added with no key associated with them.
+      description: Attributes to add to the `<svg>` element. If key/value pairs are passed, the attributes are added with the paired value. If an array is passed, attributes are added with no key associated with them.
       default: null
     attribute:
 ---

--- a/plugins/addAttributesToSVGElement.js
+++ b/plugins/addAttributesToSVGElement.js
@@ -41,7 +41,7 @@ plugins: [
 `;
 
 /**
- * Add attributes to an outer <svg> element. Example config:
+ * Add attributes to an outer <svg> element.
  *
  * @author April Arcus
  *


### PR DESCRIPTION
Trivial PR that fixes a typo in addAttributesToSVGElement, and removes some redundant words from the JS Doc of the plugin.