### PR TITLE
chore(removeScripts): remove redundant regex pattern

### DIFF
--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -52,7 +52,7 @@ export const fn = () => {
 
             const index = parentNode.children.indexOf(node);
             const usefulChildren = node.children.filter(
-              (child) => !(child.type === 'text' && /\s*/.test(child.value)),
+              (child) => child.type !== 'text',
             );
             parentNode.children.splice(index, 1, ...usefulChildren);
 


### PR DESCRIPTION
CodeQL picked up a redundant regular expression we had in removeScripts. This just removes it since it functionally changes nothing.