### PR TITLE
fix(#2140): SVGO fails with ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows

### DIFF
--- a/lib/svgo-node.js
+++ b/lib/svgo-node.js
@@ -2,13 +2,15 @@ import os from 'os';
 import fs from 'fs/promises';
 import path from 'path';
 import * as svgo from './svgo.js';
+import url from 'url';
 
 /**
  * @param {string} configFile
  * @returns {Promise<import('./types.js').Config>}
  */
 const importConfig = async (configFile) => {
-  const imported = await import(path.resolve(configFile));
+  const resolvedPath = path.resolve(configFile);
+  const imported = await import(url.pathToFileURL(resolvedPath).toString());
   const config = imported.default;
 
   if (config == null || typeof config !== 'object' || Array.isArray(config)) {


### PR DESCRIPTION
Fixes the issue with the module loader for configuration files on win32 platforms by converting the given path to a file:// type url.

This is a regression that was introduced by https://github.com/svg/svgo/pull/2107 where the import call was adapted to use path.resolve instead primarily for type checking purposes.

To restore the original behaviour but also keep the types intact we simply roll back to the url.pathToFileURL call and afterwards convert the URL object to string. It seems weird but does what it should. 

## Related

* Fixes https://github.com/svg/svgo/pull/2140