### PR TITLE
fix(convertColors): use currentColor instead of currentcolor

### DIFF
--- a/docs/04-plugins/convertColors.mdx
+++ b/docs/04-plugins/convertColors.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     currentColor:
-      description: If to convert all instances of a color to `currentcolor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/docs/Web/CSS/color) property in CSS.
+      description: If to convert all instances of a color to `currentColor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/docs/Web/CSS/color) property in CSS.
       default: false
     names2hex:
       description: If to convert color names to the hex equivalent.

--- a/docs/04-plugins/removeAttrs.mdx
+++ b/docs/04-plugins/removeAttrs.mdx
@@ -10,7 +10,7 @@ svgo:
       description: The pattern syntax used by this plugin is `element:attribute:value`, this changes the delimiter from `:` to another string.
       default: ':'
     preserveCurrentColor:
-      description: If to ignore the attribute when it's set to `currentcolor`.
+      description: If to ignore the attribute when it's set to `currentColor`.
       default: false
 ---
 

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -107,7 +107,7 @@ export const fn = (_root, params) => {
                 matched = val !== 'none';
               }
               if (matched) {
-                val = 'currentcolor';
+                val = 'currentColor';
               }
             }
 
@@ -136,7 +136,11 @@ export const fn = (_root, params) => {
               }
             }
 
-            if (convertCase && !includesUrlReference(val)) {
+            if (
+              convertCase &&
+              !includesUrlReference(val) &&
+              val !== 'currentColor'
+            ) {
               if (convertCase === 'lower') {
                 val = val.toLowerCase();
               } else if (convertCase === 'upper') {

--- a/test/plugins/convertColors.04.svg.txt
+++ b/test/plugins/convertColors.04.svg.txt
@@ -11,12 +11,12 @@
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg">
-    <g color="currentcolor"/>
-    <g color="currentcolor"/>
+    <g color="currentColor"/>
+    <g color="currentColor"/>
     <g color="none"/>
-    <path fill="currentcolor"/>
-    <path fill="currentcolor"/>
-    <path fill="currentcolor"/>
+    <path fill="currentColor"/>
+    <path fill="currentColor"/>
+    <path fill="currentColor"/>
     <path fill="none"/>
 </svg>
 

--- a/test/plugins/convertColors.06.svg.txt
+++ b/test/plugins/convertColors.06.svg.txt
@@ -21,7 +21,7 @@ Do not apply currentColor to masks.
 @@@
 
 <svg xmlns="http://www.w3.org/2000/svg">
-    <path fill="currentcolor"/>
+    <path fill="currentColor"/>
     <mask id="mask1" fill="#fff"/>
     <mask id="mask2">
         <path fill="rgba(255,255,255,0.75)"/>
@@ -33,7 +33,7 @@ Do not apply currentColor to masks.
         </g>
         <mask id="inner-mask" fill="rgba(0,0,0,.5)"/>
     </mask>
-    <path fill="currentcolor"/>
+    <path fill="currentColor"/>
 </svg>
 
 @@@


### PR DESCRIPTION
Fixes an issue where we convert `currentColor` to lowercase, so it becomes `currentcolor` (not spec compliant) and breaks in specific SVG previewers.

The impact was low as many clients supported both `currentColor` and `currentcolor`, however, what we had before was incorrect.

## Related

* Fixes https://github.com/svg/svgo/issues/2136
* Introduced in https://github.com/svg/svgo/pull/1692