### PR TITLE
fix(cleanupAttrs): handle numeric attribute values (#2219)

### DIFF
--- a/lib/svgo.test.js
+++ b/lib/svgo.test.js
@@ -369,6 +369,39 @@ test('multipass option should trigger plugins multiple times', () => {
   expect(data).toBe(`<svg id="klmnopqrstuvwxyz"/>`);
 });
 
+test('cleanupAttrs handles numeric attribute values', () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>`;
+  /** @type {import('./types.js').CustomPlugin} */
+  const addNumericDimensions = {
+    name: 'addNumericDimensions',
+    fn: () => ({
+      element: {
+        enter: (node) => {
+          if (
+            node.name === 'svg' &&
+            node.attributes.width == null &&
+            node.attributes.height == null &&
+            node.attributes.viewBox == null
+          ) {
+            // @ts-expect-error regression test for non-string attribute values
+            node.attributes.width = 0;
+            // @ts-expect-error regression test for non-string attribute values
+            node.attributes.height = 0;
+          }
+        },
+      },
+    }),
+  };
+
+  const { data } = optimize(svg, {
+    plugins: [addNumericDimensions, 'cleanupAttrs'],
+  });
+
+  expect(data).toBe(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0"><rect width="10" height="10"/></svg>',
+  );
+});
+
 test('encode as datauri', () => {
   const input = `
     <svg xmlns="http://www.w3.org/2000/svg">

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -26,11 +26,12 @@ export const fn = (root, params) => {
       enter: (node) => {
         for (const name of Object.keys(node.attributes)) {
           const value = node.attributes[name];
-          if (value == null) {
+          if (value === undefined) {
             continue;
           }
 
-          let attrValue = typeof value === 'string' ? value : String(value);
+          let attrValue =
+            value === null ? '' : typeof value === 'string' ? value : String(value);
 
           if (newlines) {
             // new line which requires a space instead

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -25,27 +25,30 @@ export const fn = (root, params) => {
     element: {
       enter: (node) => {
         for (const name of Object.keys(node.attributes)) {
+          const value = node.attributes[name];
+          if (value == null) {
+            continue;
+          }
+
+          let attrValue = typeof value === 'string' ? value : String(value);
+
           if (newlines) {
             // new line which requires a space instead
-            node.attributes[name] = node.attributes[name].replace(
+            attrValue = attrValue.replace(
               regNewlinesNeedSpace,
               (match, p1, p2) => p1 + ' ' + p2,
             );
             // simple new line
-            node.attributes[name] = node.attributes[name].replace(
-              regNewlines,
-              '',
-            );
+            attrValue = attrValue.replace(regNewlines, '');
           }
           if (trim) {
-            node.attributes[name] = node.attributes[name].trim();
+            attrValue = attrValue.trim();
           }
           if (spaces) {
-            node.attributes[name] = node.attributes[name].replace(
-              regSpaces,
-              ' ',
-            );
+            attrValue = attrValue.replace(regSpaces, ' ');
           }
+
+          node.attributes[name] = attrValue;
         }
       },
     },


### PR DESCRIPTION

Fixes #2219.

`cleanupAttrs` assumes attribute values are strings and crashes when an upstream step assigns numeric values such as `0` to `width` or `height`.

This change coerces non-string attribute values to strings before applying whitespace cleanup and adds a regression test covering numeric `width` / `height` values on `<svg>` elements without a `viewBox`.