### PR TITLE
Removed call to encodeSVGDatauri() from coa.js and added test case.

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import colors from 'picocolors';
 import { fileURLToPath } from 'url';
-import { encodeSVGDatauri, decodeSVGDatauri } from './tools.js';
+import { decodeSVGDatauri } from './tools.js';
 import { loadConfig, optimize } from '../svgo-node.js';
 import { builtin } from '../builtin.js';
 
@@ -407,9 +407,6 @@ function processSVGData(config, info, data, output, input) {
     } else {
       throw error;
     }
-  }
-  if (config.datauri) {
-    result.data = encodeSVGDatauri(result.data, config.datauri);
   }
   var resultFileSize = Buffer.byteLength(result.data, 'utf8'),
     processingTime = Date.now() - startTime;

--- a/test/coa/_index.test.js
+++ b/test/coa/_index.test.js
@@ -15,13 +15,16 @@ const svgFiles = [
 const tempFolder = 'temp';
 const noop = () => {};
 
+/**
+ * @param {string[]} args
+ */
 function runProgram(args) {
   const program = new Command();
   svgo(program);
   // prevent running process.exit
   program.exitOverride(() => {});
   // parser skips first two arguments
-  return program.parseAsync([0, 1, ...args]);
+  return program.parseAsync(['0', '1', ...args]);
 }
 
 describe('coa', function () {
@@ -46,6 +49,10 @@ describe('coa', function () {
     global.process.exit = initialProcessExit;
   }
 
+  /**
+   * @param {string} folderPath
+   * @returns {number}
+   */
   function calcFolderSvgWeight(folderPath) {
     return fs
       .readdirSync(folderPath)
@@ -61,6 +68,23 @@ describe('coa', function () {
         0,
       );
   }
+
+  it('should generate correct datauri', async () => {
+    const outfilePath = tempFolder + '/test.svg';
+    await runProgram([
+      '-i',
+      path.resolve(__dirname, 'testSvgDatauri') + '/test.svg',
+      '-o',
+      outfilePath,
+      '--datauri',
+      'enc',
+      '--quiet',
+    ]);
+    const outData = fs.readFileSync(outfilePath, 'utf8');
+    expect(outData).toBe(
+      'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctext%20x%3D%225%22%20y%3D%2215%22%3ETEST%3C%2Ftext%3E%3C%2Fsvg%3E',
+    );
+  });
 
   it('should optimize folder', async () => {
     const initWeight = calcFolderSvgWeight(svgFolderPath);

--- a/test/coa/testSvgDatauri/test.svg
+++ b/test/coa/testSvgDatauri/test.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <text x="5" y="15">TEST</text>
+</svg>


### PR DESCRIPTION
encodeSVGDatauri() is called within the optimize() function, but was being called a second time in coa.js when SVGO was run from the command line, giving a doubly-encoded, incorrect result.

This PR removes the call from coa.js and adds a test case.

Resolves #2048.