### PR TITLE
fix: fix `loadConfig` types

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -37,7 +37,7 @@ export * from './svgo.js';
  * You can also specify relative or absolute path and customize current working
  * directory.
  *
- * @type {<T extends string>(configFile: T | null, cwd?: string) => Promise<T extends string ? import('./svgo.js').Config : import('./svgo.js').Config | null>}
+ * @type {<T extends string>(configFile?: T | null, cwd?: string) => Promise<T extends string ? import('./svgo.js').Config : import('./svgo.js').Config | null>}
  */
 export const loadConfig = async (configFile, cwd = process.cwd()) => {
   if (configFile != null) {


### PR DESCRIPTION
`configFile` is optional in 4.0.0-rc.1

https://github.com/svg/svgo/blob/49954bc0d9ec3dcf166bef59657ad1e78909ff1e/lib/svgo-node.d.ts#L10-L17