### PR TITLE
chore: add krita namespace to list of editor namespaces

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -2080,6 +2080,7 @@ export const elems = {
 export const editorNamespaces = new Set([
   'http://creativecommons.org/ns#',
   'http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd',
+  'http://krita.org/namespaces/svg/krita',
   'http://ns.adobe.com/AdobeIllustrator/10.0/',
   'http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/',
   'http://ns.adobe.com/Extensibility/1.0/',


### PR DESCRIPTION
Adds Krita's SVG extension namespace to the list of editor namespaces.

I did export an SVG from Krita manually to confirm this is an expected namespace that Krita actually exports SVGs with.

## Related

* Fixes https://github.com/svg/svgo/issues/2130
* Originally reported in https://github.com/gregberge/svgr/issues/1001#issue-3049625403