### PR TITLE
chore: add npm registry server to yarnrc

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
-.yarn
+.yarn/
+.yarnrc.yml

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,9 @@
 nodeLinker: node-modules
 
+npmRegistryServer: "https://registry.npmjs.org/"
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: '@yarnpkg/plugin-interactive-tools'
+    spec: "@yarnpkg/plugin-interactive-tools"
 
 yarnPath: .yarn/releases/yarn-3.8.2.cjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
   {
     ignores: [
       '.yarn/**',
+      '.yarnrc.yml',
       'node_modules/**',
       'dist/**',
       'test/regression-fixtures/**',


### PR DESCRIPTION
Sets the `npmRegistryServer` in our `.yarnrc.yml` so that the `yarn npm login` and `yarn npm publish` command hit the correct server.

Also adds `.yarnrc.yml` to our linter ignore configs as I'm treating this as a generated file.