### PR TITLE
fix: Remove unused <use> elements when deleting empty symbols (issue 1765).

### DIFF
--- a/test/plugins/removeEmptyContainers.07.svg.txt
+++ b/test/plugins/removeEmptyContainers.07.svg.txt
@@ -1,0 +1,31 @@
+If a container with an id attribute is removed, remove any <use>s associated with the id.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+    <symbol id="a">
+        <path d="M 10 10 H 90" style="stroke:black;stroke-width:2"/>
+    </symbol>
+    <symbol id="b">
+        <path d="M 10 20 H 90"/>
+    </symbol>
+    <symbol id="c"/>
+    <symbol id="d"/>
+    <use xlink:href="#a"/>
+    <use href="#b" style="stroke:red;stroke-width:2"/>
+    <use xlink:href="#c"/>
+    <use href="#d" style="stroke:red;stroke-width:2"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+    <symbol id="a">
+        <path d="M 10 10 H 90" style="stroke:black;stroke-width:2"/>
+    </symbol>
+    <symbol id="b">
+        <path d="M 10 20 H 90"/>
+    </symbol>
+    <use xlink:href="#a"/>
+    <use href="#b" style="stroke:red;stroke-width:2"/>
+</svg>


### PR DESCRIPTION
When removeEmptyContainers removes a symbol referenced by `<use>`, the stray `<use>`s were being left in the SVG, though they no longer reference a valid element. This PR modifies removeEmptyContainers to also remove the dangling `<use>` elements.

Closes #1765, closes #1618, closes #1194.