### PR TITLE
fix: invoke mapNodesToParents lazily

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -1,7 +1,8 @@
 import * as csstree from 'css-tree';
 import * as csswhat from 'css-what';
 import { syntax } from 'csso';
-import { matches, visit } from './xast.js';
+import { matches } from './xast.js';
+import { visit } from './util/visit.js';
 import {
   attrsGroups,
   inheritableAttrs,

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -1,5 +1,5 @@
 import { collectStylesheet, computeStyle } from './style.js';
-import { visit } from './xast.js';
+import { visit } from './util/visit.js';
 import { parseSvg } from './parser.js';
 
 /**

--- a/lib/svgo.js
+++ b/lib/svgo.js
@@ -1,7 +1,8 @@
 import { builtinPlugins } from './builtin.js';
 import { encodeSVGDatauri } from './svgo/tools.js';
 import { invokePlugins } from './svgo/plugins.js';
-import { mapNodesToParents, querySelector, querySelectorAll } from './xast.js';
+import { querySelector, querySelectorAll } from './xast.js';
+import { mapNodesToParents } from './util/map-nodes-to-parents.js';
 import { parseSvg } from './parser.js';
 import { stringifySvg } from './stringifier.js';
 import { VERSION } from './version.js';

--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -1,3 +1,5 @@
+import { mapNodesToParents } from '../util/map-nodes-to-parents.js';
+
 /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['isTag']} */
 const isTag = (node) => {
   return node.type === 'element';
@@ -69,12 +71,17 @@ const findOne = (test, elems) => {
 };
 
 /**
- * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>} parents
+ * @param {import('../types.js').XastParent} relativeNode
+ * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>=} parents
  * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
  */
-export function createAdapter(parents) {
+export function createAdapter(relativeNode, parents) {
   /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getParent']} */
   const getParent = (node) => {
+    if (!parents) {
+      parents = mapNodesToParents(relativeNode);
+    }
+
     return parents.get(node) || null;
   };
 

--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -1,4 +1,4 @@
-import { visit } from '../xast.js';
+import { visit } from '../util/visit.js';
 
 /**
  * Plugins engine.

--- a/lib/util/map-nodes-to-parents.js
+++ b/lib/util/map-nodes-to-parents.js
@@ -1,0 +1,29 @@
+import { visit } from './visit.js';
+
+/**
+ * Maps all nodes to their parent node recursively.
+ *
+ * @param {import('../types.js').XastParent} node
+ * @returns {Map<import('../types.js').XastNode, import('../types.js').XastParent>}
+ */
+export function mapNodesToParents(node) {
+  /** @type {Map<import('../types.js').XastNode, import('../types.js').XastParent>} */
+  const parents = new Map();
+
+  for (const child of node.children) {
+    parents.set(child, node);
+    visit(
+      child,
+      {
+        element: {
+          enter: (child, parent) => {
+            parents.set(child, parent);
+          },
+        },
+      },
+      node,
+    );
+  }
+
+  return parents;
+}

--- a/lib/util/visit.js
+++ b/lib/util/visit.js
@@ -1,0 +1,36 @@
+export const visitSkip = Symbol();
+
+/**
+ * @param {import('../types.js').XastNode} node
+ * @param {import('../types.js').Visitor} visitor
+ * @param {any=} parentNode
+ */
+export const visit = (node, visitor, parentNode) => {
+  const callbacks = visitor[node.type];
+  if (callbacks?.enter) {
+    // @ts-expect-error hard to infer
+    const symbol = callbacks.enter(node, parentNode);
+    if (symbol === visitSkip) {
+      return;
+    }
+  }
+  // visit root children
+  if (node.type === 'root') {
+    // copy children array to not lose cursor when children is spliced
+    for (const child of node.children) {
+      visit(child, visitor, node);
+    }
+  }
+  // visit element children if still attached to parent
+  if (node.type === 'element') {
+    if (parentNode.children.includes(node)) {
+      for (const child of node.children) {
+        visit(child, visitor, node);
+      }
+    }
+  }
+  if (callbacks?.exit) {
+    // @ts-expect-error hard to infer
+    callbacks.exit(node, parentNode);
+  }
+};

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -2,42 +2,15 @@ import { is, selectAll, selectOne } from 'css-select';
 import { createAdapter } from './svgo/css-select-adapter.js';
 
 /**
- * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>} parents
+ * @param {import('./types.js').XastParent} relativeNode
+ * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {import('css-select').Options<import('./types.js').XastNode & { children?: any }, import('./types.js').XastElement>}
  */
-function createCssSelectOptions(parents) {
+function createCssSelectOptions(relativeNode, parents) {
   return {
     xmlMode: true,
-    adapter: createAdapter(parents),
+    adapter: createAdapter(relativeNode, parents),
   };
-}
-
-/**
- * Maps all nodes to their parent node recursively.
- *
- * @param {import('./types.js').XastParent} node
- * @returns {Map<import('./types.js').XastNode, import('./types.js').XastParent>}
- */
-export function mapNodesToParents(node) {
-  /** @type {Map<import('./types.js').XastNode, import('./types.js').XastParent>} */
-  const parents = new Map();
-
-  for (const child of node.children) {
-    parents.set(child, node);
-    visit(
-      child,
-      {
-        element: {
-          enter: (child, parent) => {
-            parents.set(child, parent);
-          },
-        },
-      },
-      node,
-    );
-  }
-
-  return parents;
 }
 
 /**
@@ -46,12 +19,8 @@ export function mapNodesToParents(node) {
  * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {import('./types.js').XastChild[]} All matching elements.
  */
-export const querySelectorAll = (
-  node,
-  selector,
-  parents = mapNodesToParents(node),
-) => {
-  return selectAll(selector, node, createCssSelectOptions(parents));
+export const querySelectorAll = (node, selector, parents) => {
+  return selectAll(selector, node, createCssSelectOptions(node, parents));
 };
 
 /**
@@ -60,12 +29,8 @@ export const querySelectorAll = (
  * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {?import('./types.js').XastChild} First match, or null if there was no match.
  */
-export const querySelector = (
-  node,
-  selector,
-  parents = mapNodesToParents(node),
-) => {
-  return selectOne(selector, node, createCssSelectOptions(parents));
+export const querySelector = (node, selector, parents) => {
+  return selectOne(selector, node, createCssSelectOptions(node, parents));
 };
 
 /**
@@ -74,45 +39,8 @@ export const querySelector = (
  * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {boolean}
  */
-export const matches = (node, selector, parents = mapNodesToParents(node)) => {
-  return is(node, selector, createCssSelectOptions(parents));
-};
-
-export const visitSkip = Symbol();
-
-/**
- * @param {import('./types.js').XastNode} node
- * @param {import('./types.js').Visitor} visitor
- * @param {any=} parentNode
- */
-export const visit = (node, visitor, parentNode) => {
-  const callbacks = visitor[node.type];
-  if (callbacks?.enter) {
-    // @ts-expect-error hard to infer
-    const symbol = callbacks.enter(node, parentNode);
-    if (symbol === visitSkip) {
-      return;
-    }
-  }
-  // visit root children
-  if (node.type === 'root') {
-    // copy children array to not lose cursor when children is spliced
-    for (const child of node.children) {
-      visit(child, visitor, node);
-    }
-  }
-  // visit element children if still attached to parent
-  if (node.type === 'element') {
-    if (parentNode.children.includes(node)) {
-      for (const child of node.children) {
-        visit(child, visitor, node);
-      }
-    }
-  }
-  if (callbacks?.exit) {
-    // @ts-expect-error hard to infer
-    callbacks.exit(node, parentNode);
-  }
+export const matches = (node, selector, parents) => {
+  return is(node, selector, createCssSelectOptions(node, parents));
 };
 
 /**

--- a/lib/xast.test.js
+++ b/lib/xast.test.js
@@ -1,4 +1,5 @@
-import { detachNodeFromParent, visit, visitSkip } from './xast.js';
+import { detachNodeFromParent } from './xast.js';
+import { visit, visitSkip } from './util/visit.js';
 
 /**
  * @param {import('./types.js').XastElement[]} children

--- a/plugins/cleanupEnableBackground.js
+++ b/plugins/cleanupEnableBackground.js
@@ -1,5 +1,5 @@
 import * as csstree from 'css-tree';
-import { visit } from '../lib/xast.js';
+import { visit } from '../lib/util/visit.js';
 
 export const name = 'cleanupEnableBackground';
 export const description =

--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -1,4 +1,4 @@
-import { visitSkip } from '../lib/xast.js';
+import { visitSkip } from '../lib/util/visit.js';
 import { findReferences, hasScripts } from '../lib/svgo/tools.js';
 
 /**

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -2,7 +2,7 @@ import { js2path, path2js } from './_path.js';
 import { pathElems } from './_collections.js';
 import { applyTransforms } from './applyTransforms.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
-import { visit } from '../lib/xast.js';
+import { visit } from '../lib/util/visit.js';
 import { cleanupOutData, toFixed } from '../lib/svgo/tools.js';
 
 /**

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -1,11 +1,8 @@
 import * as csstree from 'css-tree';
 import { syntax } from 'csso';
 import { attrsGroups, pseudoClasses } from './_collections.js';
-import {
-  detachNodeFromParent,
-  querySelectorAll,
-  visitSkip,
-} from '../lib/xast.js';
+import { detachNodeFromParent, querySelectorAll } from '../lib/xast.js';
+import { visitSkip } from '../lib/util/visit.js';
 import { compareSpecificity, includesAttrSelector } from '../lib/style.js';
 
 /**

--- a/plugins/mergeStyles.js
+++ b/plugins/mergeStyles.js
@@ -1,4 +1,5 @@
-import { detachNodeFromParent, visitSkip } from '../lib/xast.js';
+import { detachNodeFromParent } from '../lib/xast.js';
+import { visitSkip } from '../lib/util/visit.js';
 
 export const name = 'mergeStyles';
 export const description = 'merge multiple style elements into one';

--- a/plugins/moveElemsAttrsToGroup.js
+++ b/plugins/moveElemsAttrsToGroup.js
@@ -1,4 +1,4 @@
-import { visit } from '../lib/xast.js';
+import { visit } from '../lib/util/visit.js';
 import { inheritableAttrs, pathElems } from './_collections.js';
 
 export const name = 'moveElemsAttrsToGroup';

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -1,10 +1,6 @@
 import { elemsGroups } from './_collections.js';
-import {
-  detachNodeFromParent,
-  querySelector,
-  visit,
-  visitSkip,
-} from '../lib/xast.js';
+import { detachNodeFromParent, querySelector } from '../lib/xast.js';
+import { visit, visitSkip } from '../lib/util/visit.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 import { parsePathData } from '../lib/path.js';
 import { findReferences, hasScripts } from '../lib/svgo/tools.js';

--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -1,4 +1,5 @@
-import { detachNodeFromParent, visitSkip } from '../lib/xast.js';
+import { detachNodeFromParent } from '../lib/xast.js';
+import { visitSkip } from '../lib/util/visit.js';
 import { parsePathData } from '../lib/path.js';
 import { intersects } from './_path.js';
 

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -5,7 +5,8 @@ import {
   elemsGroups,
   presentationNonInheritableGroupAttrs,
 } from './_collections.js';
-import { detachNodeFromParent, visitSkip } from '../lib/xast.js';
+import { detachNodeFromParent } from '../lib/xast.js';
+import { visitSkip } from '../lib/util/visit.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 
 /**

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -1,4 +1,5 @@
-import { detachNodeFromParent, visit, visitSkip } from '../lib/xast.js';
+import { detachNodeFromParent } from '../lib/xast.js';
+import { visit, visitSkip } from '../lib/util/visit.js';
 import { collectStylesheet, computeStyle } from '../lib/style.js';
 import { hasScripts } from '../lib/svgo/tools.js';
 import { elemsGroups } from './_collections.js';


### PR DESCRIPTION
In a recent PR, I introduced a significant performance regression to SVGO. This was missed as it only had a noticeable impact on very large SVGs. In the SVG I tested locally, it took 70~ seconds to optimize before the commit, then 240~ seconds after the commit.

This fix takes it down to around 74~ seconds.

Instead of populating the map of nodes to parent nodes eagerly when creating the css-select Adapter, we know defer it to when css-select would actually invoke the `Adapter#getParent` method. In most instances, the map was never being used, so it was a waste of compute to initialize and populate the map.

To avoid Rollup reporting circular dependencies, I've created a `util` directory, and migrated some of the helpers to isolated files.

## Related

* Issue introduced in https://github.com/svg/svgo/pull/2113
* SVG tested was from https://github.com/svg/svgo/issues/2075