### PR TITLE
chore: increment version to v4.0.0-rc.5

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -4,4 +4,4 @@
  * @type {string}
  * @since 4.0.0
  */
-export const VERSION = '4.0.0-rc.4';
+export const VERSION = '4.0.0-rc.5';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@3.8.7",
   "name": "svgo",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "SVGO is a Node.js library and command-line application for optimizing vector images.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Just increments the version for v4.0.0-rc.5 so we can do another release candidate.

We're hopefully looking to make this release soon, but I just want to make sure we have a good run with release candidates first without any major bug reports.