### PR TITLE
docs(removeAttributesBySelector): properly document and check types

### DIFF
--- a/docs/04-plugins/removeAttributesBySelector.mdx
+++ b/docs/04-plugins/removeAttributesBySelector.mdx
@@ -3,8 +3,14 @@ title: removeAttributesBySelector
 svgo:
   pluginId: removeAttributesBySelector
   parameters:
+    selector:
+      description: A CSS selector that matches the elements to be modified.
+      default: "[fill='#00ff00']"
+    attributes:
+      description: An attribute, or array of attributes, to remove from the matched elements.
+      default: fill
     selectors:
-      description: An array of objects with two properties, `selector`, and `attributes`, which represent a CSS selector and the attributes to remove respectively.
+      description: An array of objects, each containing `selector` and `attributes` as described above. To match on more than one selector, use this parameter instead of the two above.
       default: null
 ---
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,7 @@ import { InlineStylesParams } from '../plugins/inlineStyles.js';
 import { MergePathsParams } from '../plugins/mergePaths.js';
 import { MinifyStylesParams } from '../plugins/minifyStyles.js';
 import { PrefixIdsParams } from '../plugins/prefixIds.js';
+import { RemoveAttributesBySelectorParams } from '../plugins/removeAttributesBySelector.js';
 import { RemoveAttrsParams } from '../plugins/removeAttrs.js';
 import { RemoveCommentsParams } from '../plugins/removeComments.js';
 import { RemoveDeprecatedAttrsParams } from '../plugins/removeDeprecatedAttrs.js';
@@ -99,7 +100,7 @@ export type BuiltinsWithOptionalParams = DefaultPlugins & {
 export type BuiltinsWithRequiredParams = {
   addAttributesToSVGElement: AddAttributesToSVGElementParams;
   addClassesToSVGElement: AddClassesToSVGElementParams;
-  removeAttributesBySelector: any;
+  removeAttributesBySelector: RemoveAttributesBySelectorParams;
   removeAttrs: RemoveAttrsParams;
   removeElementsByAttr: RemoveElementsByAttrParams;
 };

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -35,7 +35,7 @@ Without either, the plugin is a noop.`;
  *   {
  *     name: "removeAttributesBySelector",
  *     params: {
- *       selector: "[fill='#00ff00']"
+ *       selector: "[fill='#00ff00']",
  *       attributes: "fill"
  *     }
  *   }

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -1,8 +1,30 @@
 import { querySelectorAll } from '../lib/xast.js';
 
+/**
+ * @typedef AttributesBySelector
+ * @property {string} selector
+ * @property {string | string[]} attributes
+ * @property {never} selectors
+ */
+
+/**
+ * @typedef AttributesBySelectors
+ * @property {never} selector
+ * @property {never} attributes
+ * @property {Array<AttributesBySelector>} selectors
+ */
+
+/**
+ * @typedef {(AttributesBySelector | AttributesBySelectors)} RemoveAttributesBySelectorParams
+ */
+
 export const name = 'removeAttributesBySelector';
 export const description =
   'removes attributes of elements that match a css selector';
+
+const ENOATTRS = `Warning: The plugin "removeAttributesBySelector" is missing parameters.
+It should have a list of "selectors", or one "selector" and one "attributes".
+Without either, the plugin is a noop.`;
 
 /**
  * Removes attributes of elements that match a css selector.
@@ -67,13 +89,21 @@ export const description =
  *   ↓
  * <rect x="0" y="0" width="100" height="100"/>
  *
- * @link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors|MDN CSS Selectors
+ * @link https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors|MDN CSS Selectors
  *
  * @author Bradley Mease
  *
- * @type {import('../lib/types.js').Plugin<any>}
+ * @type {import('../lib/types.js').Plugin<RemoveAttributesBySelectorParams>}
  */
 export const fn = (root, params) => {
+  if (
+    !Array.isArray(params.selectors) &&
+    (!params.selector || !params.attributes)
+  ) {
+    console.warn(ENOATTRS);
+    return null;
+  }
+
   const selectors = Array.isArray(params.selectors)
     ? params.selectors
     : [params];

--- a/test/plugins/removeAttributesBySelector.04.svg.txt
+++ b/test/plugins/removeAttributesBySelector.04.svg.txt
@@ -1,0 +1,13 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="100" height="100" fill="#00ff00" stroke="#00ff00"/>
+</svg>
+
+@@@
+
+{}

--- a/test/plugins/removeAttributesBySelector.05.svg.txt
+++ b/test/plugins/removeAttributesBySelector.05.svg.txt
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <g>
+        <rect x="0" y="0" width="100" height="100" fill="#00ff00"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <g>
+        <rect x="0" y="0" width="100" height="100"/>
+    </g>
+</svg>
+
+@@@
+
+{ "selector": "g rect", "attributes": "fill" }


### PR DESCRIPTION
I'm uncertain if the switch to `matches` in #1978 is a good idea perfwise. But it has a subset which are clearly good ideas, so this PR is  just those.

- better documentation
- better types
- warning on incorrect configuration
- more tests