### PR TITLE
refactor(cleanupNumericValues): improve how viewbox is split

### DIFF
--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -37,9 +37,10 @@ export const fn = (_root, params) => {
     element: {
       enter: (node) => {
         if (node.attributes.viewBox != null) {
-          const nums = node.attributes.viewBox.split(/\s,?\s*|,\s*/g);
+          const nums = node.attributes.viewBox.split(
+            /\b(?:\s+,?|\s*,)\s*(?=\S)/g,
+          );
           node.attributes.viewBox = nums
-            .filter((value) => value.length != 0)
             .map((value) => {
               const num = Number(value);
               return Number.isNaN(num)


### PR DESCRIPTION
After fixing a bug in cleanupNumericValues, a comment proposed that we handle this slightly differently.

This is a minor refactor/optimization of cleanupNumericValues. The idea is that if we're going to use a regular expression anyway, we might as well get the regex to do all the work to avoid filtering later.

```js
const data = [
  '0 0 100 100',
  ' 0 0 100 100 ',
  '  0  0  100  100  ',
  ' 0  0  0.5  .5 ',
  '20.000001 -19.99999 17.123456 70.708090',
];

const splitV1 = (viewbox) => {
  return viewbox.split(/\s,?\s*|,\s*/g).filter(v => v.length != 0);
};
// v1 x 1,771,127 ops/sec ±0.49% (98 runs sampled)

const splitV5 = (viewbox) => {
  return viewbox.split(/\b(?:\s+,?|\s*,)\s*(?=\S)/g);
};
// v6 x 1,873,086 ops/sec ±0.39% (100 runs sampled)
```

## Related

* Improvement proposed in https://github.com/svg/svgo/pull/2036#discussion_r1649415777