### PR TITLE
chore: bulk update all jsdoc and jsdoctypes

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -86,34 +86,28 @@ const config = {
 /**
  * Convert SVG (XML) string to SVG-as-JS object.
  *
- * @type {(data: string, from?: string) => XastRoot}
+ * @param {string} data
+ * @param {string=} from
+ * @returns {XastRoot}
  */
 export const parseSvg = (data, from) => {
   const sax = SAX.parser(config.strict, config);
-  /**
-   * @type {XastRoot}
-   */
+  /** @type {XastRoot} */
   const root = { type: 'root', children: [] };
-  /**
-   * @type {XastParent}
-   */
+  /** @type {XastParent} */
   let current = root;
-  /**
-   * @type {XastParent[]}
-   */
+  /** @type {XastParent[]} */
   const stack = [root];
 
   /**
-   * @type {(node: XastChild) => void}
+   * @param {XastChild} node
    */
   const pushToContent = (node) => {
     current.children.push(node);
   };
 
   sax.ondoctype = (doctype) => {
-    /**
-     * @type {XastDoctype}
-     */
+    /** @type {XastDoctype} */
     const node = {
       type: 'doctype',
       // TODO parse doctype for name, public and system to match xast
@@ -135,9 +129,7 @@ export const parseSvg = (data, from) => {
   };
 
   sax.onprocessinginstruction = (data) => {
-    /**
-     * @type {XastInstruction}
-     */
+    /** @type {XastInstruction} */
     const node = {
       type: 'instruction',
       name: data.name,
@@ -147,9 +139,7 @@ export const parseSvg = (data, from) => {
   };
 
   sax.oncomment = (comment) => {
-    /**
-     * @type {XastComment}
-     */
+    /** @type {XastComment} */
     const node = {
       type: 'comment',
       value: comment.trim(),
@@ -158,9 +148,7 @@ export const parseSvg = (data, from) => {
   };
 
   sax.oncdata = (cdata) => {
-    /**
-     * @type {XastCdata}
-     */
+    /** @type {XastCdata} */
     const node = {
       type: 'cdata',
       value: cdata,
@@ -169,9 +157,7 @@ export const parseSvg = (data, from) => {
   };
 
   sax.onopentag = (data) => {
-    /**
-     * @type {XastElement}
-     */
+    /** @type {XastElement} */
     let element = {
       type: 'element',
       name: data.name,
@@ -190,18 +176,14 @@ export const parseSvg = (data, from) => {
     if (current.type === 'element') {
       // prevent trimming of meaningful whitespace inside textual tags
       if (textElems.has(current.name)) {
-        /**
-         * @type {XastText}
-         */
+        /** @type {XastText} */
         const node = {
           type: 'text',
           value: text,
         };
         pushToContent(node);
       } else if (/\S/.test(text)) {
-        /**
-         * @type {XastText}
-         */
+        /** @type {XastText} */
         const node = {
           type: 'text',
           value: text.trim(),

--- a/lib/path.js
+++ b/lib/path.js
@@ -4,6 +4,11 @@ import { removeLeadingZero, toFixed } from './svgo/tools.js';
  * @typedef {import('./types.js').PathDataItem} PathDataItem
  * @typedef {import('./types.js').PathDataCommand} PathDataCommand
  * @typedef {'none' | 'sign' | 'whole' | 'decimal_point' | 'decimal' | 'e' | 'exponent_sign' | 'exponent'} ReadNumberState
+ *
+ * @typedef StringifyPathDataOptions
+ * @property {PathDataItem[]} pathData
+ * @property {number=} precision
+ * @property {boolean=} disableSpaceAfterFlags
  */
 
 // Based on https://www.w3.org/TR/SVG11/paths.html#PathDataBNF
@@ -32,7 +37,8 @@ const argsCountPerCommand = {
 };
 
 /**
- * @type {(c: string) => c is PathDataCommand}
+ * @param {string} c
+ * @returns {c is PathDataCommand}
  */
 const isCommand = (c) => {
   return c in argsCountPerCommand;
@@ -59,7 +65,9 @@ const isDigit = (c) => {
 };
 
 /**
- * @type {(string: string, cursor: number) => [number, ?number]}
+ * @param {string} string
+ * @param {number} cursor
+ * @returns {[number, ?number]}
  */
 const readNumber = (string, cursor) => {
   let i = cursor;
@@ -130,13 +138,9 @@ const readNumber = (string, cursor) => {
  * @returns {PathDataItem[]}
  */
 export const parsePathData = (string) => {
-  /**
-   * @type {PathDataItem[]}
-   */
+  /** @type {PathDataItem[]} */
   const pathData = [];
-  /**
-   * @type {?PathDataCommand}
-   */
+  /** @type {?PathDataCommand} */
   let command = null;
   let args = /** @type {number[]} */ ([]);
   let argsCount = 0;
@@ -232,10 +236,9 @@ export const parsePathData = (string) => {
 };
 
 /**
- * @type {(number: number, precision?: number) => {
- *   roundedStr: string,
- *   rounded: number
- * }}
+ * @param {number} number
+ * @param {number=} precision
+ * @returns {{ roundedStr: string, rounded: number }}
  */
 const roundAndStringify = (number, precision) => {
   if (precision != null) {
@@ -252,12 +255,11 @@ const roundAndStringify = (number, precision) => {
  * Elliptical arc large-arc and sweep flags are rendered with spaces
  * because many non-browser environments are not able to parse such paths
  *
- * @type {(
- *   command: string,
- *   args: number[],
- *   precision?: number,
- *   disableSpaceAfterFlags?: boolean
- * ) => string}
+ * @param {string} command
+ * @param {number[]} args
+ * @param {number=} precision
+ * @param {boolean=} disableSpaceAfterFlags
+ * @returns {string}
  */
 const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
   let result = '';
@@ -287,14 +289,6 @@ const stringifyArgs = (command, args, precision, disableSpaceAfterFlags) => {
 
   return result;
 };
-
-/**
- * @typedef {{
- *   pathData: PathDataItem[];
- *   precision?: number;
- *   disableSpaceAfterFlags?: boolean;
- * }} StringifyPathDataOptions
- */
 
 /**
  * @param {StringifyPathDataOptions} options

--- a/lib/path.test.js
+++ b/lib/path.test.js
@@ -154,9 +154,7 @@ describe('stringify path data', () => {
     ).toBe('M.1 1e-7 2 2');
   });
   it('should configure precision', () => {
-    /**
-     * @type {PathDataItem[]}
-     */
+    /** @type {PathDataItem[]} */
     const pathData = [
       { command: 'M', args: [0, -1.9876] },
       { command: 'L', args: [0.3, 3.14159265] },
@@ -177,9 +175,7 @@ describe('stringify path data', () => {
     ).toBe('M0-2 0 3 0-3 100 200');
   });
   it('allows to avoid spaces after arc flags', () => {
-    /**
-     * @type {PathDataItem[]}
-     */
+    /** @type {PathDataItem[]} */
     const pathData = [
       { command: 'M', args: [0, 0] },
       { command: 'A', args: [50, 50, 10, 1, 0, 0.2, 20] },

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -10,16 +10,17 @@ import { textElems } from '../plugins/_collections.js';
  * @typedef {import('./types.js').XastCdata} XastCdata
  * @typedef {import('./types.js').XastComment} XastComment
  * @typedef {import('./types.js').StringifyOptions} StringifyOptions
- * @typedef {{
- *   indent: string,
- *   textContext: ?XastElement,
- *   indentLevel: number,
- * }} State
  * @typedef {Required<StringifyOptions>} Options
+ *
+ * @typedef State
+ * @property {string} indent
+ * @property {?XastElement} textContext
+ * @property {number} indentLevel
  */
 
 /**
- * @type {(char: string) => string}
+ * @param {string} char
+ * @returns {string}
  */
 const encodeEntity = (char) => {
   return entities[char];
@@ -65,9 +66,11 @@ const entities = {
 };
 
 /**
- * convert XAST to SVG string
+ * Converts XAST to SVG string.
  *
- * @type {(data: XastRoot, userOptions?: StringifyOptions) => string}
+ * @param {XastRoot} data
+ * @param {StringifyOptions=} userOptions
+ * @returns {string}
  */
 export const stringifySvg = (data, userOptions = {}) => {
   /** @type {Options} */
@@ -104,7 +107,10 @@ export const stringifySvg = (data, userOptions = {}) => {
 };
 
 /**
- * @type {(node: XastParent, config: Options, state: State) => string}
+ * @param {XastParent} data
+ * @param {Options} config
+ * @param {State} state
+ * @returns {string}
  */
 const stringifyNode = (data, config, state) => {
   let svg = '';
@@ -134,9 +140,11 @@ const stringifyNode = (data, config, state) => {
 };
 
 /**
- * create indent string in accordance with the current node level.
+ * Create indent string in accordance with the current node level.
  *
- * @type {(config: Options, state: State) => string}
+ * @param {Options} config
+ * @param {State} state
+ * @returns {string}
  */
 const createIndent = (config, state) => {
   let indent = '';
@@ -147,14 +155,18 @@ const createIndent = (config, state) => {
 };
 
 /**
- * @type {(node: XastDoctype, config: Options) => string}
+ * @param {XastDoctype} node
+ * @param {Options} config
+ * @returns {string}
  */
 const stringifyDoctype = (node, config) => {
   return config.doctypeStart + node.data.doctype + config.doctypeEnd;
 };
 
 /**
- * @type {(node: XastInstruction, config: Options) => string}
+ * @param {XastInstruction} node
+ * @param {Options} config
+ * @returns {string}
  */
 const stringifyInstruction = (node, config) => {
   return (
@@ -163,14 +175,19 @@ const stringifyInstruction = (node, config) => {
 };
 
 /**
- * @type {(node: XastComment, config: Options) => string}
+ * @param {XastComment} node
+ * @param {Options} config
+ * @returns {string}
  */
 const stringifyComment = (node, config) => {
   return config.commentStart + node.value + config.commentEnd;
 };
 
 /**
- * @type {(node: XastCdata, config: Options, state: State) => string}
+ * @param {XastCdata} node
+ * @param {Options} config
+ * @param {State} state
+ * @returns {string}
  */
 const stringifyCdata = (node, config, state) => {
   return (
@@ -182,7 +199,10 @@ const stringifyCdata = (node, config, state) => {
 };
 
 /**
- * @type {(node: XastElement, config: Options, state: State) => string}
+ * @param {XastElement} node
+ * @param {Options} config
+ * @param {State} state
+ * @returns {string}
  */
 const stringifyElement = (node, config, state) => {
   // empty element and short tag
@@ -251,7 +271,9 @@ const stringifyElement = (node, config, state) => {
 };
 
 /**
- * @type {(node: XastElement, config: Options) => string}
+ * @param {XastElement} node
+ * @param {Options} config
+ * @returns {string}
  */
 const stringifyAttributes = (node, config) => {
   let attrs = '';
@@ -270,7 +292,10 @@ const stringifyAttributes = (node, config) => {
 };
 
 /**
- * @type {(node: XastText, config: Options, state: State) => string}
+ * @param {XastText} node
+ * @param {Options} config
+ * @param {State} state
+ * @returns {string}
  */
 const stringifyText = (node, config, state) => {
   return (

--- a/lib/style.js
+++ b/lib/style.js
@@ -25,12 +25,12 @@ import {
 const csstreeWalkSkip = csstree.walk.skip;
 
 /**
- * @type {(ruleNode: CsstreeRule, dynamic: boolean) => StylesheetRule[]}
+ * @param {CsstreeRule} ruleNode
+ * @param {boolean} dynamic
+ * @returns {StylesheetRule[]}
  */
 const parseRule = (ruleNode, dynamic) => {
-  /**
-   * @type {StylesheetDeclaration[]}
-   */
+  /** @type {StylesheetDeclaration[]} */
   const declarations = [];
   // collect declarations
   ruleNode.block.children.forEach((cssNode) => {
@@ -69,7 +69,9 @@ const parseRule = (ruleNode, dynamic) => {
 };
 
 /**
- * @type {(css: string, dynamic: boolean) => StylesheetRule[]}
+ * @param {string} css
+ * @param {boolean} dynamic
+ * @returns {StylesheetRule[]}
  */
 const parseStylesheet = (css, dynamic) => {
   /** @type {StylesheetRule[]} */
@@ -107,7 +109,8 @@ const parseStylesheet = (css, dynamic) => {
 };
 
 /**
- * @type {(css: string) => StylesheetDeclaration[]}
+ * @param {string} css
+ * @returns {StylesheetDeclaration[]}
  */
 const parseStyleDeclarations = (css) => {
   /** @type {StylesheetDeclaration[]} */
@@ -215,7 +218,8 @@ export const compareSpecificity = (a, b) => {
 };
 
 /**
- * @type {(root: XastRoot) => Stylesheet}
+ * @param {XastRoot} root
+ * @returns {Stylesheet}
  */
 export const collectStylesheet = (root) => {
   /** @type {StylesheetRule[]} */

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -8,7 +8,9 @@ import { parseSvg } from './parser.js';
  */
 
 /**
- * @type {(node: XastParent, id: string) => XastElement}
+ * @param {XastParent} node
+ * @param {string} id
+ * @returns {XastElement}
  */
 const getElementById = (node, id) => {
   /** @type {?XastElement} */

--- a/lib/svgo-node.test.js
+++ b/lib/svgo-node.test.js
@@ -2,10 +2,6 @@ import os from 'os';
 import path from 'path';
 import { optimize, loadConfig } from './svgo-node.js';
 
-/**
- * @typedef {import('../lib/types.js').Plugin<?>} Plugin
- */
-
 const describeLF = os.EOL === '\r\n' ? describe.skip : describe;
 const describeCRLF = os.EOL === '\r\n' ? describe : describe.skip;
 

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -1,10 +1,15 @@
+import { attrsGroups, referencesProps } from '../../plugins/_collections.js';
+
 /**
  * @typedef {import('../types.js').DataUri} DataUri
  * @typedef {import('../types.js').PathDataCommand} PathDataCommand
  * @typedef {import('../../lib/types.js').XastElement} XastElement
+ *
+ * @typedef CleanupOutDataParams
+ * @property {boolean=} noSpaceAfterFlags
+ * @property {boolean=} leadingZero
+ * @property {boolean=} negativeExtraSpace
  */
-
-import { attrsGroups, referencesProps } from '../../plugins/_collections.js';
 
 const regReferencesUrl = /\burl\((["'])?#(.+?)\1\)/g;
 const regReferencesHref = /^#(.+?)$/;
@@ -13,7 +18,9 @@ const regReferencesBegin = /(\w+)\.[a-zA-Z]/;
 /**
  * Encode plain SVG data string into Data URI string.
  *
- * @type {(str: string, type?: DataUri) => string}
+ * @param {string} str
+ * @param {DataUri=} type
+ * @returns {string}
  */
 export const encodeSVGDatauri = (str, type) => {
   var prefix = 'data:image/svg+xml';
@@ -34,7 +41,8 @@ export const encodeSVGDatauri = (str, type) => {
 /**
  * Decode SVG Data URI string into plain SVG string.
  *
- * @type {(str: string) => string}
+ * @param {string} str
+ * @returns {string}
  */
 export const decodeSVGDatauri = (str) => {
   var regexp = /data:image\/svg\+xml(;charset=[^;,]*)?(;base64)?,(.*)/;
@@ -59,27 +67,20 @@ export const decodeSVGDatauri = (str) => {
 };
 
 /**
- * @typedef {{
- *   noSpaceAfterFlags?: boolean,
- *   leadingZero?: boolean,
- *   negativeExtraSpace?: boolean
- * }} CleanupOutDataParams
- */
-
-/**
  * Convert a row of numbers to an optimized string view.
  *
  * @example
  * [0, -1, .5, .5] → "0-1 .5.5"
  *
- * @type {(data: number[], params: CleanupOutDataParams, command?: PathDataCommand) => string}
+ * @param {number[]} data
+ * @param {CleanupOutDataParams} params
+ * @param {PathDataCommand=} command
+ * @returns {string}
  */
 export const cleanupOutData = (data, params, command) => {
   let str = '';
   let delimiter;
-  /**
-   * @type {number}
-   */
+  /** @type {number} */
   let prev;
 
   data.forEach((item, i) => {

--- a/lib/xast.test.js
+++ b/lib/xast.test.js
@@ -6,18 +6,18 @@
 import { visit, visitSkip, detachNodeFromParent } from './xast.js';
 
 /**
- * @type {(children: XastElement[]) => XastRoot}
+ * @param {XastElement[]} children
+ * @returns {XastRoot}
  */
 const root = (children) => {
   return { type: 'root', children };
 };
 
 /**
- * @type {(
- *   name: string,
- *   attrs?: ?Record<string, string>,
- *   children?: XastElement[]
- * ) => XastElement}
+ * @param {string} name
+ * @param {?Record<string, string>} attrs
+ * @param {XastElement[]} children
+ * @returns {XastElement}
  */
 const x = (name, attrs = null, children = []) => {
   return { type: 'element', name, attributes: attrs || {}, children };
@@ -25,9 +25,7 @@ const x = (name, attrs = null, children = []) => {
 
 test('visit enters into nodes', () => {
   const ast = root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]);
-  /**
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const entered = [];
   visit(ast, {
     root: {
@@ -52,9 +50,7 @@ test('visit enters into nodes', () => {
 
 test('visit exits from nodes', () => {
   const ast = root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]);
-  /**
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const exited = [];
   visit(ast, {
     root: {
@@ -79,9 +75,7 @@ test('visit exits from nodes', () => {
 
 test('visit skips entering children if node is detached', () => {
   const ast = root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]);
-  /**
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const entered = [];
   visit(ast, {
     element: {
@@ -99,9 +93,7 @@ test('visit skips entering children if node is detached', () => {
 
 test('visit skips entering children when symbol is passed', () => {
   const ast = root([x('g', null, [x('rect'), x('circle')]), x('ellipse')]);
-  /**
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const entered = [];
   visit(ast, {
     element: {

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -1,12 +1,7 @@
 // https://www.w3.org/TR/SVG11/intro.html#Definitions
 
 /**
- * @typedef {import('../lib/svgo.ts')} svgo
- */
-
-/**
  * @type {Record<string, Set<string>>}
- * @see svgo#_collections
  */
 export const elemsGroups = {
   animation: new Set([
@@ -105,19 +100,12 @@ export const elemsGroups = {
   ]),
 };
 
-/**
- * @see svgo#_collections
- */
 export const textElems = new Set([...elemsGroups.textContent, 'pre', 'title']);
 
-/**
- * @see svgo#_collections
- */
 export const pathElems = new Set(['glyph', 'missing-glyph', 'path']);
 
 /**
  * @type {Record<string, Set<string>>}
- * @see svgo#_collections
  */
 export const attrsGroups = {
   animationAddition: new Set(['additive', 'accumulate']),
@@ -316,7 +304,6 @@ export const attrsGroups = {
 
 /**
  * @type {Record<string, Record<string, string>>}
- * @see svgo#_collections
  */
 export const attrsGroupsDefaults = {
   core: { 'xml:space': 'default' },
@@ -384,7 +371,6 @@ export const attrsGroupsDefaults = {
 
 /**
  * @type {Record<string, { safe?: Set<string>, unsafe?: Set<string> }>}
- * @see svgo#_collections
  */
 export const attrsGroupsDeprecated = {
   animationAttributeTarget: { unsafe: new Set(['attributeType']) },
@@ -414,7 +400,6 @@ export const attrsGroupsDeprecated = {
  *   contentGroups?: Set<string>,
  *   content?: Set<string>,
  * }>}
- * @see svgo#_collections
  */
 export const elems = {
   a: {
@@ -2073,9 +2058,6 @@ export const elems = {
   },
 };
 
-/**
- * @see svgo#_collections
- */
 export const editorNamespaces = new Set([
   'http://creativecommons.org/ns#',
   'http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd',
@@ -2101,9 +2083,6 @@ export const editorNamespaces = new Set([
   'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
 ]);
 
-/**
- * @see svgo#_collections
- */
 export const referencesProps = new Set([
   'clip-path',
   'color-profile',
@@ -2117,9 +2096,6 @@ export const referencesProps = new Set([
   'style',
 ]);
 
-/**
- * @see svgo#_collections
- */
 export const inheritableAttrs = new Set([
   'clip-rule',
   'color-interpolation-filters',
@@ -2181,7 +2157,6 @@ export const presentationNonInheritableGroupAttrs = new Set([
 
 /**
  * @type {Record<string, string>}
- * @see svgo#_collections
  */
 export const colorsNames = {
   aliceblue: '#f0f8ff',
@@ -2372,9 +2347,6 @@ export const colorsShortNames = {
   '#f5deb3': 'wheat',
 };
 
-/**
- * @see svgo#_collections
- */
 export const colorsProps = new Set([
   'color',
   'fill',
@@ -2384,9 +2356,6 @@ export const colorsProps = new Set([
   'stroke',
 ]);
 
-/**
- * @see svgo#_collections
- */
 export const pseudoClasses = {
   displayState: new Set(['fullscreen', 'modal', 'picture-in-picture']),
   input: new Set([

--- a/plugins/_path.js
+++ b/plugins/_path.js
@@ -3,24 +3,39 @@ import { parsePathData, stringifyPathData } from '../lib/path.js';
 /**
  * @typedef {import('../lib/types.js').XastElement} XastElement
  * @typedef {import('../lib/types.js').PathDataItem} PathDataItem
+ *
+ * @typedef Js2PathParams
+ * @property {number=} floatPrecision
+ * @property {boolean=} noSpaceAfterFlags
+ *
+ * @typedef Point
+ * @property {number[][]} list
+ * @property {number} minX
+ * @property {number} minY
+ * @property {number} maxX
+ * @property {number} maxY
+ *
+ * @typedef Points
+ * @property {Point[]} list
+ * @property {number} minX
+ * @property {number} minY
+ * @property {number} maxX
+ * @property {number} maxY
  */
 
-/**
- * @type {[number, number]}
- */
+/** @type {[number, number]} */
 var prevCtrlPoint;
 
 /**
  * Convert path string to JS representation.
  *
- * @type {(path: XastElement) => PathDataItem[]}
+ * @param {XastElement} path
+ * @returns {PathDataItem[]}
  */
 export const path2js = (path) => {
   // @ts-expect-error legacy
   if (path.pathJS) return path.pathJS;
-  /**
-   * @type {PathDataItem[]}
-   */
+  /** @type {PathDataItem[]} */
   const pathData = []; // JS representation of the path data
   const newPathData = parsePathData(path.attributes.d);
   for (const { command, args } of newPathData) {
@@ -38,13 +53,11 @@ export const path2js = (path) => {
 /**
  * Convert relative Path data to absolute.
  *
- * @type {(data: PathDataItem[]) => PathDataItem[]}
- *
+ * @param {PathDataItem[]} data
+ * @returns {PathDataItem[]}
  */
 const convertRelativeToAbsolute = (data) => {
-  /**
-   * @type {PathDataItem[]}
-   */
+  /** @type {PathDataItem[]} */
   const newData = [];
   let start = [0, 0];
   let cursor = [0, 0];
@@ -170,13 +183,11 @@ const convertRelativeToAbsolute = (data) => {
 };
 
 /**
- * @typedef {{ floatPrecision?: number, noSpaceAfterFlags?: boolean }} Js2PathParams
- */
-
-/**
  * Convert path array to string.
  *
- * @type {(path: XastElement, data: PathDataItem[], params: Js2PathParams) => void}
+ * @param {XastElement} path
+ * @param {PathDataItem[]} data
+ * @param {Js2PathParams} params
  */
 export const js2path = function (path, data, params) {
   // @ts-expect-error legacy
@@ -208,7 +219,9 @@ export const js2path = function (path, data, params) {
 };
 
 /**
- * @type {(dest: number[], source: number[]) => number[]}
+ * @param {number[]} dest
+ * @param {number[]} source
+ * @returns {number[]}
  */
 function set(dest, source) {
   dest[0] = source[source.length - 2];
@@ -221,7 +234,9 @@ function set(dest, source) {
  * collision using Gilbert-Johnson-Keerthi distance algorithm
  * https://web.archive.org/web/20180822200027/http://entropyinteractive.com/2011/04/gjk-algorithm/
  *
- * @type {(path1: PathDataItem[], path2: PathDataItem[]) => boolean}
+ * @param {PathDataItem[]} path1
+ * @param {PathDataItem[]} path2
+ * @returns {boolean}
  */
 export const intersects = function (path1, path2) {
   // Collect points of every subpath.
@@ -281,17 +296,24 @@ export const intersects = function (path1, path2) {
   });
 
   /**
-   * @type {(a: Point, b: Point, direction: number[]) => number[]}
+   * @param {Point} a
+   * @param {Point} b
+   * @param {number[]} direction
+   * @returns {number[]}
    */
   function getSupport(a, b, direction) {
     return sub(supportPoint(a, direction), supportPoint(b, minus(direction)));
   }
 
-  // Computes farthest polygon point in particular direction.
-  // Thanks to knowledge of min/max x and y coordinates we can choose a quadrant to search in.
-  // Since we're working on convex hull, the dot product is increasing until we find the farthest point.
   /**
-   * @type {(polygon: Point, direction: number[]) => number[]}
+   * Computes farthest polygon point in particular direction. Thanks to
+   * knowledge of min/max x and y coordinates we can choose a quadrant to search
+   * in. Since we're working on convex hull, the dot product is increasing until
+   * we find the farthest point.
+   *
+   * @param {Point} polygon
+   * @param {number[]} direction
+   * @returns {number[]}
    */
   function supportPoint(polygon, direction) {
     var index =
@@ -313,7 +335,9 @@ export const intersects = function (path1, path2) {
 };
 
 /**
- * @type {(simplex: number[][], direction: number[]) => boolean}
+ * @param {number[][]} simplex
+ * @param {number[]} direction
+ * @returns {boolean}
  */
 function processSimplex(simplex, direction) {
   // we only need to handle to 1-simplex and 2-simplex
@@ -370,28 +394,35 @@ function processSimplex(simplex, direction) {
 }
 
 /**
- * @type {(v: number[]) => number[]}
+ * @param {number[]} v
+ * @returns {number[]}
  */
 function minus(v) {
   return [-v[0], -v[1]];
 }
 
 /**
- * @type {(v1: number[], v2: number[]) => number[]}
+ * @param {number[]} v1
+ * @param {number[]} v2
+ * @returns {number[]}
  */
 function sub(v1, v2) {
   return [v1[0] - v2[0], v1[1] - v2[1]];
 }
 
 /**
- * @type {(v1: number[], v2: number[]) => number}
+ * @param {number[]} v1
+ * @param {number[]} v2
+ * @returns {number}
  */
 function dot(v1, v2) {
   return v1[0] * v2[0] + v1[1] * v2[1];
 }
 
 /**
- * @type {(v1: number[], v2: number[]) => number[]}
+ * @param {number[]} v
+ * @param {number[]} from
+ * @returns {number[]}
  */
 function orth(v, from) {
   var o = [-v[1], v[0]];
@@ -399,37 +430,18 @@ function orth(v, from) {
 }
 
 /**
- * @typedef {{
- *   list: number[][],
- *   minX: number,
- *   minY: number,
- *   maxX: number,
- *   maxY: number
- * }} Point
- */
-
-/**
- * @typedef {{
- *   list: Point[],
- *   minX: number,
- *   minY: number,
- *   maxX: number,
- *   maxY: number
- * }} Points
- */
-
-/**
- * @type {(pathData: PathDataItem[]) => Points}
+ * @param {PathDataItem[]} pathData
+ * @returns {Points}
  */
 function gatherPoints(pathData) {
-  /**
-   * @type {Points}
-   */
+  /** @type {Points} */
   const points = { list: [], minX: 0, minY: 0, maxX: 0, maxY: 0 };
 
-  // Writes data about the extreme points on each axle
   /**
-   * @type {(path: Point, point: number[]) => void}
+   * Writes data about the extreme points on each axle.
+   *
+   * @param {Point} path
+   * @param {number[]} point
    */
   const addPoint = (path, point) => {
     if (!path.list.length || point[1] > path.list[path.maxY][1]) {
@@ -471,9 +483,11 @@ function gatherPoints(pathData) {
     let data = pathDataItem.args;
     let ctrlPoint = basePoint;
 
+    // TODO fix null hack
     /**
-     * @type {(n: number, i: number) => number}
-     * TODO fix null hack
+     * @param {number} n
+     * @param {number} i
+     * @returns {number}
      */
     const toAbsolute = (n, i) => n + (basePoint == null ? 0 : basePoint[i % 2]);
 
@@ -600,10 +614,12 @@ function gatherPoints(pathData) {
 }
 
 /**
- * Forms a convex hull from set of points of every subpath using monotone chain convex hull algorithm.
- * https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+ * Forms a convex hull from set of points of every subpath using monotone chain
+ * convex hull algorithm.
  *
- * @type {(points: Point) => Point}
+ * @see https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+ * @param {Point} points
+ * @returns {Point}
  */
 function convexHull(points) {
   points.list.sort(function (a, b) {
@@ -652,9 +668,7 @@ function convexHull(points) {
 
   const hullList = lower.concat(upper);
 
-  /**
-   * @type {Point}
-   */
+  /** @type {Point} */
   const hull = {
     list: hullList,
     minX: 0, // by sorting
@@ -667,28 +681,30 @@ function convexHull(points) {
 }
 
 /**
- * @type {(o: number[], a: number[], b: number[]) => number}
+ * @param {number[]} o
+ * @param {number[]} a
+ * @param {number[]} b
+ * @returns {number}
  */
 function cross(o, a, b) {
   return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
 }
 
 /**
- * Based on code from Snap.svg (Apache 2 license). http://snapsvg.io/
- * Thanks to Dmitry Baranovskiy for his great work!
+ * Based on code from [Snap.svg](http://snapsvg.io/) (Apache 2 license). Thanks
+ * to Dmitry Baranovskiy for his great work!
  *
- * @type {(
- *  x1: number,
- *  y1: number,
- *  rx: number,
- *  ry: number,
- *  angle: number,
- *  large_arc_flag: number,
- *  sweep_flag: number,
- *  x2: number,
- *  y2: number,
- *  recursive: number[]
- * ) => number[]}
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} rx
+ * @param {number} ry
+ * @param {number} angle
+ * @param {number} large_arc_flag
+ * @param {number} sweep_flag
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number[]} recursive
+ * @returns {number[]}
  */
 const a2c = (
   x1,
@@ -706,18 +722,23 @@ const a2c = (
   // https://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
   const _120 = (Math.PI * 120) / 180;
   const rad = (Math.PI / 180) * (+angle || 0);
-  /**
-   * @type {number[]}
-   */
+  /** @type {number[]} */
   let res = [];
   /**
-   * @type {(x: number, y: number, rad: number) => number}
+   * @param {number} x
+   * @param {number} y
+   * @param {number} rad
+   * @returns {number}
    */
   const rotateX = (x, y, rad) => {
     return x * Math.cos(rad) - y * Math.sin(rad);
   };
+
   /**
-   * @type {(x: number, y: number, rad: number) => number}
+   * @param {number} x
+   * @param {number} y
+   * @param {number} rad
+   * @returns {number}
    */
   const rotateY = (x, y, rad) => {
     return x * Math.sin(rad) + y * Math.cos(rad);

--- a/plugins/_transforms.js
+++ b/plugins/_transforms.js
@@ -1,21 +1,24 @@
 import { cleanupOutData, toFixed } from '../lib/svgo/tools.js';
 
 /**
- * @typedef {{ name: string, data: number[] }} TransformItem
- * @typedef {{
- *   convertToShorts: boolean,
- *   degPrecision?: number,
- *   floatPrecision: number,
- *   transformPrecision: number,
- *   matrixToTransform: boolean,
- *   shortTranslate: boolean,
- *   shortScale: boolean,
- *   shortRotate: boolean,
- *   removeUseless: boolean,
- *   collapseIntoOne: boolean,
- *   leadingZero: boolean,
- *   negativeExtraSpace: boolean,
- * }} TransformParams
+ * @typedef TransformItem
+ * @property {string} name
+ * @property {number[]} data
+ *
+ * @typedef TransformParams
+ * @property {boolean} convertToShorts
+ * @property {number=} degPrecision
+ * @property {number} floatPrecision
+ * @property {number} transformPrecision
+ * @property {boolean} matrixToTransform
+ * @property {boolean} shortTranslate
+ * @property {boolean} shortScale
+ * @property {boolean} shortRotate
+ * @property {boolean} removeUseless
+ * @property {boolean} collapseIntoOne
+ * @property {boolean} leadingZero
+ * @property {boolean} negativeExtraSpace
+ *
  */
 
 const transformTypes = new Set([
@@ -488,7 +491,8 @@ export const matrixToTransform = (origMatrix, params) => {
 /**
  * Convert transform to the matrix data.
  *
- * @type {(transform: TransformItem) => number[] }
+ * @param {TransformItem} transform
+ * @returns {number[]}
  */
 const transformToMatrix = (transform) => {
   if (transform.name === 'matrix') {
@@ -534,16 +538,16 @@ const transformToMatrix = (transform) => {
 };
 
 /**
- * Applies transformation to an arc. To do so, we represent ellipse as a matrix, multiply it
- * by the transformation matrix and use a singular value decomposition to represent in a form
- * rotate(θ)·scale(a b)·rotate(φ). This gives us new ellipse params a, b and θ.
- * SVD is being done with the formulae provided by Wolfram|Alpha (svd {{m0, m2}, {m1, m3}})
+ * Applies transformation to an arc. To do so, we represent ellipse as a matrix,
+ * multiply it by the transformation matrix and use a singular value
+ * decomposition to represent in a form rotate(θ)·scale(a b)·rotate(φ). This
+ * gives us new ellipse params a, b and θ. SVD is being done with the formulae
+ * provided by Wolfram|Alpha (svd {{m0, m2}, {m1, m3}})
  *
- * @type {(
- *   cursor: [x: number, y: number],
- *   arc: number[],
- *   transform: number[]
- * ) => number[]}
+ * @param {[number, number]} cursor
+ * @param {number[]} arc
+ * @param {number[]} transform
+ * @returns {number[]}
  */
 export const transformArc = (cursor, arc, transform) => {
   const x = arc[5] - cursor[0];
@@ -604,7 +608,9 @@ export const transformArc = (cursor, arc, transform) => {
 /**
  * Multiply transformation matrices.
  *
- * @type {(a: number[], b: number[]) => number[]}
+ * @param {number[]} a
+ * @param {number[]} b
+ * @returns {number[]}
  */
 const multiplyTransformMatrices = (a, b) => {
   return [
@@ -618,7 +624,9 @@ const multiplyTransformMatrices = (a, b) => {
 };
 
 /**
- * @type {(transform: TransformItem, params: TransformParams) => TransformItem}
+ * @param {TransformItem} transform
+ * @param {TransformParams} params
+ * @returns {TransformItem}
  */
 export const roundTransform = (transform, params) => {
   switch (transform.name) {
@@ -649,7 +657,9 @@ export const roundTransform = (transform, params) => {
 };
 
 /**
- * @type {(data: number[], params: TransformParams) => number[]}
+ * @param {number[]} data
+ * @param {TransformParams} params
+ * @returns {number[]}
  */
 const degRound = (data, params) => {
   if (
@@ -664,7 +674,9 @@ const degRound = (data, params) => {
 };
 
 /**
- * @type {(data: number[], params: TransformParams) => number[]}
+ * @param {number[]} data
+ * @param {TransformParams} params
+ * @returns {number[]}
  */
 const floatRound = (data, params) => {
   if (params.floatPrecision >= 1 && params.floatPrecision < 20) {
@@ -675,7 +687,9 @@ const floatRound = (data, params) => {
 };
 
 /**
- * @type {(data: number[], params: TransformParams) => number[]}
+ * @param {number[]} data
+ * @param {TransformParams} params
+ * @returns {number[]}
  */
 const transformRound = (data, params) => {
   if (params.transformPrecision >= 1 && params.floatPrecision < 20) {
@@ -688,16 +702,16 @@ const transformRound = (data, params) => {
 /**
  * Rounds numbers in array.
  *
- * @type {(data: number[]) => number[]}
+ * @param {number[]} data
+ * @returns {number[]}
  */
 const round = (data) => {
   return data.map(Math.round);
 };
 
 /**
- * Decrease accuracy of floating-point numbers
- * in transforms keeping a specified number of decimals.
- * Smart rounds values like 2.349 to 2.35.
+ * Decrease accuracy of floating-point numbers in transforms keeping a specified
+ * number of decimals. Smart rounds values like 2.349 to 2.35.
  *
  * @param {number} precision
  * @param {number[]} data

--- a/plugins/applyTransforms.js
+++ b/plugins/applyTransforms.js
@@ -1,8 +1,3 @@
-/**
- * @typedef {import('../lib/types.js').PathDataItem} PathDataItem
- * @typedef {import('../lib/types.js').XastElement} XastElement
- */
-
 import { path2js } from './_path.js';
 import {
   transformsMultiply,
@@ -15,8 +10,8 @@ import { collectStylesheet, computeStyle } from '../lib/style.js';
 import { removeLeadingZero, includesUrlReference } from '../lib/svgo/tools.js';
 
 /**
- * @typedef {PathDataItem[]} PathData
- * @typedef {number[]} Matrix
+ * @typedef {import('../lib/types.js').PathDataItem} PathDataItem
+ * @typedef {import('../lib/types.js').XastElement} XastElement
  */
 
 const regNumericValues = /[-+]?(\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g;
@@ -158,7 +153,10 @@ export const applyTransforms = (root, params) => {
 };
 
 /**
- * @type {(matrix: Matrix, x: number, y: number) => [number, number]}
+ * @param {number[]} matrix
+ * @param {number} x
+ * @param {number} y
+ * @returns {[number, number]}
  */
 const transformAbsolutePoint = (matrix, x, y) => {
   const newX = matrix[0] * x + matrix[2] * y + matrix[4];
@@ -167,7 +165,10 @@ const transformAbsolutePoint = (matrix, x, y) => {
 };
 
 /**
- * @type {(matrix: Matrix, x: number, y: number) => [number, number]}
+ * @param {number[]} matrix
+ * @param {number} x
+ * @param {number} y
+ * @returns {[number, number]}
  */
 const transformRelativePoint = (matrix, x, y) => {
   const newX = matrix[0] * x + matrix[2] * y;
@@ -176,16 +177,13 @@ const transformRelativePoint = (matrix, x, y) => {
 };
 
 /**
- * @type {(pathData: PathData, matrix: Matrix) => void}
+ * @param {PathDataItem[]} pathData
+ * @param {number[]} matrix
  */
 const applyMatrixToPathData = (pathData, matrix) => {
-  /**
-   * @type {[number, number]}
-   */
+  /** @type {[number, number]} */
   const start = [0, 0];
-  /**
-   * @type {[number, number]}
-   */
+  /** @type {[number, number]} */
   const cursor = [0, 0];
 
   for (const pathItem of pathData) {

--- a/plugins/cleanupEnableBackground.js
+++ b/plugins/cleanupEnableBackground.js
@@ -1,6 +1,10 @@
 import * as csstree from 'css-tree';
 import { visit } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'cleanupEnableBackground';
 export const description =
   'remove or cleanup enable-background attribute when possible';
@@ -17,7 +21,7 @@ const regEnableBackground =
  *             ⬇
  * <svg width="100" height="50">
  * @author Kir Belevich
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = (root) => {
   let hasFilter = false;

--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -74,7 +74,9 @@ const maxIdIndex = generateIdChars.length - 1;
 /**
  * Check if an ID starts with any one of a list of strings.
  *
- * @type {(string: string, prefixes: string[]) => boolean}
+ * @param {string} string
+ * @param {string[]} prefixes
+ * @returns {boolean}
  */
 const hasStringPrefix = (string, prefixes) => {
   for (const prefix of prefixes) {
@@ -114,7 +116,8 @@ const generateId = (currentId) => {
 /**
  * Get string from generated ID array.
  *
- * @type {(arr: number[]) => string}
+ * @param {number[]} arr
+ * @returns {string}
  */
 const getIdString = (arr) => {
   return arr.map((i) => generateIdChars[i]).join('');
@@ -144,13 +147,9 @@ export const fn = (_root, params) => {
     : preservePrefixes
       ? [preservePrefixes]
       : [];
-  /**
-   * @type {Map<string, XastElement>}
-   */
+  /** @type {Map<string, XastElement>} */
   const nodeById = new Map();
-  /**
-   * @type {Map<string, {element: XastElement, name: string }[]>}
-   */
+  /** @type {Map<string, {element: XastElement, name: string }[]>} */
   const referencesById = new Map();
   let deoptimized = false;
 

--- a/plugins/cleanupListOfValues.js
+++ b/plugins/cleanupListOfValues.js
@@ -49,7 +49,8 @@ export const fn = (_root, params) => {
   } = params;
 
   /**
-   * @type {(lists: string) => string}
+   * @param {string} lists
+   * @returns {string}
    */
   const roundValues = (lists) => {
     const roundedList = [];
@@ -64,9 +65,7 @@ export const fn = (_root, params) => {
         let num = Number(Number(match[1]).toFixed(floatPrecision));
         /** @type {any} */
         let matchedUnit = match[3] || '';
-        /**
-         * @type {'' | keyof typeof absoluteLengths}
-         */
+        /** @type {'' | keyof typeof absoluteLengths} */
         let units = matchedUnit;
 
         // convert absolute values to pixels

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -2,6 +2,7 @@ import { computeStyle, collectStylesheet } from '../lib/style.js';
 import { inheritableAttrs, elemsGroups } from './_collections.js';
 
 /**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
  * @typedef {import('../lib/types.js').XastElement} XastElement
  * @typedef {import('../lib/types.js').XastNode} XastNode
  */
@@ -10,7 +11,9 @@ export const name = 'collapseGroups';
 export const description = 'collapses useless groups';
 
 /**
- * @type {(node: XastNode, name: string) => boolean}
+ * @param {XastNode} node
+ * @param {string} name
+ * @returns {boolean}
  */
 const hasAnimatedAttr = (node, name) => {
   if (node.type === 'element') {
@@ -49,7 +52,7 @@ const hasAnimatedAttr = (node, name) => {
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -32,7 +32,8 @@ const regHEX = /^#(([a-fA-F0-9])\2){3}$/;
  *
  * @author Jed Schmidt
  *
- * @type {(rgb: number[]) => string}
+ * @param {number[]} param0
+ * @returns {string}
  */
 const convertRgbToHex = ([r, g, b]) => {
   // combine the octets into a 32-bit integer as: [1][r][g][b]

--- a/plugins/convertEllipseToCircle.js
+++ b/plugins/convertEllipseToCircle.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'convertEllipseToCircle';
 export const description = 'converts non-eccentric <ellipse>s to <circle>s';
 
@@ -8,7 +12,7 @@ export const description = 'converts non-eccentric <ellipse>s to <circle>s';
  *
  * @author Taylor Hunt
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/convertOneStopGradients.js
+++ b/plugins/convertOneStopGradients.js
@@ -7,6 +7,7 @@ import {
 import { computeStyle, collectStylesheet } from '../lib/style.js';
 
 /**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
  * @typedef {import('../lib/types.js').XastElement} XastElement
  * @typedef {import('../lib/types.js').XastParent} XastParent
  */
@@ -19,7 +20,7 @@ export const description =
  * Converts one-stop (single color) gradients to a plain color.
  *
  * @author Seth Falco <seth@falco.fun>
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  * @see https://developer.mozilla.org/docs/Web/SVG/Element/linearGradient
  * @see https://developer.mozilla.org/docs/Web/SVG/Element/radialGradient
  */
@@ -33,14 +34,10 @@ export const fn = (root) => {
    */
   const effectedDefs = new Set();
 
-  /**
-   * @type {Map<XastElement, XastParent>}
-   */
+  /** @type {Map<XastElement, XastParent>} */
   const allDefs = new Map();
 
-  /**
-   * @type {Map<XastElement, XastParent>}
-   */
+  /** @type {Map<XastElement, XastParent>} */
   const gradientsToDetach = new Map();
 
   /** Number of references to the xlink:href attribute. */

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -96,9 +96,7 @@ export const fn = (root, params) => {
     forceAbsolutePath = false,
   } = params;
 
-  /**
-   * @type {InternalParams}
-   */
+  /** @type {InternalParams} */
   const newParams = {
     applyTransforms: _applyTransforms,
     applyTransformsStroked,
@@ -215,7 +213,8 @@ export const fn = (root, params) => {
 /**
  * Convert absolute path data coordinates to relative.
  *
- * @type {(pathData: PathDataItem[]) => PathDataItem[]}
+ * @param {PathDataItem[]} pathData
+ * @returns {PathDataItem[]}
  */
 const convertToRelative = (pathData) => {
   let start = [0, 0];
@@ -388,11 +387,10 @@ const convertToRelative = (pathData) => {
 /**
  * Main filters loop.
  *
- * @type {(
- *   path: PathDataItem[],
- *   params: InternalParams,
- *   aux: { isSafeToUseZ: boolean, maybeHasStrokeAndLinecap: boolean, hasMarkerMid: boolean }
- * ) => PathDataItem[]}
+ * @param {PathDataItem[]} path
+ * @param {InternalParams} params
+ * @param {{ isSafeToUseZ: boolean, maybeHasStrokeAndLinecap: boolean, hasMarkerMid: boolean }} param2
+ * @returns {PathDataItem[]}
  */
 function filters(
   path,
@@ -439,9 +437,7 @@ function filters(
         var r = roundData([circle.radius])[0],
           angle = findArcAngle(sdata, circle),
           sweep = sdata[5] * sdata[0] - sdata[4] * sdata[1] > 0 ? 1 : 0,
-          /**
-           * @type {PathDataItem}
-           */
+          /** @type {PathDataItem} */
           arc = {
             command: 'a',
             args: [r, r, 0, 0, sweep, sdata[4], sdata[5]],
@@ -450,14 +446,10 @@ function filters(
             // @ts-expect-error
             base: item.base,
           },
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           output = [arc],
           // relative coordinates to adjust the found circle
-          /**
-           * @type {Point}
-           */
+          /** @type {Point} */
           relCenter = [
             circle.center[0] - sdata[4],
             circle.center[1] - sdata[5],
@@ -922,7 +914,9 @@ function filters(
 /**
  * Writes data in shortest form using absolute or relative coordinates.
  *
- * @type {(path: PathDataItem[], params: InternalParams) => PathDataItem[]}
+ * @param {PathDataItem[]} path
+ * @param {InternalParams} params
+ * @returns {PathDataItem[]}
  */
 function convertToMixed(path, params) {
   var prev = path[0];
@@ -1004,7 +998,8 @@ function convertToMixed(path, params) {
  * Checks if curve is convex. Control points of such a curve must form a convex
  * quadrilateral with diagonals crosspoint inside of it.
  *
- * @type {(data: number[]) => boolean}
+ * @param {number[]} data
+ * @returns {boolean}
  */
 function isConvex(data) {
   var center = getIntersection([
@@ -1030,7 +1025,8 @@ function isConvex(data) {
 /**
  * Computes lines equations by two points and returns their intersection point.
  *
- * @type {(coords: number[]) => undefined | Point}
+ * @param {number[]} coords
+ * @returns {Point | undefined}
  */
 function getIntersection(coords) {
   // Prev line equation parameters.
@@ -1045,9 +1041,7 @@ function getIntersection(coords) {
 
   if (!denom) return; // parallel lines haven't an intersection
 
-  /**
-   * @type {Point}
-   */
+  /** @type {Point} */
   var cross = [(b1 * c2 - b2 * c1) / denom, (a1 * c2 - a2 * c1) / -denom];
   if (
     !isNaN(cross[0]) &&
@@ -1060,12 +1054,12 @@ function getIntersection(coords) {
 }
 
 /**
- * Decrease accuracy of floating-point numbers
- * in path data keeping a specified number of decimals.
- * Smart rounds values like 2.3491 to 2.35 instead of 2.349.
+ * Decrease accuracy of floating-point numbers in path data keeping a specified
+ * number of decimals. Smart rounds values like 2.3491 to 2.35 instead of 2.349.
  * Doesn't apply "smartness" if the number precision fits already.
  *
- * @type {(data: number[]) => number[]}
+ * @param {number[]} data
+ * @returns {number[]}
  */
 function strongRound(data) {
   const precisionNum = precision || 0;
@@ -1085,7 +1079,8 @@ function strongRound(data) {
 /**
  * Simple rounding function if precision is 0.
  *
- * @type {(data: number[]) => number[]}
+ * @param {number[]} data
+ * @returns {number[]}
  */
 function round(data) {
   for (var i = data.length; i-- > 0; ) {
@@ -1095,10 +1090,11 @@ function round(data) {
 }
 
 /**
- * Checks if a curve is a straight line by measuring distance
- * from middle points to the line formed by end points.
+ * Checks if a curve is a straight line by measuring distance from middle points
+ * to the line formed by end points.
  *
- * @type {(data: number[]) => boolean}
+ * @param {number[]} data
+ * @returns {boolean}
  */
 function isCurveStraightLine(data) {
   // Get line equation a·x + b·y + c = 0 coefficients a, b (c = 0) by start and end points.
@@ -1121,8 +1117,9 @@ function isCurveStraightLine(data) {
 /**
  * Calculates the sagitta of an arc if possible.
  *
- * @type {(data: number[]) => number | undefined}
  * @see https://wikipedia.org/wiki/Sagitta_(geometry)#Formulas
+ * @param {number[]} data
+ * @returns {number | undefined}
  */
 function calculateSagitta(data) {
   if (data[3] === 1) return undefined;
@@ -1136,7 +1133,9 @@ function calculateSagitta(data) {
 /**
  * Converts next curve from shorthand to full form using the current curve data.
  *
- * @type {(item: PathDataItem, data: number[]) => PathDataItem}
+ * @param {PathDataItem} item
+ * @param {number[]} data
+ * @returns {PathDataItem}
  */
 function makeLonghand(item, data) {
   switch (item.command) {
@@ -1157,7 +1156,9 @@ function makeLonghand(item, data) {
 /**
  * Returns distance between two points
  *
- * @type {(point1: Point, point2: Point) => number}
+ * @param {Point} point1
+ * @param {Point} point2
+ * @returns {number}
  */
 function getDistance(point1, point2) {
   return Math.hypot(point1[0] - point2[0], point1[1] - point2[1]);
@@ -1179,7 +1180,9 @@ function reflectPoint(controlPoint, base) {
  * a·(1 - t)³·p1 + b·(1 - t)²·t·p2 + c·(1 - t)·t²·p3 + d·t³·p4,
  * where pN are control points and p1 is zero due to relative coordinates.
  *
- * @type {(curve: number[], t: number) => Point}
+ * @param {number[]} curve
+ * @param {number} t
+ * @returns {Point}
  */
 function getCubicBezierPoint(curve, t) {
   var sqrT = t * t,
@@ -1196,7 +1199,8 @@ function getCubicBezierPoint(curve, t) {
 /**
  * Finds circle by 3 points of the curve and checks if the curve fits the found circle.
  *
- * @type {(curve: number[]) => undefined | Circle}
+ * @param {number[]} curve
+ * @returns {Circle | undefined}
  */
 function findCircle(curve) {
   var midPoint = getCubicBezierPoint(curve, 1 / 2),
@@ -1236,7 +1240,9 @@ function findCircle(curve) {
 /**
  * Checks if a curve fits the given circle.
  *
- * @type {(curve: number[], circle: Circle) => boolean}
+ * @param {number[]} curve
+ * @param {Circle} circle
+ * @returns {boolean}
  */
 function isArc(curve, circle) {
   var tolerance = Math.min(
@@ -1257,7 +1263,9 @@ function isArc(curve, circle) {
 /**
  * Checks if a previous curve fits the given circle.
  *
- * @type {(curve: number[], circle: Circle) => boolean}
+ * @param {number[]} curve
+ * @param {Circle} circle
+ * @returns {boolean}
  */
 function isArcPrev(curve, circle) {
   return isArc(curve, {
@@ -1268,8 +1276,10 @@ function isArcPrev(curve, circle) {
 
 /**
  * Finds angle of a curve fitting the given arc.
-
- * @type {(curve: number[], relCircle: Circle) => number}
+ *
+ * @param {number[]} curve
+ * @param {Circle} relCircle
+ * @returns {number}
  */
 function findArcAngle(curve, relCircle) {
   var x1 = -relCircle.center[0],
@@ -1285,7 +1295,9 @@ function findArcAngle(curve, relCircle) {
 /**
  * Converts given path data to string.
  *
- * @type {(params: InternalParams, pathData: PathDataItem[]) => string}
+ * @param {InternalParams} params
+ * @param {PathDataItem[]} pathData
+ * @returns {string}
  */
 function data2Path(params, pathData) {
   return pathData.reduce(function (pathString, item) {

--- a/plugins/convertShapeToPath.js
+++ b/plugins/convertShapeToPath.js
@@ -47,9 +47,7 @@ export const fn = (root, params) => {
           // cleanupNumericValues when 'px' units has already been removed.
           // TODO: Calculate sizes from % and non-px units if possible.
           if (Number.isNaN(x - y + width - height)) return;
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const pathData = [
             { command: 'M', args: [x, y] },
             { command: 'H', args: [x + width] },
@@ -72,9 +70,7 @@ export const fn = (root, params) => {
           const x2 = Number(node.attributes.x2 || '0');
           const y2 = Number(node.attributes.y2 || '0');
           if (Number.isNaN(x1 - y1 + x2 - y2)) return;
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const pathData = [
             { command: 'M', args: [x1, y1] },
             { command: 'L', args: [x2, y2] },
@@ -99,9 +95,7 @@ export const fn = (root, params) => {
             detachNodeFromParent(node, parentNode);
             return;
           }
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const pathData = [];
           for (let i = 0; i < coords.length; i += 2) {
             pathData.push({
@@ -125,9 +119,7 @@ export const fn = (root, params) => {
           if (Number.isNaN(cx - cy + r)) {
             return;
           }
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const pathData = [
             { command: 'M', args: [cx, cy - r] },
             { command: 'A', args: [r, r, 0, 1, 0, cx, cy + r] },
@@ -150,9 +142,7 @@ export const fn = (root, params) => {
           if (Number.isNaN(ecx - ecy + rx - ry)) {
             return;
           }
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const pathData = [
             { command: 'M', args: [ecx, ecy - ry] },
             { command: 'A', args: [rx, ry, 0, 1, 0, ecx, ecy + ry] },

--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -9,7 +9,8 @@ export const name = 'convertStyleToAttrs';
 export const description = 'converts style to attributes';
 
 /**
- * @type {(...args: string[]) => string}
+ * @param {...string} args
+ * @returns {string}
  */
 const g = (...args) => {
   return '(?:' + args.join('|') + ')';
@@ -85,9 +86,7 @@ export const fn = (_root, params) => {
         if (node.attributes.style != null) {
           // ['opacity: 1', 'color: #000']
           let styles = [];
-          /**
-           * @type {Record<string, string>}
-           */
+          /** @type {Record<string, string>} */
           const newAttributes = {};
 
           // Strip CSS comments preserving escape sequences and strings.

--- a/plugins/convertTransform.js
+++ b/plugins/convertTransform.js
@@ -24,6 +24,24 @@ import {
  * @property {boolean=} collapseIntoOne
  * @property {boolean=} leadingZero
  * @property {boolean=} negativeExtraSpace
+ *
+ * @typedef TransformParams
+ * @property {boolean} convertToShorts
+ * @property {number=} degPrecision
+ * @property {number} floatPrecision
+ * @property {number} transformPrecision
+ * @property {boolean} matrixToTransform
+ * @property {boolean} shortTranslate
+ * @property {boolean} shortScale
+ * @property {boolean} shortRotate
+ * @property {boolean} removeUseless
+ * @property {boolean} collapseIntoOne
+ * @property {boolean} leadingZero
+ * @property {boolean} negativeExtraSpace
+ *
+ * @typedef TransformItem
+ * @property {string} name
+ * @property {number[]} data
  */
 
 export const name = 'convertTransform';
@@ -92,27 +110,6 @@ export const fn = (_root, params) => {
 };
 
 /**
- * @typedef {{
- *   convertToShorts: boolean,
- *   degPrecision?: number,
- *   floatPrecision: number,
- *   transformPrecision: number,
- *   matrixToTransform: boolean,
- *   shortTranslate: boolean,
- *   shortScale: boolean,
- *   shortRotate: boolean,
- *   removeUseless: boolean,
- *   collapseIntoOne: boolean,
- *   leadingZero: boolean,
- *   negativeExtraSpace: boolean,
- * }} TransformParams
- */
-
-/**
- * @typedef {{ name: string, data: number[] }} TransformItem
- */
-
-/**
  * @param {XastElement} item
  * @param {string} attrName
  * @param {TransformParams} params
@@ -144,14 +141,17 @@ const convertTransform = (item, attrName, params) => {
 
 /**
  * Defines precision to work with certain parts.
- * transformPrecision - for scale and four first matrix parameters (needs a better precision due to multiplying),
- * floatPrecision - for translate including two last matrix and rotate parameters,
- * degPrecision - for rotate and skew. By default it's equal to (roughly)
- * transformPrecision - 2 or floatPrecision whichever is lower. Can be set in params.
  *
- * @type {(data: TransformItem[], params: TransformParams) => TransformParams}
+ * - `transformPrecision` - for scale and four first matrix parameters (needs a better precision due to multiplying).
+ * - `floatPrecision` - for translate including two last matrix and rotate parameters.
+ * - `degPrecision` - for rotate and skew. By default it's equal to (roughly).
+ * - `transformPrecision` - 2 or floatPrecision whichever is lower. Can be set in params.
  *
- * clone params so it don't affect other elements transformations.
+ * Clone parameters so that it doesn't affect other element transformations.
+ *
+ * @param {TransformItem[]} data
+ * @param {TransformParams} param1
+ * @returns {TransformParams}
  */
 const definePrecision = (data, { ...newParams }) => {
   const matrixData = [];
@@ -186,9 +186,11 @@ const definePrecision = (data, { ...newParams }) => {
 };
 
 /**
- * Returns number of digits after the point. 0.125 → 3
+ * Returns number of digits after the point.
  *
- * @type {(n: number) => number}
+ * @example 0.125 → 3
+ * @param {number} n
+ * @returns {number}
  */
 const floatDigits = (n) => {
   const str = n.toString();
@@ -274,7 +276,8 @@ const convertToShorts = (transforms, params) => {
 /**
  * Remove useless transforms.
  *
- * @type {(transforms: TransformItem[]) => TransformItem[]}
+ * @param {TransformItem[]} transforms
+ * @returns {TransformItem[]}
  */
 const removeUseless = (transforms) => {
   return transforms.filter((transform) => {

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -57,7 +57,11 @@ export const fn = (root, params) => {
   } = params;
 
   /**
-   * @type {{ node: XastElement, parentNode: XastParent, cssAst: csstree.StyleSheet }[]}
+   * @type {{
+   *   node: XastElement,
+   *   parentNode: XastParent,
+   *   cssAst: csstree.StyleSheet
+   * }[]}
    */
   const styles = [];
   /**

--- a/plugins/mergeStyles.js
+++ b/plugins/mergeStyles.js
@@ -1,6 +1,7 @@
 import { visitSkip, detachNodeFromParent } from '../lib/xast.js';
 
 /**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
  * @typedef {import('../lib/types.js').XastElement} XastElement
  * @typedef {import('../lib/types.js').XastChild} XastChild
  */
@@ -13,17 +14,13 @@ export const description = 'merge multiple style elements into one';
  *
  * @author strarsis <strarsis@gmail.com>
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
-  /**
-   * @type {?XastElement}
-   */
+  /** @type {?XastElement} */
   let firstStyleElement = null;
   let collectedStyles = '';
-  /**
-   * @type {'text' | 'cdata'}
-   */
+  /** @type {'text' | 'cdata'} */
   let styleContentType = 'text';
 
   return {
@@ -79,9 +76,7 @@ export const fn = () => {
           firstStyleElement = node;
         } else {
           detachNodeFromParent(node, parentNode);
-          /**
-           * @type {XastChild}
-           */
+          /** @type {XastChild} */
           const child = { type: styleContentType, value: collectedStyles };
           firstStyleElement.children = [child];
         }

--- a/plugins/moveElemsAttrsToGroup.js
+++ b/plugins/moveElemsAttrsToGroup.js
@@ -1,6 +1,10 @@
 import { visit } from '../lib/xast.js';
 import { inheritableAttrs, pathElems } from './_collections.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'moveElemsAttrsToGroup';
 export const description =
   'Move common attributes of group children to the group';
@@ -25,7 +29,7 @@ export const description =
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = (root) => {
   // find if any style element is present
@@ -55,7 +59,8 @@ export const fn = (root) => {
         }
 
         /**
-         * find common attributes in group children
+         * Find common attributes in group children.
+         *
          * @type {Map<string, string>}
          */
         const commonAttributes = new Map();

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -1,6 +1,10 @@
 import { pathElems, referencesProps } from './_collections.js';
 import { includesUrlReference } from '../lib/svgo/tools.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'moveGroupAttrsToElems';
 export const description =
   'moves some group attributes to the content elements';
@@ -23,7 +27,7 @@ const pathElemsWithGroupsAndText = [...pathElems, 'g', 'text'];
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -16,8 +16,10 @@ export const name = 'prefixIds';
 export const description = 'prefix IDs';
 
 /**
- * extract basename from path
- * @type {(path: string) => string}
+ * Extract basename from path.
+ *
+ * @param {string} path
+ * @returns {string}
  */
 const getBasename = (path) => {
   // extract everything after latest slash or backslash
@@ -29,15 +31,18 @@ const getBasename = (path) => {
 };
 
 /**
- * escapes a string for being used as ID
- * @type {(string: string) => string}
+ * Escapes a string for being used as ID.
+ *
+ * @param {string} str
+ * @returns {string}
  */
 const escapeIdentifierName = (str) => {
   return str.replace(/[. ]/g, '_');
 };
 
 /**
- * @type {(string: string) => string}
+ * @param {string} string
+ * @returns {string}
  */
 const unquote = (string) => {
   if (

--- a/plugins/removeDoctype.js
+++ b/plugins/removeDoctype.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeDoctype';
 export const description = 'removes doctype declaration';
 
@@ -25,7 +29,7 @@ export const description = 'removes doctype declaration';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeEditorsNSData.js
+++ b/plugins/removeEditorsNSData.js
@@ -27,9 +27,7 @@ export const fn = (_root, params) => {
   if (Array.isArray(params.additionalNamespaces)) {
     namespaces = [...editorNamespaces, ...params.additionalNamespaces];
   }
-  /**
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const prefixes = [];
   return {
     element: {

--- a/plugins/removeEmptyAttrs.js
+++ b/plugins/removeEmptyAttrs.js
@@ -1,5 +1,9 @@
 import { attrsGroups } from './_collections.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeEmptyAttrs';
 export const description = 'removes empty attributes';
 
@@ -8,7 +12,7 @@ export const description = 'removes empty attributes';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeEmptyContainers.js
+++ b/plugins/removeEmptyContainers.js
@@ -2,6 +2,10 @@ import { elemsGroups } from './_collections.js';
 import { detachNodeFromParent } from '../lib/xast.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeEmptyContainers';
 export const description = 'removes empty container elements';
 
@@ -18,7 +22,7 @@ export const description = 'removes empty container elements';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -90,17 +90,13 @@ export const fn = (root, params) => {
    */
   const removedDefIds = new Set();
 
-  /**
-   * @type {Map<XastElement, XastParent>}
-   */
+  /** @type {Map<XastElement, XastParent>} */
   const allDefs = new Map();
 
   /** @type {Set<string>} */
   const allReferences = new Set();
 
-  /**
-   * @type {Map<string, Array<{ node: XastElement, parentNode: XastParent }>>}
-   */
+  /** @type {Map<string, Array<{ node: XastElement, parentNode: XastParent }>>} */
   const referencesById = new Map();
 
   /**

--- a/plugins/removeMetadata.js
+++ b/plugins/removeMetadata.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeMetadata';
 export const description = 'removes <metadata>';
 
@@ -10,7 +14,7 @@ export const description = 'removes <metadata>';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeNonInheritableGroupAttrs.js
+++ b/plugins/removeNonInheritableGroupAttrs.js
@@ -4,6 +4,10 @@ import {
   presentationNonInheritableGroupAttrs,
 } from './_collections.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeNonInheritableGroupAttrs';
 export const description =
   'removes non-inheritable group’s presentational attributes';
@@ -13,7 +17,7 @@ export const description =
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -1,10 +1,11 @@
-/**
- * @typedef {import('../lib/types.js').PathDataItem} PathDataItem
- */
-
 import { visitSkip, detachNodeFromParent } from '../lib/xast.js';
 import { parsePathData } from '../lib/path.js';
 import { intersects } from './_path.js';
+
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ * @typedef {import('../lib/types.js').PathDataItem} PathDataItem
+ */
 
 export const name = 'removeOffCanvasPaths';
 export const description =
@@ -15,7 +16,7 @@ export const description =
  *
  * @author JoshyPHP
  *
- * @type {import('../lib/types.js').Plugin<'removeOffCanvasPaths'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   /**
@@ -113,9 +114,7 @@ export const fn = () => {
           }
 
           const { left, top, width, height } = viewBoxData;
-          /**
-           * @type {PathDataItem[]}
-           */
+          /** @type {PathDataItem[]} */
           const viewBoxPathData = [
             { command: 'M', args: [left, top] },
             { command: 'h', args: [width] },

--- a/plugins/removeRasterImages.js
+++ b/plugins/removeRasterImages.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeRasterImages';
 export const description = 'removes raster images (disabled by default)';
 
@@ -10,7 +14,7 @@ export const description = 'removes raster images (disabled by default)';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin<'removeRasterImages'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -1,6 +1,10 @@
 import { attrsGroups } from './_collections.js';
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeScripts';
 export const description = 'removes scripts (disabled by default)';
 
@@ -19,7 +23,7 @@ const eventAttrs = [
  * https://www.w3.org/TR/SVG11/script.html
  *
  * @author Patrick Klingemann
- * @type {import('../lib/types.js').Plugin<'removeScripts'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeStyleElement.js
+++ b/plugins/removeStyleElement.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeStyleElement';
 export const description = 'removes <style> element (disabled by default)';
 
@@ -10,7 +14,7 @@ export const description = 'removes <style> element (disabled by default)';
  *
  * @author Betsy Dupuis
  *
- * @type {import('../lib/types.js').Plugin<'removeStyleElement'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeTitle.js
+++ b/plugins/removeTitle.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeTitle';
 export const description = 'removes <title>';
 
@@ -10,7 +14,7 @@ export const description = 'removes <title>';
  *
  * @author Igor Kalashnikov
  *
- * @type {import('../lib/types.js').Plugin<'removeTitle'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -29,23 +29,15 @@ export const description =
 
 // resolve all groups references
 
-/**
- * @type {Map<string, Set<string>>}
- */
+/** @type {Map<string, Set<string>>} */
 const allowedChildrenPerElement = new Map();
-/**
- * @type {Map<string, Set<string>>}
- */
+/** @type {Map<string, Set<string>>} */
 const allowedAttributesPerElement = new Map();
-/**
- * @type {Map<string, Map<string, string>>}
- */
+/** @type {Map<string, Map<string, string>>} */
 const attributesDefaultsPerElement = new Map();
 
 for (const [name, config] of Object.entries(elems)) {
-  /**
-   * @type {Set<string>}
-   */
+  /** @type {Set<string>} */
   const allowedChildren = new Set();
   if (config.content) {
     for (const elementName of config.content) {
@@ -62,18 +54,14 @@ for (const [name, config] of Object.entries(elems)) {
       }
     }
   }
-  /**
-   * @type {Set<string>}
-   */
+  /** @type {Set<string>} */
   const allowedAttributes = new Set();
   if (config.attrs) {
     for (const attrName of config.attrs) {
       allowedAttributes.add(attrName);
     }
   }
-  /**
-   * @type {Map<string, string>}
-   */
+  /** @type {Map<string, string>} */
   const attributesDefaults = new Map();
   if (config.defaults) {
     for (const [attrName, defaultValue] of Object.entries(config.defaults)) {

--- a/plugins/removeUnusedNS.js
+++ b/plugins/removeUnusedNS.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeUnusedNS';
 export const description = 'removes unused namespaces declaration';
 
@@ -7,12 +11,10 @@ export const description = 'removes unused namespaces declaration';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
-  /**
-   * @type {Set<string>}
-   */
+  /** @type {Set<string>} */
   const unusedNamespaces = new Set();
   return {
     element: {

--- a/plugins/removeUselessDefs.js
+++ b/plugins/removeUselessDefs.js
@@ -2,6 +2,7 @@ import { detachNodeFromParent } from '../lib/xast.js';
 import { elemsGroups } from './_collections.js';
 
 /**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
  * @typedef {import('../lib/types.js').XastElement} XastElement
  */
 
@@ -13,7 +14,7 @@ export const description = 'removes elements in <defs> without id';
  *
  * @author Lev Solntsev
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {
@@ -24,9 +25,7 @@ export const fn = () => {
           (elemsGroups.nonRendering.has(node.name) &&
             node.attributes.id == null)
         ) {
-          /**
-           * @type {XastElement[]}
-           */
+          /** @type {XastElement[]} */
           const usefulNodes = [];
           collectUsefulNodes(node, usefulNodes);
           if (usefulNodes.length === 0) {
@@ -40,7 +39,8 @@ export const fn = () => {
 };
 
 /**
- * @type {(node: XastElement, usefulNodes: XastElement[]) => void}
+ * @param {XastElement} node
+ * @param {XastElement[]} usefulNodes
  */
 const collectUsefulNodes = (node, usefulNodes) => {
   for (const child of node.children) {

--- a/plugins/removeViewBox.js
+++ b/plugins/removeViewBox.js
@@ -1,6 +1,10 @@
 export const name = 'removeViewBox';
 export const description = 'removes viewBox attribute when possible';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 const viewBoxElems = new Set(['pattern', 'svg', 'symbol']);
 
 /**
@@ -15,7 +19,7 @@ const viewBoxElems = new Set(['pattern', 'svg', 'symbol']);
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin<'removeViewBox'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeXMLNS.js
+++ b/plugins/removeXMLNS.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeXMLNS';
 export const description =
   'removes xmlns attribute (for inline svg, disabled by default)';
@@ -12,7 +16,7 @@ export const description =
  *
  * @author Ricardo Tomasi
  *
- * @type {import('../lib/types.js').Plugin<'removeXMLNS'>}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/removeXMLProcInst.js
+++ b/plugins/removeXMLProcInst.js
@@ -1,5 +1,9 @@
 import { detachNodeFromParent } from '../lib/xast.js';
 
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'removeXMLProcInst';
 export const description = 'removes XML processing instructions';
 
@@ -11,7 +15,7 @@ export const description = 'removes XML processing instructions';
  *
  * @author Kir Belevich
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -2,6 +2,7 @@ import { collectStylesheet } from '../lib/style.js';
 import { detachNodeFromParent, querySelectorAll } from '../lib/xast.js';
 
 /**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
  * @typedef {import('../lib/types.js').XastElement} XastElement
  * @typedef {import('../lib/types.js').XastParent} XastParent
  * @typedef {import('../lib/types.js').XastNode} XastNode
@@ -19,14 +20,12 @@ export const description =
  *
  * @author Jacob Howcroft
  *
- * @type {import('../lib/types.js').Plugin<'reusePaths'>}
+ * @type {Plugin}
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);
 
-  /**
-   * @type {Map<string, XastElement[]>}
-   */
+  /** @type {Map<string, XastElement[]>} */
   const paths = new Map();
 
   /**

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -39,7 +39,8 @@ export const fn = (_root, params) => {
   } = params;
 
   /**
-   * @type {(name: string) => number}
+   * @param {string} name
+   * @returns {number}
    */
   const getNsPriority = (name) => {
     if (xmlnsOrder === 'front') {
@@ -61,7 +62,9 @@ export const fn = (_root, params) => {
   };
 
   /**
-   * @type {(a: [string, string], b: [string, string]) => number}
+   * @param {[string, string]} param0
+   * @param {[string, string]} param1
+   * @returns {number}
    */
   const compareAttrs = ([aName], [bName]) => {
     // sort namespaces
@@ -98,9 +101,7 @@ export const fn = (_root, params) => {
       enter: (node) => {
         const attrs = Object.entries(node.attributes);
         attrs.sort(compareAttrs);
-        /**
-         * @type {Record<string, string>}
-         */
+        /** @type {Record<string, string>} */
         const sortedAttributes = {};
         for (const [name, value] of attrs) {
           sortedAttributes[name] = value;

--- a/plugins/sortDefsChildren.js
+++ b/plugins/sortDefsChildren.js
@@ -1,22 +1,25 @@
+/**
+ * @typedef {import('../lib/types.js').Plugin} Plugin
+ */
+
 export const name = 'sortDefsChildren';
 export const description = 'Sorts children of <defs> to improve compression';
 
 /**
- * Sorts children of defs in order to improve compression.
- * Sorted first by frequency then by element name length then by element name (to ensure grouping).
+ * Sorts children of defs in order to improve compression. Sorted first by
+ * frequency then by element name length then by element name (to ensure
+ * grouping).
  *
  * @author David Leston
  *
- * @type {import('../lib/types.js').Plugin}
+ * @type {Plugin}
  */
 export const fn = () => {
   return {
     element: {
       enter: (node) => {
         if (node.name === 'defs') {
-          /**
-           * @type {Map<string, number>}
-           */
+          /** @type {Map<string, number>} */
           const frequencies = new Map();
           for (const child of node.children) {
             if (child.type === 'element') {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -10,7 +10,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * @type {(proc: ChildProcessWithoutNullStreams) => Promise<string>}
+ * @param {ChildProcessWithoutNullStreams} proc
+ * @returns {Promise<string>}
  */
 const waitStdout = (proc) => {
   return new Promise((resolve) => {
@@ -21,7 +22,8 @@ const waitStdout = (proc) => {
 };
 
 /**
- * @type {(proc: ChildProcessWithoutNullStreams) => Promise<void>}
+ * @param {ChildProcessWithoutNullStreams} proc
+ * @returns {Promise<void>}
  */
 const waitClose = (proc) => {
   return new Promise((resolve) => {


### PR DESCRIPTION
Does a bulk update on all JSDoc and JSDoc types. I've spent a lot of time looking at these since I was investigating a better way to approach exporting our types.

In many of my previous PRs, I'd be slowly amending some of the JSDocs anyway, but decided to do a bulk update now to normalize how we do JSDocs, which will reduce the noise in future PRs.

* For functions, prefer the more verbose tags like `@param` and `@returns`, rather than `@type`. We use this version in some cases to document the function, and I personally prefer this syntax is it closer to what JSDoc intended rather than coupling too tightly the type checker.
* When using `@type` on its own, use a single line.
* Keep all `@typedef` directives at the top of the file under the `import` statements.
* Fix minor grammar/casing issues in some JSDocs, I also formatted docs to utilize 80 columns.
* Removes some instances where we import a `@typedef` but never use it.
* In `plugins/_collections.js`, dropped the `@see` directive, as in retrospect I think it doesn't make sense to point the implementation to where it was exported.
* In `plugins/applyTransforms.js`, deletes the two type aliases for `PathData` and `Matrix` as the types were being aliases to achieve what variables names already do.

This makes _no_ changes to the implementation.