### PR TITLE
chore: migrate from ts-ignore to ts-expect-error

### DIFF
--- a/lib/xast.js
+++ b/lib/xast.js
@@ -44,7 +44,7 @@ export const visitSkip = Symbol();
 export const visit = (node, visitor, parentNode) => {
   const callbacks = visitor[node.type];
   if (callbacks && callbacks.enter) {
-    // @ts-ignore hard to infer
+    // @ts-expect-error hard to infer
     const symbol = callbacks.enter(node, parentNode);
     if (symbol === visitSkip) {
       return;
@@ -66,7 +66,7 @@ export const visit = (node, visitor, parentNode) => {
     }
   }
   if (callbacks && callbacks.exit) {
-    // @ts-ignore hard to infer
+    // @ts-expect-error hard to infer
     callbacks.exit(node, parentNode);
   }
 };

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -16,7 +16,7 @@ var prevCtrlPoint;
  * @type {(path: XastElement) => PathDataItem[]}
  */
 export const path2js = (path) => {
-  // @ts-ignore legacy
+  // @ts-expect-error legacy
   if (path.pathJS) return path.pathJS;
   /**
    * @type {PathDataItem[]}
@@ -30,7 +30,7 @@ export const path2js = (path) => {
   if (pathData.length && pathData[0].command == 'm') {
     pathData[0].command = 'M';
   }
-  // @ts-ignore legacy
+  // @ts-expect-error legacy
   path.pathJS = pathData;
   return pathData;
 };
@@ -179,7 +179,7 @@ const convertRelativeToAbsolute = (data) => {
  * @type {(path: XastElement, data: PathDataItem[], params: Js2PathParams) => void}
  */
 export const js2path = function (path, data, params) {
-  // @ts-ignore legacy
+  // @ts-expect-error legacy
   path.pathJS = data;
 
   const pathData = [];
@@ -565,7 +565,7 @@ function gatherPoints(pathData) {
       case 'A':
         if (basePoint != null) {
           // Convert the arc to Bézier curves and use the same approximation
-          // @ts-ignore no idea what's going on here
+          // @ts-expect-error no idea what's going on here
           var curves = a2c.apply(0, basePoint.concat(data));
           for (
             var cData;

--- a/plugins/addAttributesToSVGElement.js
+++ b/plugins/addAttributesToSVGElement.js
@@ -60,14 +60,14 @@ export const fn = (root, params) => {
           for (const attribute of attributes) {
             if (typeof attribute === 'string') {
               if (node.attributes[attribute] == null) {
-                // @ts-ignore disallow explicit nullable attribute value
+                // @ts-expect-error disallow explicit nullable attribute value
                 node.attributes[attribute] = undefined;
               }
             }
             if (typeof attribute === 'object') {
               for (const key of Object.keys(attribute)) {
                 if (node.attributes[key] == null) {
-                  // @ts-ignore disallow explicit nullable attribute value
+                  // @ts-expect-error disallow explicit nullable attribute value
                   node.attributes[key] = attribute[key];
                 }
               }

--- a/plugins/cleanupEnableBackground.js
+++ b/plugins/cleanupEnableBackground.js
@@ -111,7 +111,7 @@ export const fn = (root) => {
             enableBackgroundDeclaration
           ) {
             const styleValue = csstree.generate(
-              // @ts-ignore
+              // @ts-expect-error
               enableBackgroundDeclaration.data.value,
             );
             const styleCleaned = cleanupValue(
@@ -122,7 +122,7 @@ export const fn = (root) => {
             );
 
             if (styleCleaned) {
-              // @ts-ignore
+              // @ts-expect-error
               enableBackgroundDeclaration.data.value = {
                 type: 'Raw',
                 value: styleCleaned,

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -129,7 +129,7 @@ export const fn = (root, params) => {
   if (_applyTransforms) {
     visit(
       root,
-      // @ts-ignore
+      // @ts-expect-error
       applyTransforms(root, {
         transformPrecision,
         applyTransformsStroked,
@@ -208,7 +208,7 @@ export const fn = (root, params) => {
               });
             }
 
-            // @ts-ignore
+            // @ts-expect-error
             js2path(node, data, newParams);
           }
         }
@@ -379,11 +379,11 @@ const convertToRelative = (pathData) => {
     pathItem.args = args;
     // store absolute coordinates for later use
     // base should preserve reference from other element
-    // @ts-ignore
+    // @ts-expect-error
     pathItem.base = prevCoords;
-    // @ts-ignore
+    // @ts-expect-error
     pathItem.coords = [cursor[0], cursor[1]];
-    // @ts-ignore
+    // @ts-expect-error
     prevCoords = pathItem.coords;
   }
 
@@ -450,9 +450,9 @@ function filters(
           arc = {
             command: 'a',
             args: [r, r, 0, 0, sweep, sdata[4], sdata[5]],
-            // @ts-ignore
+            // @ts-expect-error
             coords: item.coords.slice(),
-            // @ts-ignore
+            // @ts-expect-error
             base: item.base,
           },
           /**
@@ -480,11 +480,11 @@ function filters(
           (prev.command == 'a' && prev.sdata && isArcPrev(prev.sdata, circle))
         ) {
           arcCurves.unshift(prev);
-          // @ts-ignore
+          // @ts-expect-error
           arc.base = prev.base;
-          // @ts-ignore
+          // @ts-expect-error
           arc.args[5] = arc.coords[0] - arc.base[0];
-          // @ts-ignore
+          // @ts-expect-error
           arc.args[6] = arc.coords[1] - arc.base[1];
           var prevData = prev.command == 'a' ? prev.sdata : prev.args;
           var prevAngle = findArcAngle(prevData, {
@@ -522,21 +522,21 @@ function filters(
             arcCurves.push(next);
             if (2 * Math.PI - angle > 1e-3) {
               // less than 360°
-              // @ts-ignore
+              // @ts-expect-error
               arc.coords = next.coords;
-              // @ts-ignore
+              // @ts-expect-error
               arc.args[5] = arc.coords[0] - arc.base[0];
-              // @ts-ignore
+              // @ts-expect-error
               arc.args[6] = arc.coords[1] - arc.base[1];
             } else {
               // full circle, make a half-circle arc and add a second one
               arc.args[5] = 2 * (relCircle.center[0] - nextData[4]);
               arc.args[6] = 2 * (relCircle.center[1] - nextData[5]);
-              // @ts-ignore
+              // @ts-expect-error
               arc.coords = [
-                // @ts-ignore
+                // @ts-expect-error
                 arc.base[0] + arc.args[5],
-                // @ts-ignore
+                // @ts-expect-error
                 arc.base[1] + arc.args[6],
               ];
               arc = {
@@ -547,14 +547,14 @@ function filters(
                   0,
                   0,
                   sweep,
-                  // @ts-ignore
+                  // @ts-expect-error
                   next.coords[0] - arc.coords[0],
-                  // @ts-ignore
+                  // @ts-expect-error
                   next.coords[1] - arc.coords[1],
                 ],
-                // @ts-ignore
+                // @ts-expect-error
                 coords: next.coords,
-                // @ts-ignore
+                // @ts-expect-error
                 base: arc.coords,
               };
               output.push(arc);
@@ -572,22 +572,22 @@ function filters(
           }
           if (hasPrev) {
             var prevArc = output.shift();
-            // @ts-ignore
+            // @ts-expect-error
             roundData(prevArc.args);
-            // @ts-ignore
+            // @ts-expect-error
             relSubpoint[0] += prevArc.args[5] - prev.args[prev.args.length - 2];
-            // @ts-ignore
+            // @ts-expect-error
             relSubpoint[1] += prevArc.args[6] - prev.args[prev.args.length - 1];
             prev.command = 'a';
-            // @ts-ignore
+            // @ts-expect-error
             prev.args = prevArc.args;
-            // @ts-ignore
+            // @ts-expect-error
             item.base = prev.coords = prevArc.coords;
           }
-          // @ts-ignore
+          // @ts-expect-error
           arc = output.shift();
           if (arcCurves.length == 1) {
-            // @ts-ignore
+            // @ts-expect-error
             item.sdata = sdata.slice(); // preserve curve data for future checks
           } else if (arcCurves.length - 1 - hasPrev > 0) {
             // filter out consumed next items
@@ -596,7 +596,7 @@ function filters(
           if (!arc) return false;
           command = 'a';
           data = arc.args;
-          // @ts-ignore
+          // @ts-expect-error
           item.coords = arc.coords;
         }
       }
@@ -614,19 +614,19 @@ function filters(
           command === 'c'
         ) {
           for (var i = data.length; i--; ) {
-            // @ts-ignore
+            // @ts-expect-error
             data[i] += item.base[i % 2] - relSubpoint[i % 2];
           }
         } else if (command == 'h') {
-          // @ts-ignore
+          // @ts-expect-error
           data[0] += item.base[0] - relSubpoint[0];
         } else if (command == 'v') {
-          // @ts-ignore
+          // @ts-expect-error
           data[0] += item.base[1] - relSubpoint[1];
         } else if (command == 'a') {
-          // @ts-ignore
+          // @ts-expect-error
           data[5] += item.base[0] - relSubpoint[0];
-          // @ts-ignore
+          // @ts-expect-error
           data[6] += item.base[1] - relSubpoint[1];
         }
         roundData(data);
@@ -698,26 +698,26 @@ function filters(
       // m 0 12 C 4 4 8 4 12 12 → M 0 12 Q 6 0 12 12
       if (params.convertToQ && command == 'c') {
         const x1 =
-          // @ts-ignore
+          // @ts-expect-error
           0.75 * (item.base[0] + data[0]) - 0.25 * item.base[0];
         const x2 =
-          // @ts-ignore
+          // @ts-expect-error
           0.75 * (item.base[0] + data[2]) - 0.25 * (item.base[0] + data[4]);
         if (Math.abs(x1 - x2) < error * 2) {
           const y1 =
-            // @ts-ignore
+            // @ts-expect-error
             0.75 * (item.base[1] + data[1]) - 0.25 * item.base[1];
           const y2 =
-            // @ts-ignore
+            // @ts-expect-error
             0.75 * (item.base[1] + data[3]) - 0.25 * (item.base[1] + data[5]);
           if (Math.abs(y1 - y2) < error * 2) {
             const newData = data.slice();
             newData.splice(
               0,
               4,
-              // @ts-ignore
+              // @ts-expect-error
               x1 + x2 - item.base[0],
-              // @ts-ignore
+              // @ts-expect-error
               y1 + y2 - item.base[1],
             );
             roundData(newData);
@@ -760,7 +760,7 @@ function filters(
         if (command != 'h' && command != 'v') {
           prev.args[1] += data[1];
         }
-        // @ts-ignore
+        // @ts-expect-error
         prev.coords = item.coords;
         path[index] = prev;
         return false;
@@ -817,15 +817,15 @@ function filters(
           // t + q → t + t
           else if (prev.command === 't') {
             const predictedControlPoint = reflectPoint(
-              // @ts-ignore
+              // @ts-expect-error
               qControlPoint,
-              // @ts-ignore
+              // @ts-expect-error
               item.base,
             );
             const realControlPoint = [
-              // @ts-ignore
+              // @ts-expect-error
               data[0] + item.base[0],
-              // @ts-ignore
+              // @ts-expect-error
               data[1] + item.base[1],
             ];
             if (
@@ -874,9 +874,9 @@ function filters(
         (command === 'l' || command === 'h' || command === 'v')
       ) {
         if (
-          // @ts-ignore
+          // @ts-expect-error
           Math.abs(pathBase[0] - item.coords[0]) < error &&
-          // @ts-ignore
+          // @ts-expect-error
           Math.abs(pathBase[1] - item.coords[1]) < error
         ) {
           command = 'z';
@@ -896,22 +896,22 @@ function filters(
       (command === 'Z' || command === 'z') &&
       params.removeUseless &&
       isSafeToUseZ &&
-      // @ts-ignore
+      // @ts-expect-error
       Math.abs(item.base[0] - item.coords[0]) < error / 10 &&
-      // @ts-ignore
+      // @ts-expect-error
       Math.abs(item.base[1] - item.coords[1]) < error / 10
     )
       return false;
 
     if (command === 'q') {
-      // @ts-ignore
+      // @ts-expect-error
       prevQControlPoint = [data[0] + item.base[0], data[1] + item.base[1]];
     } else if (command === 't') {
       if (qControlPoint) {
-        // @ts-ignore
+        // @ts-expect-error
         prevQControlPoint = reflectPoint(qControlPoint, item.base);
       } else {
-        // @ts-ignore
+        // @ts-expect-error
         prevQControlPoint = item.coords;
       }
     } else {
@@ -953,19 +953,19 @@ function convertToMixed(path, params) {
       command === 'c'
     ) {
       for (var i = adata.length; i--; ) {
-        // @ts-ignore
+        // @ts-expect-error
         adata[i] += item.base[i % 2];
       }
     } else if (command == 'h') {
-      // @ts-ignore
+      // @ts-expect-error
       adata[0] += item.base[0];
     } else if (command == 'v') {
-      // @ts-ignore
+      // @ts-expect-error
       adata[0] += item.base[1];
     } else if (command == 'a') {
-      // @ts-ignore
+      // @ts-expect-error
       adata[5] += item.base[0];
-      // @ts-ignore
+      // @ts-expect-error
       adata[6] += item.base[1];
     }
 
@@ -993,7 +993,7 @@ function convertToMixed(path, params) {
               prev.args[prev.args.length - 1] % 1))
         ))
     ) {
-      // @ts-ignore
+      // @ts-expect-error
       item.command = command.toUpperCase();
       item.args = adata;
     }
@@ -1218,23 +1218,23 @@ function findCircle(curve) {
       m2[1] - (m2[0] - midPoint[0]),
     ]),
     radius = center && getDistance([0, 0], center),
-    // @ts-ignore
+    // @ts-expect-error
     tolerance = Math.min(arcThreshold * error, (arcTolerance * radius) / 100);
 
   if (
     center &&
-    // @ts-ignore
+    // @ts-expect-error
     radius < 1e15 &&
     [1 / 4, 3 / 4].every(function (point) {
       return (
         Math.abs(
-          // @ts-ignore
+          // @ts-expect-error
           getDistance(getCubicBezierPoint(curve, point), center) - radius,
         ) <= tolerance
       );
     })
   )
-    // @ts-ignore
+    // @ts-expect-error
     return { center: center, radius: radius };
 }
 

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -78,7 +78,7 @@ export const fn = (root, params) => {
 
         const cssText = node.children
           .filter((child) => child.type === 'text' || child.type === 'cdata')
-          // @ts-ignore
+          // @ts-expect-error
           .map((child) => child.value)
           .join('');
 


### PR DESCRIPTION
Minor change to use the `@ts-expect-error` directive instead of `@ts-ignore`. In the near future, we should work towards removing all of these directives by having better typing.