### PR TITLE
refactor(cleanupNumbericValues): improve how viewbox is split

### DIFF
--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -37,9 +37,8 @@ export const fn = (_root, params) => {
     element: {
       enter: (node) => {
         if (node.attributes.viewBox != null) {
-          const nums = node.attributes.viewBox.split(/\s,?\s*|,\s*/g);
+          const nums = node.attributes.viewBox.trim().split(/(?:\s,?|,)\s*/g);
           node.attributes.viewBox = nums
-            .filter((value) => value.length != 0)
             .map((value) => {
               const num = Number(value);
               return Number.isNaN(num)


### PR DESCRIPTION
1. Uses trim on the string instead of iterating the results after splitting.
2. Reduces duplicate matching in the regex pattern. 

The performance difference is minor, but measurable:

```js
const data = [
  '0 0 120 120',
  '0 0 230 120',
  '110 0 120 120',
  '0 0 200.28423 200.28423',
  '20.000001 -19.99999 17.123456 70.708090',
  ' 0 0      150 100 ',
  '  0  0  0.5  .5  ',
];

function splitAndFilter(viewbox) {
  return viewbox
    .split(/(?:\s,?|,)\s*/g)
    .filter(v => v.length != 0)
    .map(Number);
};
// split and filter x 566,854 ops/sec ±0.58% (95 runs sampled)

function trimAndSplit(viewbox) {
  return viewbox
    .trim()
    .split(/(?:\s,?|,)\s*/g)
    .map(Number);
};
// trim and split x 583,812 ops/sec ±0.56% (96 runs sampled)
```

### Related

* Alternate solution for https://github.com/svg/svgo/pull/2036
* Based on conversation https://github.com/svg/svgo/pull/2036#discussion_r1649415777