### PR TITLE
Update links in _transforms.js

### DIFF
--- a/plugins/_transforms.js
+++ b/plugins/_transforms.js
@@ -184,7 +184,7 @@ const getDecompositions = (matrix) => {
 /**
  * @param {TransformItem} matrix
  * @returns {TransformItem[]|undefined}
- * @see {@link https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html} Where applicable, variables are named in accordance with this document.
+ * @see {@link https://frederic-wang.fr/2013/12/01/decomposition-of-2d-transform-matrices/} Where applicable, variables are named in accordance with this document.
  */
 const decomposeQRAB = (matrix) => {
   const data = matrix.data;
@@ -239,7 +239,7 @@ const decomposeQRAB = (matrix) => {
 /**
  * @param {TransformItem} matrix
  * @returns {TransformItem[]|undefined}
- * @see {@link https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html} Where applicable, variables are named in accordance with this document.
+ * @see {@link https://frederic-wang.fr/2013/12/01/decomposition-of-2d-transform-matrices/} Where applicable, variables are named in accordance with this document.
  */
 const decomposeQRCD = (matrix) => {
   const data = matrix.data;


### PR DESCRIPTION
Fixed link in doc comments. Previous link reaches a 404.

Old:
https://frederic-wang.fr/decomposition-of-2d-transform-matrices.html

New:
https://frederic-wang.fr/2013/12/01/decomposition-of-2d-transform-matrices/