### PR TITLE
Disable inline styles by default if CSS at rules are present.

### DIFF
--- a/plugins/plugins-types.d.ts
+++ b/plugins/plugins-types.d.ts
@@ -77,6 +77,8 @@ type DefaultPlugins = {
   };
   mergeStyles: void;
   inlineStyles: {
+    /** If true, do not inline styles if any CSS at rules are present. */
+    disableIfAtRulesPresent?: boolean;
     /**
      * Inlines selectors that match once only.
      *

--- a/test/plugins/inlineStyles.13.svg.txt
+++ b/test/plugins/inlineStyles.13.svg.txt
@@ -64,3 +64,7 @@
     </defs>
     <rect width="100" height="100" style="fill:blue"/>
 </svg>
+
+@@@
+
+{"disableIfAtRulesPresent":false}

--- a/test/plugins/inlineStyles.14.svg.txt
+++ b/test/plugins/inlineStyles.14.svg.txt
@@ -27,4 +27,4 @@
 
 @@@
 
-{"useMqs": ["media only screen and (min-device-width:320px) and (max-device-width:480px) and (-webkit-min-device-pixel-ratio:2)"]}
+{"useMqs": ["media only screen and (min-device-width:320px) and (max-device-width:480px) and (-webkit-min-device-pixel-ratio:2)"],"disableIfAtRulesPresent":false}

--- a/test/plugins/inlineStyles.29.svg.txt
+++ b/test/plugins/inlineStyles.29.svg.txt
@@ -1,0 +1,35 @@
+Styles should not be inlined in the presence of media queries.
+
+See: https://github.com/svg/svgo/issues/1834
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+    <style>
+        .fill {
+            fill: red
+        }
+        @media (max-width:500px) {
+            .fill {
+                fill: blue
+            }
+        }
+    </style>
+    <rect class="fill" x="1" y="1" width="10" height="10"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+    <style>
+        .fill {
+            fill: red
+        }
+        @media (max-width:500px) {
+            .fill {
+                fill: blue
+            }
+        }
+    </style>
+    <rect class="fill" x="1" y="1" width="10" height="10"/>
+</svg>


### PR DESCRIPTION
The inlineStyles plugin will move styles inline even if they are used in media queries, which causes the media queries to not work.

This PR changes the default behavior of the plugin so that it will not inline any styles if there are at-rules present in the CSS.

There is logic in the plugin to skip over some media queries. I can't think of a use case for this, but there are 2 test cases that rely on it, so I preserved this behavior. Since the default is now to not inline the styles if at-rules are present, I added a new configuration parameter ("disableIfAtRulesPresent"), and changed these 2 test cases to override the default setting of this parameter.

Resolves #1834, resolves #1359.