### PR TITLE
`.coords` is bad actually

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -877,10 +877,8 @@ function filters(
         (command === 'l' || command === 'h' || command === 'v')
       ) {
         if (
-          // @ts-expect-error
-          Math.abs(pathBase[0] - item.coords[0]) < error &&
-          // @ts-expect-error
-          Math.abs(pathBase[1] - item.coords[1]) < error
+          Math.abs(pathBase[0] - relSubpoint[0]) < error &&
+          Math.abs(pathBase[1] - relSubpoint[1]) < error
         ) {
           command = 'z';
           data = [];
@@ -918,7 +916,7 @@ function filters(
         prevQControlPoint = reflectPoint(qControlPoint, item.base);
       } else {
         // @ts-expect-error
-        prevQControlPoint = item.coords;
+        prevQControlPoint = relSubpoint.slice();
       }
     } else {
       prevQControlPoint = undefined;

--- a/test/plugins/convertPathData.39.svg.txt
+++ b/test/plugins/convertPathData.39.svg.txt
@@ -1,0 +1,17 @@
+Proper, post-rounding coordinate system (1, 1), not pre-rounding (0.8, 0.8), should be used when converting going home to z
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path d="M 0 0 l 0.4 0.4 l 0.4 0.4" />
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path d="m0 0 1 1"/>
+</svg>
+
+@@@
+
+{ "floatPrecision": 0 }


### PR DESCRIPTION
it turns out in the past i used `item.coords` (post-instruction coordinate in ORIGINAL svg) when i should've been using `relSubpoint`; this switches to `relSubpoint` when fitting.