### PR TITLE
feat(convertColors): add excludeMulticolor option to exclude multicolor icons

### DIFF
--- a/docs/04-plugins/convertColors.mdx
+++ b/docs/04-plugins/convertColors.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     currentColor:
-      description: If to convert all instances of a color to `currentColor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/docs/Web/CSS/color) property in CSS.
+      description: If to convert all instances of a color to `currentColor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/docs/Web/CSS/color) property in CSS. Can be a boolean, string, RegExp, or an object with `value` and `excludeMulticolor` options.
       default: false
     names2hex:
       description: If to convert color names to the hex equivalent.
@@ -23,6 +23,29 @@ svgo:
       description: If to convert hex colors to the color name, if the color name is shorter then the hex equivalent.
       default: true
 ---
+
+## currentColor Object Options
+
+When `currentColor` is an object, you can use these additional options:
+
+- **`value`**: Specific color value to convert (boolean, string, or RegExp). If not specified, converts all colors.
+- **`excludeMulticolor`**: When `true`, prevents conversion on multi-color and gradient icons while still converting on single-color icons.
+
+## Usage Examples
+
+```js
+// Convert all colors to currentColor
+{ currentColor: true }
+
+// Convert only red colors to currentColor
+{ currentColor: 'red' }
+
+// Convert only red colors, but exclude multi-color icons
+{ currentColor: { value: 'red', excludeMulticolor: true } }
+
+// Convert all colors, but exclude multi-color icons
+{ currentColor: { excludeMulticolor: true } }
+```
 
 Converts color references to the shortest equivalent.
 

--- a/test/plugins/convertColors.07.svg.txt
+++ b/test/plugins/convertColors.07.svg.txt
@@ -1,0 +1,17 @@
+Test currentColor object form with value parameter - should convert specific color to currentColor.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="red" stroke="red"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="currentColor" stroke="currentColor"/>
+</svg>
+
+@@@
+
+{"currentColor": {"value": "red", "excludeMulticolor": true}} 

--- a/test/plugins/convertColors.08.svg.txt
+++ b/test/plugins/convertColors.08.svg.txt
@@ -1,0 +1,19 @@
+Test currentColor object form with value parameter on multi-color icon - should convert only specified color.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="red" stroke="blue"/>
+    <circle fill="green"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect fill="currentColor" stroke="#00f"/>
+    <circle fill="green"/>
+</svg>
+
+@@@
+
+{"currentColor": {"value": "red", "excludeMulticolor": true}} 

--- a/test/plugins/convertColors.09.svg.txt
+++ b/test/plugins/convertColors.09.svg.txt
@@ -1,0 +1,31 @@
+Test currentColor object form with value parameter on gradient icon - should convert only specified color.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="grad">
+            <stop offset="0%" stop-color="red"/>
+            <stop offset="100%" stop-color="blue"/>
+        </linearGradient>
+    </defs>
+    <rect fill="url(#grad)"/>
+    <circle fill="green"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="grad">
+            <stop offset="0%" stop-color="red"/>
+            <stop offset="100%" stop-color="#00f"/>
+        </linearGradient>
+    </defs>
+    <rect fill="url(#grad)"/>
+    <circle fill="currentColor"/>
+</svg>
+
+@@@
+
+{"currentColor": {"value": "green", "excludeMulticolor": true}} 


### PR DESCRIPTION
## Description

When using the `convertColors` plugin with `currentColor` configuration, I found that multi-color icons were also being converted to `currentColor`, making them appear as single-color in actual use. I wanted to preserve the colors of multi-color icons while only converting single-color icons to `currentColor`. I discovered issue #1302 describing the same problem, so I tried adding parameter configuration to differentiate between multi-color and single-color icons.

## New Parameters

- **`value`**: Specifies target colors for conversion (boolean, string, or RegExp)
- **`excludeMulticolor`**: When set to `true`, excludes conversion on multi-color and gradient icons

## Usage Examples

```js
// Convert all colors, but exclude multi-color icons
{ currentColor: { excludeMulticolor: true } }

// Convert only red colors, but exclude multi-color icons
{ currentColor: { value: 'red', excludeMulticolor: true } }
```