### PR TITLE
fix: cleanupIds changes style IDs incorrectly

### DIFF
--- a/test/plugins/cleanupIds.27.svg.txt
+++ b/test/plugins/cleanupIds.27.svg.txt
@@ -1,0 +1,36 @@
+When two IDs are referenced in the same attribute, make sure they both get changed even if the new
+value of the first ID is the same as the old value of the second ID.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <linearGradient id="a">
+        <stop stop-color="blue" offset="0"/>
+    </linearGradient>
+    <linearGradient id="ccc">
+        <stop stop-color="#f00" offset="0"/>
+    </linearGradient>
+    <linearGradient id="b">
+        <stop stop-color="green" offset="0"/>
+    </linearGradient>
+    <rect y="40" width="10" height="20" style="fill:url(#a)"/>
+    <rect y="10" width="10" height="20" style="fill:url(#ccc);stroke:url(#b);stroke-width:3"/>
+    <rect y="70" width="10" height="20" style="fill:url(#ccc);stroke:#ccc;stroke-width:3"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <linearGradient id="a">
+        <stop stop-color="blue" offset="0"/>
+    </linearGradient>
+    <linearGradient id="b">
+        <stop stop-color="#f00" offset="0"/>
+    </linearGradient>
+    <linearGradient id="c">
+        <stop stop-color="green" offset="0"/>
+    </linearGradient>
+    <rect y="40" width="10" height="20" style="fill:url(#a)"/>
+    <rect y="10" width="10" height="20" style="fill:url(#b);stroke:url(#c);stroke-width:3"/>
+    <rect y="70" width="10" height="20" style="fill:url(#b);stroke:#ccc;stroke-width:3"/>
+</svg>


### PR DESCRIPTION
If a style references 2 ids (e.g., `fill:url(#c);stroke:url(#b);`), and the IDs were changed so that c=>b and b=>a, cleanupIds was only changing the first element in the style twice.

This was very unlikely to happen on the first pass (regression results were unchanged), but common on subsequent passes (with multipass, regression results went from 467 failures and 199,877 pixel mismatches before the fix to 128 failures and 6,337 pixel mismatches after.

This PR fixes the issue by changing all references in the style at once. This required some rearranging and additional bookkeeping, in particular:

- new IDs need to be generated before starting the replacement, since they all need to be available to the style replacement code
- we need to keep track of which elements have had their styles updated so we don't try to update them again when the element is visited again

Note: this was originally PR #1956, but that PR got closed when I rebased.