### PR TITLE
ci: add publish action for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: yarn install
+      - run: |
+          if jq -r .version <package.json | grep -q \\-rc.; then
+            yarn npm publish --access public --tag rc
+          else
+            yarn npm publish --access public
+          fi


### PR DESCRIPTION
Defines a GitHub action to publish releases from GitHub CI using the [npm trusted publishers](https://docs.npmjs.com/trusted-publishers) method.

I've tested this on a smaller project I maintain ([jsonresume/jsonresume-theme-class](https://github.com/jsonresume/jsonresume-theme-class/releases/tag/v0.5.0)) and everything went great, so I'm adopting this in svg/svgo as well.

This makes the process of releasing a little less stressful, and significantly reduces the likelihood for human error, like releasing versions under the wrong dist-tag. :sweat:

The only difference between this workflow and other ones I've defined is that for SVGO, I use `jq` to check if the version name includes `-rc.` which indicates it's a release candidate. If so, we use the `rc` dist-tag.