### PR TITLE
Disable removeUselessStrokeAndFill if SVG contains animations.

### DIFF
--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -20,18 +20,22 @@ export const fn = (root, params) => {
     removeNone = false,
   } = params;
 
-  // style and script elements deoptimise this plugin
-  let hasStyleOrScript = false;
+  // style, animation, and script elements deoptimise this plugin
+  let deoptimized = false;
   visit(root, {
     element: {
       enter: (node) => {
-        if (node.name === 'style' || hasScripts(node)) {
-          hasStyleOrScript = true;
+        if (
+          node.name === 'style' ||
+          hasScripts(node) ||
+          elemsGroups.animation.has(node.name)
+        ) {
+          deoptimized = true;
         }
       },
     },
   });
-  if (hasStyleOrScript) {
+  if (deoptimized) {
     return null;
   }
 

--- a/test/plugins/removeUselessStrokeAndFill.06.svg.txt
+++ b/test/plugins/removeUselessStrokeAndFill.06.svg.txt
@@ -1,6 +1,6 @@
 Issue 1677: don't remove fill from animated elements.
 
-===========================
+===
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
   <animate href="#a" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
@@ -19,10 +19,10 @@ Issue 1677: don't remove fill from animated elements.
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
-    <animate href="#a" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
-    <animate href="#b" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+    <animate href="#a" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze"/>
+    <animate href="#b" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze"/>
     <circle cx="12" cy="12" r="8" fill="red" fill-opacity="0">
-        <animate attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+        <animate attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze"/>
     </circle>
     <circle id="a" cx="36" cy="12" r="8" fill="blue" fill-opacity="0"/>
     <g id="b" fill-opacity="0">

--- a/test/plugins/removeUselessStrokeAndFill.06.svg.txt
+++ b/test/plugins/removeUselessStrokeAndFill.06.svg.txt
@@ -1,0 +1,34 @@
+Issue 1677: don't remove fill from animated elements.
+
+===========================
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+  <animate href="#a" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+  <animate href="#b" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+  <circle cx="12" cy="12" r="8" fill="red" fill-opacity="0">
+    <animate attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+  </circle>
+  <circle id="a" cx="36" cy="12" r="8" fill="blue" fill-opacity="0"/>
+  <g id="b" fill-opacity="0">
+    <g>
+      <circle cx="60" cy="12" r="8" fill="green"/>
+    </g>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+    <animate href="#a" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+    <animate href="#b" attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+    <circle cx="12" cy="12" r="8" fill="red" fill-opacity="0">
+        <animate attributeName="fill-opacity" values="0;1" dur="4s" fill="freeze" />
+    </circle>
+    <circle id="a" cx="36" cy="12" r="8" fill="blue" fill-opacity="0"/>
+    <g id="b" fill-opacity="0">
+        <g>
+            <circle cx="60" cy="12" r="8" fill="green"/>
+        </g>
+    </g>
+</svg>
+


### PR DESCRIPTION
The removeUselessStrokeAndFill plugin had logic to disable itself if the SVG contained `<style>` elements or scripts. The optimizations also failed in some cases when the SVG contains animation elements. This PR adds animation elements to the list of things that disable the plugin.

Resolves #1677.