### PR TITLE
fix(prefixIds): does not handle SMIL timing offsets

### DIFF
--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -257,12 +257,13 @@ export const fn = (_root, params, info) => {
             node.attributes[name] != null &&
             node.attributes[name].length !== 0
           ) {
-            const parts = node.attributes[name].split(/\s*;\s+/).map((val) => {
-              if (val.endsWith('.end') || val.endsWith('.start')) {
-                const [id, postfix] = val.split('.');
-                return `${prefixId(prefixGenerator, id)}.${postfix}`;
-              }
-              return val;
+            const parts = node.attributes[name].split(/\s*;\s*/).map((val) => {
+              return val.replace(
+                /^([a-zA-Z0-9_-]+)\.(begin|end)([+-].+)?$/,
+                (_, id, type, offset = '') => {
+                  return `${prefixId(prefixGenerator, id)}.${type}${offset}`;
+                },
+              );
             });
             node.attributes[name] = parts.join('; ');
           }


### PR DESCRIPTION
This PR **improves** handling of `begin` and `end` attributes in the `prefixIds` plugin.

**Problem**

The current implementation only prefixes values ending with `.end` or `.start`, but valid SMIL syntax also includes offsets such as:

- `a.end-0.5s`
- `b.begin+0.1s`

These cases are currently ignored, leading to broken animation references after ID prefixing.

**Solution**

Replace the suffix check with a regex that correctly parses:
`<id>.(begin|end)(+/-offset)?`
This ensures all valid SMIL timing references are properly prefixed.

**Impact**

- Fixes broken animation chaining
- Maintains backward compatibility
- No effect on non-SMIL attributes

**Example**

Before:

```xml
begin="a.end-0.5s"
```

After

```xml
begin="prefix-a.end-0.5s"
```

**Test**

1. without offsets, like `x.end`, OK
2. with offsets, like `b.end-0.5s`, OK
3. mix and multiple, like `x.begin;x.end-0.5s`, OK

Test code e.g:

```js
it('should prefix SMIL begin/end with offsets', () => {
  const svg = `
    <svg>
      <animate id="a" begin="b.end-0.5s" />
      <animate id="b" begin="a.begin+0.1s" />
    </svg>
  `

  const result = optimize(svg, {
    plugins: [
      'cleanupIds',
      {
        name: 'prefixIds',
        params: { prefix: 'p' },
      },
    ],
  })
  expect(result.data).toContain('p-b.end-0.5s')
  expect(result.data).toContain('p-a.begin+0.1s')
})
```

<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/653bc7c0-5004-4965-b7f8-545c0e7207ba" />

**Notice**
This PR intentionally keeps a minimal regex-based approach consistent with existing implementation, while extending coverage to valid SMIL offset syntax instead of all.

**Linked Issue**
Fixes: #2207 #2073
