### PR TITLE
docs: minor revisions in wording

### DIFF
--- a/docs/02-usage/index.mdx
+++ b/docs/02-usage/index.mdx
@@ -1,6 +1,5 @@
 ---
 title: Usage
-slug: 'usage'
 ---
 
 We officially support four interfaces for SVGO:

--- a/docs/04-plugins/inlineStyles.mdx
+++ b/docs/04-plugins/inlineStyles.mdx
@@ -16,4 +16,4 @@ svgo:
       description: What pseudo-classes and pseudo-elements to use. An empty string signifies all non-pseudo-classes and non-pseudo-elements.
 ---
 
-Merges styles from `<style>` elements to the `style` attribute of matching elements.
+Merge and inline CSS declarations from a `<style>` element to the `style` attribute of selected elements.

--- a/docs/04-plugins/removeUnknownsAndDefaults.mdx
+++ b/docs/04-plugins/removeUnknownsAndDefaults.mdx
@@ -5,7 +5,7 @@ svgo:
   defaultPlugin: true
   parameters:
     unknownContent:
-      description: If to remove elements that are not known or can't be the child of the parent element according.
+      description: If to remove elements that are not known or can't be the child of its parent element.
       default: true
     unknownAttrs:
       description: If to remove attributes that are not assignable to the respective element.
@@ -20,7 +20,7 @@ svgo:
       description: If to remove attributes that are being if the same value is being inherited by it's parent element anyway.
       default: true
     keepDataAttrs:
-      description: If to keep [`data-*`](https://developer.mozilla.org/docs/Web/SVG/Attribute/data-*) attributes.
+      description: If to keep [`data-*`](https://developer.mozilla.org/docs/Web/SVG/Attribute/data-*) attributes. Set to `false` to remove data attributes.
       default: true
     keepAriaAttrs:
       description: If to keep [ARIA (Accessible Rich Internet Applications)](https://developer.mozilla.org/docs/Web/Accessibility/ARIA) attributes, used for accessibility. This excludes `role`, which is managed with the `keepRoleAttr` parameter.


### PR DESCRIPTION
A problem we have on the SVGO.dev website is that we don't use right keywords to really match what a user might be searching for.

We have a plugin called `inlineStyles`. A user will find it when they search `inline styles`, yet it does not appear when one searches `inline css`. This is very problematic because a user really could search either.

It's not a perfect solution, but to appease both our on-site search engine and global search engines, I want to revise our copy to be clearer and use more keywords that get the page picked up for searches a user that wanted it would realistically do.

For example, for `inlineStyles`, we can refer to it as CSS declarations too. Then both our internal search and any global search engines can more easily make the link to CSS.

* `inlineStyles` - Refer to CSS so that it shows up for searches like `inline css`.
* `removeUnknownsAndDefaults` - Fixes typo in `unknownContent`.
* `removeUnknownsAndDefaults` - Explicitly clarify that setting `keepDataAttrs` to false will remove data attributes, so that it may appear when searching `remove data attributes`.

## Before

<img width="400" alt="" src="https://github.com/user-attachments/assets/2627040d-9e04-4829-bec1-c3abdf91644d" />

## After

<img width="400" alt="" src="https://github.com/user-attachments/assets/934884ab-c00c-4c05-9531-9c06469edf6b" />

## Related

* Feature request that would improve our search results: https://github.com/easyops-cn/docusaurus-search-local/issues/538