### PR TITLE
chore: omit unneccesary slugs in docs

### DIFF
--- a/docs/02-usage/02-browser.mdx
+++ b/docs/02-usage/02-browser.mdx
@@ -1,6 +1,5 @@
 ---
 title: Browser
-slug: 'browser'
 ---
 
 SVGO can run in the browser, but how to use it depends on the structure of your project.

--- a/docs/06-migrations/01-migration-from-v3-to-v4.mdx
+++ b/docs/06-migrations/01-migration-from-v3-to-v4.mdx
@@ -1,6 +1,5 @@
 ---
 title: Migration from v3 to v4
-slug: 'migration-from-v3-to-v4'
 ---
 
 This is a summary of the changes necessary to migrate from SVGO v3 to SVGO v4. If you want more details or have any questions, please refer to our [release notes for SVGO v4.0.0](https://github.com/svg/svgo/releases/tag/v4.0.0) or related pull requests. You're also encouraged to leave comments in pull requests if the existing content doesn't already answer your question.


### PR DESCRIPTION
Very minor change to remove the `slug` from front matter where it's the same as what the generated slug would be anyway. (From the file name.)