### PR TITLE
docs: fix broken link to figma-export utility

### DIFF
--- a/docs/02-usage/index.mdx
+++ b/docs/02-usage/index.mdx
@@ -19,10 +19,10 @@ This section showcases reputable projects that are stable and well maintained. P
 
 Depending on your project stack, you may want to try one of these integrations to seamlessly incorporate SVGO into your workflow:
 
-- [SVGR](https://react-svgr.com/) - Webpack loader that optimizes and transforms SVGs into React components.
+- [SVGR](https://react-svgr.com) - Webpack loader that optimizes and transforms SVGs into React components.
 - [grunt-svgmin](https://www.npmjs.com/package/grunt-svgmin) - Grunt task to optimize SVGs.
 - [postcss-svgo](https://www.npmjs.com/package/postcss-svgo) - PostCSS plugin that optimizes inline SVGs in CSS.
-- [@figma-export](https://figma-export.marcomontalbano.com/) - Node.js library to transforms Figma components into optimized SVGs.
+- [@figma-export](https://github.com/marcomontalbano/figma-export) - Node.js library to transforms Figma components into optimized SVGs.
 
 ### Frontends
 
@@ -30,4 +30,4 @@ The community have developed many frontends for SVGO, and some even have additio
 
 - [SVGOMG](https://jakearchibald.github.io/svgomg/) - Web application that wraps SVGO.
 - [Oh My SVG](https://flathub.org/apps/re.sonny.OhMySVG) - Linux desktop application that wraps SVGO.
-- [SVG Gobbler](https://svggobbler.com/) - Browser extension for finding, optimizing, and exporting SVGs.
+- [SVG Gobbler](https://svggobbler.com) - Browser extension for finding, optimizing, and exporting SVGs.


### PR DESCRIPTION
The website for marcomontalbano/figma-export has a usage limit, so sometimes users get welcomed to an error page.

Let's just link to the GitHub repository instead.