### PR TITLE
fix pretty + disabled short tags formatting

### DIFF
--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -206,6 +206,7 @@ const stringifyElement = (node, config, state) => {
         node.name +
         stringifyAttributes(node, config) +
         config.tagOpenEnd +
+        createIndent(config, state) +
         config.tagCloseStart +
         node.name +
         config.tagCloseEnd


### PR DESCRIPTION
I use disabled short tags as workaround for bug #1473

this creates problem with closing tag alignment (it always does't have any intent)

PR adds intent for closing tag without children


output before:
```html
    <clipPath id="cp-rf8vUb">
      <path d="M132 0h293v40.5c0 80.91-65.59 146.5-146.5 146.5S132 121.41 132 40.5z">
</path>
    </clipPath>
```

output after:
```html
    <clipPath id="cp-rf8vUb">
      <path d="M132 0h293v40.5c0 80.91-65.59 146.5-146.5 146.5S132 121.41 132 40.5z">
      </path>
    </clipPath>
```