### PR TITLE
chore: use issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+type: bug
 assignees: ''
 ---
 
@@ -12,9 +12,9 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to '…'
 4. See error
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,12 +2,12 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+type: feature
 assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when […]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/plugin_request.md
+++ b/.github/ISSUE_TEMPLATE/plugin_request.md
@@ -2,12 +2,13 @@
 name: Plugin request
 about: Suggest a plugin for this project
 title: ''
-labels: 'New plugin'
+labels: 'new plugin'
+type: feature
 assignees: ''
 ---
 
 **Is your plugin request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when […]
 
 **Describe what the plugin should do**
 A clear and concise description of what you want to happen.


### PR DESCRIPTION
GitHub has a feature for assigning a type to issues, which is a separate thing from labels.

Let's migrate the overarching labels to types instead, this will clean up the label list a little, since types and labels will be different things. (Like how dedicating ticket management software usually handles it.)