### PR TITLE
Ignore malformed style attributes in minifyStyles.

### DIFF
--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -129,9 +129,13 @@ export const fn = (_root, { usage, ...params }) => {
         for (const node of elementsWithStyleAttributes) {
           // style attribute
           const elemStyle = node.attributes.style;
-          node.attributes.style = csso.minifyBlock(elemStyle, {
-            ...params,
-          }).css;
+          try {
+            node.attributes.style = csso.minifyBlock(elemStyle, {
+              ...params,
+            }).css;
+          } catch {
+            /** ignore style syntax errors */
+          }
         }
       },
     },

--- a/test/plugins/minifyStyles.12.svg.txt
+++ b/test/plugins/minifyStyles.12.svg.txt
@@ -1,0 +1,13 @@
+Ensure plugin works with syntactically incorrect style attributes.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 225 425">
+    <path style="fill- opacity:0.5" d="M0 50 l50 50 0 20z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 225 425">
+    <path style="fill- opacity:0.5" d="M0 50 l50 50 0 20z"/>
+</svg>


### PR DESCRIPTION
If a style attribute contains malformed styles, csso.minifyBlock() may throw an exception. This PR changes the code to catch the exception and leave the style value unchanged.

Resolves #1863.