### PR TITLE
fix(removeUnknownsAndDefaults): skip if attr used in css selector

### DIFF
--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -7,7 +7,11 @@ import {
 } from './_collections.js';
 import { detachNodeFromParent } from '../lib/xast.js';
 import { visitSkip } from '../lib/util/visit.js';
-import { collectStylesheet, computeStyle } from '../lib/style.js';
+import {
+  collectStylesheet,
+  computeStyle,
+  includesAttrSelector,
+} from '../lib/style.js';
 
 /**
  * @typedef RemoveUnknownsAndDefaultsParams
@@ -192,7 +196,12 @@ export const fn = (root, params) => {
             attributesDefaults.get(name) === value
           ) {
             // keep defaults if parent has own or inherited style
-            if (computedParentStyle?.[name] == null) {
+            if (
+              computedParentStyle?.[name] == null &&
+              !stylesheet.rules.some((rule) =>
+                includesAttrSelector(rule.selector, name),
+              )
+            ) {
               delete node.attributes[name];
             }
           }

--- a/test/plugins/removeUnknownsAndDefaults.17.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.17.svg.txt
@@ -1,0 +1,26 @@
+Don't remove unknown attributes or attributes with default values if that
+attribute is referenced in an attribute selector in CSS.
+
+See: https://mastodon.social/@sir_pepe/114319751487861964
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 202 40">
+  <style>
+      [preserveAspectRatio] { fill: yellow; stroke: black; }
+  </style>
+  <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+    <path d="M50,10 A40,40,1,1,1,50,90 A40,40,1,1,1,50,10 M30,40 Q36,35,42,40 M58,40 Q64,35,70,40 M30,60 Q50,75,70,60 Q50,75,30,60"/>
+  </svg>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 202 40">
+    <style>
+        [preserveAspectRatio] { fill: yellow; stroke: black; }
+    </style>
+    <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+        <path d="M50,10 A40,40,1,1,1,50,90 A40,40,1,1,1,50,10 M30,40 Q36,35,42,40 M58,40 Q64,35,70,40 M30,60 Q50,75,70,60 Q50,75,30,60"/>
+    </svg>
+</svg>


### PR DESCRIPTION
The removeUnknownsAndDefaults plugin was removing attributes that were used in CSS selectors, which is problematic because that breaks styles!

We should be checking if that attribute is used as part of an attribute selector before we commit to removing it.

I've implemented it to only check for the existence of an attribute selector that references the key, rather than actually compare the value, because attribute selectors are complicated. For example:

* `[preserveAspectRatio]`
* `[preserveAspectRatio=]`
* `[preserveAspectRatio^="x"]`
* etc…

In future, we can explore making a more robust utility. But for now, let's at least not break SVGs.

## Related

* Fixes https://mastodon.social/@sir_pepe/114319751487861964
  * _(Yes I know, a bit weird that I'm referring to a Mastodon post rather than a GitHub issue. I just happen to see this on Mastodon is all. ^-^')_