### PR TITLE
performance: small optimization when parsing svgs

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -169,13 +169,17 @@ export const parseSvg = (data, from) => {
           value: text,
         };
         pushToContent(node);
-      } else if (/\S/.test(text)) {
-        /** @type {import('./types.js').XastText} */
-        const node = {
-          type: 'text',
-          value: text.trim(),
-        };
-        pushToContent(node);
+      } else {
+        const value = text.trim();
+
+        if (value !== '') {
+          /** @type {import('./types.js').XastText} */
+          const node = {
+            type: 'text',
+            value,
+          };
+          pushToContent(node);
+        }
       }
     }
   };


### PR DESCRIPTION
Very minor performance improvement to parsing of SVGs. Instead of using a regular expression, we assume we should trim the string.

1. In the majority of cases, `string#trim` is faster than `RegExp#test`. ¹
2. If the condition was true, we would call `string#trim` separately, but if we assume we should call `string#trim`, then the string is already prepped as we proceed.

¹ The only instance where `RegExp#test` is faster for our use-case is when given a string with obscene amounts of whitespace on either end (50+ chars). In the overwhelming majority of cases that we encounter, the amount of whitespace found is about what you'd expect from formatted XML, which is so little that trimming works out faster.

## Testing

I've checked and can confirm this has no impact on the final SVG for any of our regression tests.