### PR TITLE
refactor: dont covert to charcode in iswhitespace

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -3,6 +3,7 @@ import { removeLeadingZero, toFixed } from './svgo/tools.js';
 /**
  * @typedef {import('./types.js').PathDataItem} PathDataItem
  * @typedef {import('./types.js').PathDataCommand} PathDataCommand
+ * @typedef {'none' | 'sign' | 'whole' | 'decimal_point' | 'decimal' | 'e' | 'exponent_sign' | 'exponent'} ReadNumberState
  */
 
 // Based on https://www.w3.org/TR/SVG11/paths.html#PathDataBNF
@@ -38,20 +39,16 @@ const isCommand = (c) => {
 };
 
 /**
- * @type {(c: string) => boolean}
+ * @param {string} c
+ * @returns {boolean}
  */
-const isWsp = (c) => {
-  const codePoint = c.codePointAt(0);
-  return (
-    codePoint === 0x20 ||
-    codePoint === 0x9 ||
-    codePoint === 0xd ||
-    codePoint === 0xa
-  );
+const isWhiteSpace = (c) => {
+  return c === ' ' || c === '\t' || c === '\r' || c === '\n';
 };
 
 /**
- * @type {(c: string) => boolean}
+ * @param {string} c
+ * @returns {boolean}
  */
 const isDigit = (c) => {
   const codePoint = c.codePointAt(0);
@@ -60,10 +57,6 @@ const isDigit = (c) => {
   }
   return 48 <= codePoint && codePoint <= 57;
 };
-
-/**
- * @typedef {'none' | 'sign' | 'whole' | 'decimal_point' | 'decimal' | 'e' | 'exponent_sign' | 'exponent'} ReadNumberState
- */
 
 /**
  * @type {(string: string, cursor: number) => [number, ?number]}
@@ -133,7 +126,8 @@ const readNumber = (string, cursor) => {
 };
 
 /**
- * @type {(string: string) => PathDataItem[]}
+ * @param {string} string
+ * @returns {PathDataItem[]}
  */
 export const parsePathData = (string) => {
   /**
@@ -150,7 +144,7 @@ export const parsePathData = (string) => {
   let hadComma = false;
   for (let i = 0; i < string.length; i += 1) {
     const c = string.charAt(i);
-    if (isWsp(c)) {
+    if (isWhiteSpace(c)) {
       continue;
     }
     // allow comma only between arguments
@@ -170,11 +164,9 @@ export const parsePathData = (string) => {
         if (c !== 'M' && c !== 'm') {
           return pathData;
         }
-      } else {
+      } else if (args.length !== 0) {
         // stop if previous command arguments are not flushed
-        if (args.length !== 0) {
-          return pathData;
-        }
+        return pathData;
       }
       command = c;
       args = [];


### PR DESCRIPTION
While looking through `path.js`, I noticed we had a `isWsp` function, which wasn't immediately obvious was an abbreviation for `isWhiteSpace`. So I renamed it to `isWhiteSpace` so it's obvious what it's doing.

From there, since we're stepping through a string char by char before calling the function, it's redundant to call `codePointAt` when we can just compare the string immediately. This is both faster and more readable for maintainers.

Finally, I just apply a proposal from SonarLint to replace an `else { if () }` with `else if ()`.

## Benchmark

```js
const Benchmark = require('benchmark');
const suite = new Benchmark.Suite;

const data = [
  '0', // false
  '1', // false
  '-', // false
  '.', // false
  ' ', // true
  '\t', // true
  '\n', // true
  '\r', // true
  ' ', // false (technically true, but we didn't accept it before so false)
]

const isWhiteSpaceV1 = (c) => {
  const codePoint = c.codePointAt(0);
  return (
    codePoint === 0x20 ||
    codePoint === 0x9 ||
    codePoint === 0xd ||
    codePoint === 0xa
  );
};

const isWhiteSpaceV2 = (c) => {
  return (
    c === ' ' ||
    c === '\t' ||
    c === '\r' ||
    c === '\n'
  );
};

const set = new Set([' ', '\t', '\r', '\n']);
const isWhiteSpaceV3 = (c) => {
  return set.has(c);
};

suite.add('v1', () => {
  data.map((d) => isWhiteSpaceV1(d));
})
.add('v2', () => {
  data.map((d) => isWhiteSpaceV2(d));
})
.add('v3', () => {
  data.map((d) => isWhiteSpaceV3(d));
})
.on('cycle', (event) => {
  console.log(String(event.target));
})
.on('complete', function() {
  console.log('Fastest is ' + this.filter('fastest').map('name'));
})
.run({ 'async': true });
```

```
v1 x 28,871,343 ops/sec ±0.98% (86 runs sampled)
v2 x 50,999,166 ops/sec ±1.33% (90 runs sampled)
v3 x 15,390,647 ops/sec ±0.76% (96 runs sampled)
Fastest is v2
```

The impact of this change on our regression tests is negligible and within margin of error, but the code is cleaner imo, so I'm running with it.

Previous runs from other pull requests:
* [16 minutes 57 seconds](https://github.com/svg/svgo/actions/runs/9531414965/job/26272356980#step:6:12)
* [20 minutes 33 seconds](https://github.com/svg/svgo/actions/runs/9521968437/job/26250674752#step:6:12)
* [16 minutes 46 seconds](https://github.com/svg/svgo/actions/runs/9515327606/job/26229457023#step:6:12)
* [16 minutes 59 seconds](https://github.com/svg/svgo/actions/runs/9501690801/job/26188065659#step:6:12)  

This run: [16 minutes 43 seconds](https://github.com/svg/svgo/actions/runs/9535659283/job/26281685527?pr=2039#step:6:12)