### PR TITLE
ci: separate regression tests and write delta report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
 
-env:
-  FORCE_COLOR: 2
-  NODE: 20
-
 on:
   pull_request:
     branches:
@@ -14,47 +10,41 @@ permissions:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: corepack enable
       - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE }}
+        with: &setup-node-config
+          node-version: 24
           cache: yarn
       - run: yarn install
       - run: yarn lint
   types:
-    name: Types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: corepack enable
       - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE }}
-          cache: yarn
+        with: *setup-node-config
       - run: yarn install
       - run: yarn test:types
   spellcheck:
-    name: Spell Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - run: corepack enable
       - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE }}
-          cache: yarn
+        with: *setup-node-config
       - run: yarn install
       - run: yarn spellcheck
   test:
-    name: ${{ matrix.os }} Node.js ${{ matrix.node-version }}
+    name: test - ${{ matrix.os }} - Node.js v${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
         node-version:
+          - 24
           - 22
           - 20
           - 18
@@ -75,22 +65,3 @@ jobs:
       - run: yarn playwright install --with-deps chromium
       - run: yarn test
       - run: yarn test:bundles
-  regression:
-    name: Test regressions
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    needs:
-      - lint
-      - test
-    steps:
-      - uses: actions/checkout@v6
-      - run: corepack enable
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE }}
-          cache: yarn
-      - run: yarn install
-      - run: yarn playwright install --with-deps chromium
-      - run: yarn test:regression

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,55 @@
+name: Regression Test
+
+env:
+  # For debugging, you can override this to your fork to test.
+  REPO: 'svg/svgo'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - run: yarn install
+      - run: yarn playwright install --with-deps chromium
+      - run: yarn test:regression
+      # We use upload/artifacts instead of outputs because our regression test
+      # report can exceed 1 MB which is a limit GitHub imposes.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: svgo-test-report-${{ github.sha }}
+          path: /tmp/svgo.${{ github.sha }}/svgo-test-report.json
+          if-no-files-found: error
+          retention-days: 1
+  delta:
+    runs-on: ubuntu-latest
+    needs:
+      - regression
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - run: yarn install
+      - run: gh run download -R ${{ env.REPO }} -n svgo-test-report-${{ github.sha }} -D /tmp/svgo.${{ github.sha }}/
+      - run: gh run download -R ${{ env.REPO }} -n svgo-test-report -D /tmp/svgo.main/
+      - run: ./test/regression/delta.js /tmp/svgo.main/svgo-test-report.json /tmp/svgo.${{ github.sha }}/svgo-test-report.json

--- a/test/regression/delta.js
+++ b/test/regression/delta.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { bytesToHumanReadable, secsToHumanReadable } from './lib.js';
+import { readReport } from './regression-io.js';
+
+/**
+ * @typedef {object} DeltaReport
+ * @property {number} filesAffected Files that changed between the two reports.
+ * @property {number} totalFiles Total files that were in the test suite.
+ * @property {number} bytesDelta
+ *   Difference in total bytes saved. Positive if we reduce more bytes, or
+ *   negative if we reduce less bytes. Higher is better!
+ * @property {number} secsDelta
+ *   Difference in total time taken. Positive if we took longer to optimize, or
+ *   negative if we took less time to optimize. Lower is better!
+ * @property {number} memDelta
+ *   Difference in peak memory allocation. Positive if we used more memory, or
+ *   negative if we used less memory. Lower is better!
+ */
+
+const HEADING = '▶ Relative to svg/svgo.git#main';
+
+/**
+ * @param {import('./regression-io.js').TestReport} reportMain
+ * @param {import('./regression-io.js').TestReport} reportHead
+ * @returns {DeltaReport}
+ */
+function deltaReport(reportMain, reportHead) {
+  if (reportMain.version !== reportHead.version) {
+    console.error(`${HEADING}
+  Previous test report used a different version of SVGO Test Suite.
+  Rerun regression tests on main to regenerate test report, then try again.`);
+    process.exit(1);
+  }
+
+  const filesAffected = Object.keys(reportMain.checksums).reduce((acc, val) => {
+    return reportMain.checksums[val] === reportHead.checksums[val]
+      ? acc
+      : acc + 1;
+  }, 0);
+
+  return {
+    filesAffected,
+    totalFiles:
+      reportMain.files.toMatch +
+      reportMain.files.toMismatch +
+      reportMain.files.toIgnore,
+    bytesDelta: reportHead.metrics.bytesSaved - reportMain.metrics.bytesSaved,
+    secsDelta:
+      reportHead.metrics.timeTakenSecs - reportMain.metrics.timeTakenSecs,
+    memDelta:
+      reportHead.metrics.peakMemoryAlloc - reportMain.metrics.peakMemoryAlloc,
+  };
+}
+
+/**
+ * @param {DeltaReport} deltaReport
+ */
+function writeReport(deltaReport) {
+  const { bytesDelta, filesAffected, memDelta, secsDelta, totalFiles } =
+    deltaReport;
+
+  console.log(`${HEADING}
+       Files Affected: ${filesAffected.toLocaleString()} / ${totalFiles.toLocaleString()}
+        Bytes Saved Δ: ${toDisplayString(bytesDelta, (n) => bytesToHumanReadable(n))}
+         Time Taken Δ: ${toDisplayString(secsDelta, (n) => secsToHumanReadable(n))}
+  Peak Memory Alloc Δ: ${toDisplayString(memDelta, (n) => bytesToHumanReadable(n, 'KiB'))}`);
+}
+
+/**
+ * @param {number} num
+ * @param {(num: number) => string} fn
+ */
+function toDisplayString(num, fn) {
+  if (num === 0) {
+    return fn(0);
+  }
+
+  if (num > 0) {
+    return `+${fn(num)}`;
+  }
+
+  return `-${fn(Math.abs(num))}`;
+}
+
+const reportMain = /** @type {import('./regression-io.js').TestReport} */ (
+  await readReport(process.argv[2])
+);
+const reportHead = /** @type {import('./regression-io.js').TestReport} */ (
+  await readReport(process.argv[3])
+);
+const report = deltaReport(reportMain, reportHead);
+writeReport(report);


### PR DESCRIPTION
This introduces "delta reports", which is a separate report from our test report.

From now on, we'll create a test report in CI, then download the latest test report from `main`, and then create a "delta report" which is a concise report with the differences between the two reports.

For now, this is only written to STDOUT, but later I'll likely make this a comment in the GitHub UI for the review process. However, for now I'll keep the output a little out of the way to make sure it's going to work as expected. I'll expose it later once we've confirmed we get the real-world value we want from this and that it's stable.

## Demo

Once CI for this branch finishes, I'll add the logs from `Regression Test / regression` and `Regression Test / delta` to show what the reports look like.

When we get around to showing these in the GitHub UI, it will just be the two reports concatenated together.

### Test Report

```
SVGO Test Suite Version: d962dcd84733a663afcd55bf0b55483b

▶ Test Results
              Match: 4,626 / 4,626
  Expected Mismatch: 155 / 155
            Ignored: 39 / 81
            Skipped: 1

▶ Metrics
        Bytes Saved: 746.644 MiB
         Time Taken: 12m07s
  Peak Memory Alloc: 3.802 GiB
```

### Delta Report

```
▶ Relative to svg/svgo.git#main
       Files Affected: 0 / 4,862
        Bytes Saved Δ: 0 KiB
         Time Taken Δ: -05s
  Peak Memory Alloc Δ: +6.25 MiB
```

This means that:

* There were no changes between the optimization result of this PR vs. main. (Expected in this case.)
* As no files were affected, this of course had no impact on bytes saved.
* This PR was 5 seconds quicker to finish the optimization step. (Margin of error.)
* This PR had 6.25 MiB more memory allocated to it during the optimization. (Margin of error.) 

## Related

* Second half of https://github.com/svg/svgo/pull/2189
* Mostly does https://github.com/svg/svgo/issues/2160