### PR TITLE
performance: speed up mergePath child node removal

### DIFF
--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -49,8 +49,8 @@ export const fn = (root, params) => {
           return;
         }
 
-        /** @type {import('../lib/types.js').XastChild[]} */
-        const elementsToRemove = [];
+        /** @type {Set<import('../lib/types.js').XastChild>} */
+        const elementsToRemove = new Set();
         let prevChild = node.children[0];
         let prevPathData = null;
 
@@ -144,7 +144,7 @@ export const fn = (root, params) => {
 
           if (force || !intersects(prevPathData, currentPathData)) {
             prevPathData.push(...currentPathData);
-            elementsToRemove.push(child);
+            elementsToRemove.add(child);
             continue;
           }
 
@@ -161,7 +161,7 @@ export const fn = (root, params) => {
         }
 
         node.children = node.children.filter(
-          (child) => !elementsToRemove.includes(child),
+          (child) => !elementsToRemove.has(child),
         );
       },
     },


### PR DESCRIPTION
Improved performance on mergePaths plugin. Changed the to-be-deleted node from a list to Set. I ran into performance issues with large files, and some of them were significantly improved by changing the data structure.

Does not change any behavior: the list was previously used just for .includes, which is an O(n) call. The .has in set is O(1).