### PR TITLE
types: clearer types for presets

### DIFF
--- a/lib/svgo/plugins.js
+++ b/lib/svgo/plugins.js
@@ -33,7 +33,7 @@ export const invokePlugins = (
 };
 
 /**
- * @template {string} T
+ * @template {`preset-${string}`} T
  * @param {{ name: T, plugins: ReadonlyArray<import('../types.js').BuiltinPlugin<string, any>> }} arg0
  * @returns {import('../types.js').BuiltinPluginOrPreset<T, any>}
  */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -136,18 +136,26 @@ export type BuiltinPlugin<Name extends string, Params> = {
   fn: Plugin<Params>;
 };
 
+type PresetProperties<IsPreset extends boolean> = {
+  name: IsPreset extends true ? `preset-${string}` : string;
+
+  /** If the plugin is itself a preset that invokes other plugins. */
+  isPreset: IsPreset extends true ? true : undefined;
+
+  /**
+   * If {@link #isPreset} is true, an array of the plugins in the preset
+   * in the order that they are invoked.
+   */
+  plugins: IsPreset extends true
+    ? ReadonlyArray<BuiltinPlugin<string, Object>>
+    : undefined;
+};
+
 export type BuiltinPluginOrPreset<Name extends string, Params> = BuiltinPlugin<
   Name,
   Params
-> & {
-  /** If the plugin is itself a preset that invokes other plugins. */
-  isPreset?: true;
-  /**
-   * If the plugin is a preset that invokes other plugins, this returns an
-   * array of the plugins in the preset in the order that they are invoked.
-   */
-  plugins?: ReadonlyArray<BuiltinPlugin<string, Object>>;
-};
+> &
+  (PresetProperties<true> | Partial<PresetProperties<false>>);
 
 export type XastDoctype = {
   type: 'doctype';

--- a/test-d/lib/svgo-node.test-d.ts
+++ b/test-d/lib/svgo-node.test-d.ts
@@ -1,8 +1,10 @@
 import { expectType, expectAssignable } from 'tsd';
 import {
+  BuiltinPlugin,
   type Config,
   type DataUri,
   type Output,
+  builtinPlugins,
   loadConfig,
   optimize,
 } from '../../types/lib/svgo-node.js';
@@ -14,3 +16,13 @@ expectType<Promise<Config | null>>(loadConfig());
 expectType<Promise<Config | null>>(loadConfig(undefined));
 expectType<Promise<Config | null>>(loadConfig(null));
 expectType<Promise<Config>>(loadConfig('svgo.config.js'));
+
+const presetDefault = builtinPlugins.find(
+  (plugin) => plugin.name === 'preset-default',
+)!;
+if (!presetDefault.isPreset) {
+  throw Error('Could not find preset-default.');
+}
+
+expectType<ReadonlyArray<BuiltinPlugin<string, Object>>>(presetDefault.plugins);
+expectType<'preset-default'>(presetDefault.name);


### PR DESCRIPTION
This defines clearer types for SVGO presets.

Regular plugins do not have the `isPreset` or `plugins` property defined. Whereas, presets always have both `isPreset` and `plugins` defined.

Before, we simply marked both as optional properties of a preset. The problem is that this prompted developers to do unnecessary checks, for example:

```diff
- if (plugin.isPreset && plugin.plugins) {
-   // Checking plugins shouldn't be neccesary. Presets always have a plugins array.
- }
+ if (plugin.isPreset) {
+   console.log(plugin.plugins); // We want to allow this.
+ }
```

This example is based on a community contribution we received:
* https://github.com/svg/svgo/pull/2174

We'll mark these properties as optional for normal plugins, but mandatory for presets. This also adds the benefit that if one checks `BuiltinPluginOrPreset#isPreset` and it returns `true`, then it will type-narrow the plugin to one of the presets.

For example:

```ts
const presetDefault = builtinPlugins.find((plugin) => plugin.name === 'preset-default')!;
if (!presetDefault.isPreset) {
  throw Error('Could not find preset-default.');
}

expectType<ReadonlyArray<BuiltinPlugin<string, Object>>>(presetDefault.plugins);
expectType<'preset-default'>(presetDefault.name);
```

It can now type-narrow the plugin to `preset-default` because we checked if it's a preset, and `preset-default` is the only preset available.

This also therefore introduces a rule where presets must be named `preset-whatever`. For example, `preset-default`, `preset-html5`, `preset-svg2`, etc.

## Development Notes

What I really wanted:

* A single type so that documentation only had to be included once. ✅
* For the `name`, `isPreset`, and `plugins` property to type narrow in sync. ✅
* Use optional properties rather than hard-coding `undefined`. But, I had trouble achieving what I wanted here. :x:

I may revisit this later. Alternatively, feedback is always welcome, even after this PR is merged. :+1: