### PR TITLE
chore: stronger typing for xast/css-select code

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -280,8 +280,8 @@ export const computeStyle = (stylesheet, node) => {
 /**
  * Determines if the CSS selector includes or traverses the given attribute.
  *
- * Classes and IDs are generated as attribute selectors, so you can check for
- * if a `.class` or `#id` is included by passing `name=class` or `name=id`
+ * Classes and IDs are generated as attribute selectors, so you can check for if
+ * a `.class` or `#id` is included by passing `name=class` or `name=id`
  * respectively.
  *
  * @param {csstree.ListItem<csstree.CssNode> | string} selector

--- a/lib/svgo.d.ts
+++ b/lib/svgo.d.ts
@@ -1,10 +1,4 @@
-import type {
-  StringifyOptions,
-  DataUri,
-  Plugin,
-  XastChild,
-  XastNode,
-} from './types.js';
+import type { StringifyOptions, DataUri, Plugin } from './types.js';
 import type {
   BuiltinsWithOptionalParams,
   BuiltinsWithRequiredParams,
@@ -168,22 +162,4 @@ export declare const VERSION: string;
 /** The core of SVGO */
 export declare function optimize(input: string, config?: Config): Output;
 
-/**
- * @param node Element to query the children of.
- * @param selector CSS selector string.
- * @returns First match, or null if there was no match.
- */
-export declare function querySelector(
-  node: XastNode,
-  selector: string,
-): XastChild | null;
-
-/**
- * @param node Element to query the children of.
- * @param selector CSS selector string.
- * @returns All matching elements.
- */
-export declare function querySelectorAll(
-  node: XastNode,
-  selector: string,
-): XastChild[];
+export { querySelector, querySelectorAll } from './xast.js';

--- a/lib/svgo/css-select-adapter.d.ts
+++ b/lib/svgo/css-select-adapter.d.ts
@@ -1,2 +1,0 @@
-declare let obj: any;
-export default obj;

--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -1,75 +1,53 @@
 /**
+ * @typedef {Required<import('css-select').Options<XastNode & { children?: any }, XastElement & { parentNode?: any }>>['adapter']} Adapter
  * @typedef {import('../types.js').XastChild} XastChild
  * @typedef {import('../types.js').XastElement} XastElement
  * @typedef {import('../types.js').XastNode} XastNode
  * @typedef {import('../types.js').XastParent} XastParent
  */
 
-/**
- * @param {XastNode} node
- * @returns {boolean}
- */
+/** @type {Adapter['isTag']} */
 const isTag = (node) => {
   return node.type === 'element';
 };
 
-/**
- * @param {<T>(v: T) => boolean} test
- * @param {XastNode[]} elems
- * @returns {boolean}
- */
+/** @type {Adapter['existsOne']} */
 const existsOne = (test, elems) => {
   return elems.some((elem) => {
     return isTag(elem) && (test(elem) || existsOne(test, getChildren(elem)));
   });
 };
 
-/**
- * @param {XastElement} elem
- * @param {string} name
- * @returns {?string}
- */
+/** @type {Adapter['getAttributeValue']} */
 const getAttributeValue = (elem, name) => {
   return elem.attributes[name];
 };
 
-/**
- * @param {XastNode & { children?: XastChild[] }} node
- * @returns {XastChild[]}
- */
+/** @type {Adapter['getChildren']} */
 const getChildren = (node) => {
   return node.children || [];
 };
 
-/**
- * @param {XastElement} elemAst
- * @returns {string}
- */
+/** @type {Adapter['getName']} */
 const getName = (elemAst) => {
   return elemAst.name;
 };
 
-/**
- * @param {XastNode & { parentNode?: XastParent }} node
- * @returns {?XastParent}
- */
+/** @type {Adapter['getParent']} */
 const getParent = (node) => {
   return node.parentNode || null;
 };
 
 /**
- * @param {XastElement} elem
- * @returns {XastChild[]}
+ * @param {any} elem
+ * @returns {any}
  */
 const getSiblings = (elem) => {
   const parent = getParent(elem);
   return parent ? getChildren(parent) : [];
 };
 
-/**
- * @param {XastParent} node
- * @returns {string}
- */
+/** @type {Adapter['getText']} */
 const getText = (node) => {
   if (node.children[0].type === 'text' || node.children[0].type === 'cdata') {
     return node.children[0].value;
@@ -77,18 +55,14 @@ const getText = (node) => {
   return '';
 };
 
-/**
- * @param {XastElement} elem
- * @param {string} name
- * @returns {boolean}
- */
+/** @type {Adapter['hasAttrib']} */
 const hasAttrib = (elem, name) => {
   return elem.attributes[name] !== undefined;
 };
 
 /**
- * @param {Array<?XastNode>} nodes
- * @returns {Array<?XastNode>}
+ * @param {any} nodes
+ * @returns {any}
  */
 const removeSubsets = (nodes) => {
   let idx = nodes.length;
@@ -118,11 +92,7 @@ const removeSubsets = (nodes) => {
   return nodes;
 };
 
-/**
- * @param {<T>(v: T) => boolean} test
- * @param {XastNode[]} elems
- * @returns {XastNode[]}
- */
+/** @type {Adapter['findAll']} */
 const findAll = (test, elems) => {
   const result = [];
   for (const elem of elems) {
@@ -136,11 +106,7 @@ const findAll = (test, elems) => {
   return result;
 };
 
-/**
- * @param {<T>(v: T) => boolean} test
- * @param {XastNode[]} elems
- * @returns {?XastNode}
- */
+/** @type {Adapter['findOne']} */
 const findOne = (test, elems) => {
   for (const elem of elems) {
     if (isTag(elem)) {
@@ -156,6 +122,9 @@ const findOne = (test, elems) => {
   return null;
 };
 
+/**
+ * @type {Adapter}
+ */
 export default {
   isTag,
   existsOne,

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -1,36 +1,43 @@
 import { selectAll, selectOne, is } from 'css-select';
-import xastAdaptor from './svgo/css-select-adapter.js';
+import adapter from './svgo/css-select-adapter.js';
 
 /**
+ * @typedef {import('css-select').Options<XastNode & { children?: any }, XastElement & { parentNode?: any }>} Options
+ * @typedef {import('./types.js').XastElement} XastElement
  * @typedef {import('./types.js').XastNode} XastNode
  * @typedef {import('./types.js').XastChild} XastChild
  * @typedef {import('./types.js').XastParent} XastParent
  * @typedef {import('./types.js').Visitor} Visitor
- * @typedef {import('./svgo.ts').querySelector} querySelector
- * @typedef {import('./svgo.ts').querySelectorAll} querySelectorAll
  */
 
+/** @type {Options} */
 const cssSelectOptions = {
   xmlMode: true,
-  adapter: xastAdaptor,
+  adapter,
 };
 
 /**
- * @type {querySelectorAll}
+ * @param {XastNode} node Element to query the children of.
+ * @param {string} selector CSS selector string.
+ * @returns {XastChild[]} All matching elements.
  */
 export const querySelectorAll = (node, selector) => {
   return selectAll(selector, node, cssSelectOptions);
 };
 
 /**
- * @type {querySelector}
+ * @param {XastNode} node Element to query the children of.
+ * @param {string} selector CSS selector string.
+ * @returns {?XastChild} First match, or null if there was no match.
  */
 export const querySelector = (node, selector) => {
   return selectOne(selector, node, cssSelectOptions);
 };
 
 /**
- * @type {(node: XastChild, selector: string) => boolean}
+ * @param {XastElement} node
+ * @param {string} selector
+ * @returns {boolean}
  */
 export const matches = (node, selector) => {
   return is(node, selector, cssSelectOptions);
@@ -39,11 +46,13 @@ export const matches = (node, selector) => {
 export const visitSkip = Symbol();
 
 /**
- * @type {(node: XastNode, visitor: Visitor, parentNode?: any) => void}
+ * @param {XastNode} node
+ * @param {Visitor} visitor
+ * @param {?any} parentNode
  */
-export const visit = (node, visitor, parentNode) => {
+export const visit = (node, visitor, parentNode = undefined) => {
   const callbacks = visitor[node.type];
-  if (callbacks && callbacks.enter) {
+  if (callbacks?.enter) {
     // @ts-expect-error hard to infer
     const symbol = callbacks.enter(node, parentNode);
     if (symbol === visitSkip) {
@@ -65,7 +74,7 @@ export const visit = (node, visitor, parentNode) => {
       }
     }
   }
-  if (callbacks && callbacks.exit) {
+  if (callbacks?.exit) {
     // @ts-expect-error hard to infer
     callbacks.exit(node, parentNode);
   }


### PR DESCRIPTION
Significantly improves type checking for `lib/svgo/css-select-adapter.js`. Before, we declared an explicit `any` over the options.

* No longer declares the type of `querySelector` and `querySelectorAll` in our `.d.ts` file. Instead, we use a JSDoc type, and export that in our `.d.ts`. This achieves the same result, but we maintain the type with the implementation, leaving less risk for it to fall out of sync.
* Deletes `lib/svgo/css-select-adapter.d.ts` and uses the upstream types when we define our config. (I did declare `any` for two functions as they were annoying to resolve, I will look at this in future. Again, I'm striving for better, not perfect.)