### PR TITLE
ci: add spellcheck

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,13 @@
+name: Check spelling
+
+on:
+  pull_request:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: streetsidesoftware/cspell-action@v6
+        with:
+          incremental_files_only: true

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "words": [
+    "Bézier",
+    "crosspoint",
+    "deoptimizations",
+    "deoptimize",
+    "deoptimized",
+    "fontawesome",
+    "Fontello",
+    "Fonticons",
+    "frontends",
+    "inlines",
+    "opencollective",
+    "subpoint",
+    "subselector",
+    "xast",
+    "Xlink",
+    // Abbreviations
+    "elems", // elements
+    "unenc", // unencoded
+    // SVG Keywords
+    "currentcolor",
+    // SVG Nodes / Attributes and CSS Properties, including plurals
+    "bbox",
+    "hkern",
+    "horiz",
+    "hrefs",
+    "mpath",
+    "onbegin",
+    "onrepeat",
+    "panose",
+    "stemh",
+    "stemv",
+    "vkern",
+    // Software
+    "grunt-svgmin",
+    "Inkscape",
+    "SVGOMG",
+    // NPM Packages
+    "csstree",
+    "csswhat",
+    // Names
+    "André",
+    "Baranovskiy",
+    "Dmitry",
+    "Keerthi",
+  ],
+  "ignorePaths": ["*.svg.txt", "*.svg", "cspell.jsonc", "LICENSE"],
+  "ignoreRegExpList": [
+    "-moz", // Mozilla Firefox CSS prefix
+    "'.+?.svg',", // path to file with .svg extension
+    "(?:xlink|sodipodi)(?::[a-z]+)?", // Common SVG namespaces
+    "[a-z]+: '#[a-f\\d]+',", // Color names in _collection.js
+    "[a-z]+…", // Words that have been cut off by an ellipsis
+    "@author .+", // JSDoc author tag line, usually names
+    "\"name\": .+", // package.json author name property
+    "\\*\\*SVG O\\*\\*ptimizer", // README
+    "\\b[aprs]data\\b",
+    "&.+?;", // HTML entity
+    "^svgo .+", // Command-line example of SVGO
+    "<svg.+>", // Inline SVG in code
+    "Atrule", // At-rule
+    "data:image/.+", // Data URI
+    "datauri", // Data URI
+    "descs", // Abbreviation of "descriptions"
+    "ENOCLS|ENOATTRS",
+    "id=([\"']).+?\\1", // ID attribute of inline SVG
+    "import .+", // Import statements in Javascript
+    "newres",
+    "nums", // Abbreviation of "numbers"
+    "onwarn", // Rollup API,
+    "QRAB|QRCD",
+    "rrggbb",
+    "sax\\..+", // Any properties of the sax API
+    "shorthex", // Parameter of convertColors plugin
+  ],
+}

--- a/docs/04-plugins/cleanupIds.mdx
+++ b/docs/04-plugins/cleanupIds.mdx
@@ -16,7 +16,7 @@ svgo:
       description: Elements with an ID that starts with one of these prefixes will be ignored.
       default: []
     force:
-      description: This plugin normally does nothing if a `<script>` or `<style>` element is found. Setting this to true will bypass that behaviour, which may result in destructive changes.
+      description: This plugin normally does nothing if a `<script>` or `<style>` element is found. Setting this to true will bypass that behavior, which may result in destructive changes.
       default: false
   defaultPlugin: true
 ---

--- a/docs/04-plugins/convertPathData.mdx
+++ b/docs/04-plugins/convertPathData.mdx
@@ -16,7 +16,7 @@ svgo:
       description: If to convert curve commands that are effectively straight lines to line commands.
       default: true
     convertToQ:
-      description: If to convert cubic beziers to quadratic beziers when they effectively are.
+      description: If to convert cubic Bézier curves to quadratic Bézier curves when they effectively are.
       default: true
     lineShorthands:
       description: If to convert regular lines to an explicit horizontal or vertical line where possible.
@@ -63,7 +63,7 @@ You can get more context on path commands on [MDN Web Docs](https://developer.mo
 This plugin uses multiple techniques to either reduce the number of instructions or reduce the attribute length:
 
 - Convert between relative or absolute coordinates, whichever is shortest.
-- Convert between commands. For example, a bézier curve that behaves like a straight line might as well use a line instruction.
+- Convert between commands. For example, a Bézier curve that behaves like a straight line might as well use a line instruction.
 - Remove redundant commands. For example, a command that moves to the current position can be removed.
 - Trim redundant delimiters and leading zeros.
 - Round numeric values using conventional rounding rules.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,7 +11,6 @@
  * @typedef {import('./types.js').XastChild} XastChild
  */
 
-// @ts-ignore sax will be replaced with something else later
 import SAX from 'sax';
 import { textElems } from '../plugins/_collections.js';
 

--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -67,7 +67,7 @@ export declare const builtinPlugins: Array<
 >;
 
 export type Config = {
-  /** Can be used by plugins, for example prefixids */
+  /** Can be used by plugins, for example prefixIds */
   path?: string;
   /** Pass over SVGs multiple times to ensure all optimizations are applied. */
   multipass?: boolean;

--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -1,10 +1,6 @@
 import { jest } from '@jest/globals';
 import { optimize } from './svgo.js';
 
-/**
- * @typedef {import('../lib/types.js').Plugin} Plugin
- */
-
 test('allow to setup default preset', () => {
   const svg = `
     <?xml version="1.0" encoding="utf-8"?>
@@ -353,9 +349,6 @@ test('slices long line in error code snippet', () => {
 test('multipass option should trigger plugins multiple times', () => {
   const svg = `<svg id="abcdefghijklmnopqrstuvwxyz"></svg>`;
   const list = [];
-  /**
-   * @type {Plugin<void>}
-   */
   const testPlugin = {
     name: 'testPlugin',
     fn: (_root, _params, info) => {

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -89,7 +89,7 @@ export const cleanupOutData = (data, params, command) => {
     // no extra space in front of first number
     if (i == 0) delimiter = '';
 
-    // no extra space after 'arcto' command flags(large-arc and sweep flags)
+    // no extra space after arc command flags (large-arc and sweep flags)
     // a20 60 45 0 1 30 20 → a20 60 45 0130 20
     if (params.noSpaceAfterFlags && (command == 'A' || command == 'a')) {
       var pos = i % 7;

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -2397,7 +2397,7 @@ export const pseudoClasses = {
     'disabled',
     'enabled',
     'in-range',
-    'indetermined',
+    'indeterminate',
     'invalid',
     'optional',
     'out-of-range',

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -564,7 +564,7 @@ function gatherPoints(pathData) {
 
       case 'A':
         if (basePoint != null) {
-          // Convert the arc to bezier curves and use the same approximation
+          // Convert the arc to Bézier curves and use the same approximation
           // @ts-ignore no idea what's going on here
           var curves = a2c.apply(0, basePoint.concat(data));
           for (

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -19,7 +19,7 @@ export const fn = (root, params) => {
       enter: (node) => {
         for (const name of Object.keys(node.attributes)) {
           if (newlines) {
-            // new line which requires a space instead of themself
+            // new line which requires a space instead
             node.attributes[name] = node.attributes[name].replace(
               regNewlinesNeedSpace,
               (match, p1, p2) => p1 + ' ' + p2,

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -1006,8 +1006,8 @@ function convertToMixed(path, params) {
 }
 
 /**
- * Checks if curve is convex. Control points of such a curve must form
- * a convex quadrilateral with diagonals crosspoint inside of it.
+ * Checks if curve is convex. Control points of such a curve must form a convex
+ * quadrilateral with diagonals crosspoint inside of it.
  *
  * @type {(data: number[]) => boolean}
  */

--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -12,9 +12,16 @@ const g = (...args) => {
 
 const stylingProps = attrsGroups.presentation;
 const rEscape = '\\\\(?:[0-9a-f]{1,6}\\s?|\\r\\n|.)'; // Like \" or \2051. Code points consume one space.
-const rAttr = '\\s*(' + g('[^:;\\\\]', rEscape) + '*?)\\s*'; // attribute name like ‘fill’
-const rSingleQuotes = "'(?:[^'\\n\\r\\\\]|" + rEscape + ")*?(?:'|$)"; // string in single quotes: 'smth'
-const rQuotes = '"(?:[^"\\n\\r\\\\]|' + rEscape + ')*?(?:"|$)'; // string in double quotes: "smth"
+
+/** Pattern to match attribute name like: 'fill' */
+const rAttr = '\\s*(' + g('[^:;\\\\]', rEscape) + '*?)\\s*';
+
+/** Pattern to match string in single quotes like: 'foo' */
+const rSingleQuotes = "'(?:[^'\\n\\r\\\\]|" + rEscape + ")*?(?:'|$)";
+
+/** Pattern to match string in double quotes like: "foo" */
+const rQuotes = '"(?:[^"\\n\\r\\\\]|' + rEscape + ')*?(?:"|$)';
+
 const rQuotedString = new RegExp('^' + g(rSingleQuotes, rQuotes) + '$');
 // Parentheses, E.g.: url(data:image/png;base64,iVBO...).
 // ':' and ';' inside of it should be treated as is. (Just like in strings.)

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -21,8 +21,8 @@ export const description = 'inline styles (additional options)';
  * :future, or :hover, but there are other pseudo-classes that we can evaluate
  * during optimization.
  *
- * The list of pseudo-classes that we can evaluate during optimization, and
- * shouldn't be toggled conditionally through the `usePseudos` parameter.
+ * Pseudo-classes that we can evaluate during optimization, and shouldn't be
+ * toggled conditionally through the `usePseudos` parameter.
  *
  * @see https://developer.mozilla.org/docs/Web/CSS/Pseudo-classes
  */

--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -58,7 +58,7 @@ export const fn = (_root, { usage, ...params }) => {
   return {
     element: {
       enter: (node, parentNode) => {
-        // detect deoptimisations
+        // detect deoptimizations
         if (hasScripts(node)) {
           deoptimized = true;
         }
@@ -115,7 +115,7 @@ export const fn = (_root, { usage, ...params }) => {
             }
 
             // preserve cdata if necessary
-            // TODO split cdata -> text optimisation into separate plugin
+            // TODO split cdata -> text optimization into separate plugin
             if (cssText.indexOf('>') >= 0 || cssText.indexOf('<') >= 0) {
               styleNode.children[0].type = 'cdata';
               styleNode.children[0].value = minified;

--- a/plugins/plugins-types.d.ts
+++ b/plugins/plugins-types.d.ts
@@ -108,13 +108,13 @@ type DefaultPlugins = {
 
   minifyStyles: {
     /**
-     * Disable or enable a structure optimisations.
+     * Disable or enable a structure optimizations.
      * @default true
      */
     restructure?: boolean;
     /**
      * Enables merging of @media rules with the same media query split by other rules.
-     * The optimisation is unsafe in general, but should work fine in most cases. Use it on your own risk.
+     * Unsafe in general, but should work fine in most cases. Use it on your own risk.
      * @default false
      */
     forceMediaMerge?: boolean;

--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -8,10 +8,10 @@ import { intersects } from './_path.js';
 
 export const name = 'removeOffCanvasPaths';
 export const description =
-  'removes elements that are drawn outside of the viewbox (disabled by default)';
+  'removes elements that are drawn outside of the viewBox (disabled by default)';
 
 /**
- * Remove elements that are drawn outside of the viewbox.
+ * Remove elements that are drawn outside of the viewBox.
  *
  * @author JoshyPHP
  *
@@ -35,7 +35,7 @@ export const fn = () => {
       enter: (node, parentNode) => {
         if (node.name === 'svg' && parentNode.type === 'root') {
           let viewBox = '';
-          // find viewbox
+          // find viewBox
           if (node.attributes.viewBox != null) {
             // remove commas and plus signs, normalize and trim whitespace
             viewBox = node.attributes.viewBox;
@@ -46,7 +46,7 @@ export const fn = () => {
             viewBox = `0 0 ${node.attributes.width} ${node.attributes.height}`;
           }
 
-          // parse viewbox
+          // parse viewBox
           // remove commas and plus signs, normalize and trim whitespace
           viewBox = viewBox
             .replace(/[,+]|px/g, ' ')

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -20,7 +20,7 @@ export const fn = (root, params) => {
     removeNone = false,
   } = params;
 
-  // style and script elements deoptimise this plugin
+  // style and script elements deoptimize this plugin
   let hasStyleOrScript = false;
   visit(root, {
     element: {
@@ -40,7 +40,7 @@ export const fn = (root, params) => {
   return {
     element: {
       enter: (node, parentNode) => {
-        // id attribute deoptimise the whole subtree
+        // id attribute deoptimize the whole subtree
         if (node.attributes.id != null) {
           return visitSkip;
         }

--- a/plugins/removeXlink.js
+++ b/plugins/removeXlink.js
@@ -54,7 +54,7 @@ const findPrefixedAttrs = (node, prefixes, attr) => {
  * Removes XLink namespace prefixes and converts references to XLink attributes
  * to the native SVG equivalent.
  *
- * The XLink namespace is deprecated in SVG 2.
+ * XLink namespace is deprecated in SVG 2.
  *
  * @type {import('./plugins-types.js').Plugin<'removeXlink'>}
  * @see https://developer.mozilla.org/docs/Web/SVG/Attribute/xlink:href


### PR DESCRIPTION
Add spellchecking to CI. This is mostly for documentation, but we may enforce it on most if not all files anyway.

Rational is that we've let typos onto the site on too many occasions, which just isn't a great look imo, so this will hopefully reduce that.

While this PR is in a draft state, it is configured to check all files. However, before merging we will enable `incremental_files_only` so that it only checks modified/added files.

## Bug Fixes

* In `_collections`, replaced `indetermined` with [`indeterminate`](https://developer.mozilla.org/docs/Web/CSS/:indeterminate). There is no `indetermined` pseudo-class. This was a typo of indeterminate, which is a pseudo-class.

## Chores

* Replace some instances of British English with American English.

## Related

Would've prevented all of the following:

* https://github.com/svg/svgo/pull/2087
* https://github.com/svg/svgo/pull/1996
* https://github.com/svg/svgo/pull/1994
* https://github.com/svg/svgo/pull/1868
* https://github.com/svg/svgo/pull/1633