### PR TITLE
chore: refactor stringifier.js

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -72,7 +72,8 @@ const isDigit = (c) => {
 const readNumber = (string, cursor) => {
   let i = cursor;
   let value = '';
-  let state = /** @type {ReadNumberState} */ ('none');
+  /** @type {ReadNumberState} */
+  let state = 'none';
   for (; i < string.length; i += 1) {
     const c = string[i];
     if (c === '+' || c === '-') {

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -1,15 +1,15 @@
 import { textElems } from '../plugins/_collections.js';
 
 /**
- * @typedef {import('./types.js').XastParent} XastParent
- * @typedef {import('./types.js').XastRoot} XastRoot
- * @typedef {import('./types.js').XastElement} XastElement
- * @typedef {import('./types.js').XastInstruction} XastInstruction
- * @typedef {import('./types.js').XastDoctype} XastDoctype
- * @typedef {import('./types.js').XastText} XastText
+ * @typedef {import('./types.js').StringifyOptions} StringifyOptions
  * @typedef {import('./types.js').XastCdata} XastCdata
  * @typedef {import('./types.js').XastComment} XastComment
- * @typedef {import('./types.js').StringifyOptions} StringifyOptions
+ * @typedef {import('./types.js').XastDoctype} XastDoctype
+ * @typedef {import('./types.js').XastElement} XastElement
+ * @typedef {import('./types.js').XastInstruction} XastInstruction
+ * @typedef {import('./types.js').XastParent} XastParent
+ * @typedef {import('./types.js').XastRoot} XastRoot
+ * @typedef {import('./types.js').XastText} XastText
  * @typedef {Required<StringifyOptions>} Options
  *
  * @typedef State
@@ -114,28 +114,29 @@ export const stringifySvg = (data, userOptions = {}) => {
  */
 const stringifyNode = (data, config, state) => {
   let svg = '';
-  state.indentLevel += 1;
+  state.indentLevel++;
   for (const item of data.children) {
-    if (item.type === 'element') {
-      svg += stringifyElement(item, config, state);
-    }
-    if (item.type === 'text') {
-      svg += stringifyText(item, config, state);
-    }
-    if (item.type === 'doctype') {
-      svg += stringifyDoctype(item, config);
-    }
-    if (item.type === 'instruction') {
-      svg += stringifyInstruction(item, config);
-    }
-    if (item.type === 'comment') {
-      svg += stringifyComment(item, config);
-    }
-    if (item.type === 'cdata') {
-      svg += stringifyCdata(item, config, state);
+    switch (item.type) {
+      case 'element':
+        svg += stringifyElement(item, config, state);
+        break;
+      case 'text':
+        svg += stringifyText(item, config, state);
+        break;
+      case 'doctype':
+        svg += stringifyDoctype(item, config);
+        break;
+      case 'instruction':
+        svg += stringifyInstruction(item, config);
+        break;
+      case 'comment':
+        svg += stringifyComment(item, config);
+        break;
+      case 'cdata':
+        svg += stringifyCdata(item, config, state);
     }
   }
-  state.indentLevel -= 1;
+  state.indentLevel--;
   return svg;
 };
 
@@ -215,59 +216,59 @@ const stringifyElement = (node, config, state) => {
         stringifyAttributes(node, config) +
         config.tagShortEnd
       );
-    } else {
-      return (
-        createIndent(config, state) +
-        config.tagShortStart +
-        node.name +
-        stringifyAttributes(node, config) +
-        config.tagOpenEnd +
-        config.tagCloseStart +
-        node.name +
-        config.tagCloseEnd
-      );
-    }
-    // non-empty element
-  } else {
-    let tagOpenStart = config.tagOpenStart;
-    let tagOpenEnd = config.tagOpenEnd;
-    let tagCloseStart = config.tagCloseStart;
-    let tagCloseEnd = config.tagCloseEnd;
-    let openIndent = createIndent(config, state);
-    let closeIndent = createIndent(config, state);
-
-    if (state.textContext) {
-      tagOpenStart = defaults.tagOpenStart;
-      tagOpenEnd = defaults.tagOpenEnd;
-      tagCloseStart = defaults.tagCloseStart;
-      tagCloseEnd = defaults.tagCloseEnd;
-      openIndent = '';
-    } else if (textElems.has(node.name)) {
-      tagOpenEnd = defaults.tagOpenEnd;
-      tagCloseStart = defaults.tagCloseStart;
-      closeIndent = '';
-      state.textContext = node;
-    }
-
-    const children = stringifyNode(node, config, state);
-
-    if (state.textContext === node) {
-      state.textContext = null;
     }
 
     return (
-      openIndent +
-      tagOpenStart +
+      createIndent(config, state) +
+      config.tagShortStart +
       node.name +
       stringifyAttributes(node, config) +
-      tagOpenEnd +
-      children +
-      closeIndent +
-      tagCloseStart +
+      config.tagOpenEnd +
+      config.tagCloseStart +
       node.name +
-      tagCloseEnd
+      config.tagCloseEnd
     );
   }
+
+  // non-empty element
+  let tagOpenStart = config.tagOpenStart;
+  let tagOpenEnd = config.tagOpenEnd;
+  let tagCloseStart = config.tagCloseStart;
+  let tagCloseEnd = config.tagCloseEnd;
+  let openIndent = createIndent(config, state);
+  let closeIndent = createIndent(config, state);
+
+  if (state.textContext) {
+    tagOpenStart = defaults.tagOpenStart;
+    tagOpenEnd = defaults.tagOpenEnd;
+    tagCloseStart = defaults.tagCloseStart;
+    tagCloseEnd = defaults.tagCloseEnd;
+    openIndent = '';
+  } else if (textElems.has(node.name)) {
+    tagOpenEnd = defaults.tagOpenEnd;
+    tagCloseStart = defaults.tagCloseStart;
+    closeIndent = '';
+    state.textContext = node;
+  }
+
+  const children = stringifyNode(node, config, state);
+
+  if (state.textContext === node) {
+    state.textContext = null;
+  }
+
+  return (
+    openIndent +
+    tagOpenStart +
+    node.name +
+    stringifyAttributes(node, config) +
+    tagOpenEnd +
+    children +
+    closeIndent +
+    tagCloseStart +
+    node.name +
+    tagCloseEnd
+  );
 };
 
 /**
@@ -278,14 +279,13 @@ const stringifyElement = (node, config, state) => {
 const stringifyAttributes = (node, config) => {
   let attrs = '';
   for (const [name, value] of Object.entries(node.attributes)) {
-    // TODO remove attributes without values support in v3
+    attrs += ' ' + name;
+
     if (value !== undefined) {
       const encodedValue = value
         .toString()
         .replace(config.regValEntities, config.encodeEntity);
-      attrs += ' ' + name + config.attrStart + encodedValue + config.attrEnd;
-    } else {
-      attrs += ' ' + name;
+      attrs += config.attrStart + encodedValue + config.attrEnd;
     }
   }
   return attrs;


### PR DESCRIPTION
A small chore that refactors `lib/stringifier.js`.

* Utilizes early returns instead of `else` branches.
* Replaces the `if`/`else` chain with a `switch`.
* Moves the shared part of `#stringifyAttributes` outside the conditionals.
* Sorts `@typedef` directives.

---

Context: A lot of my PRs at the moment are just to clean up code, as I'm spending a lot of time going through our APIs and types. My focus right now is on quality of code, documentation, types, and testing, etc, rather than on bug fixes. Should be releasing v4.0.0-rc.2 this weekend. :crossed_fingers: