### PR TITLE
fix(removeDimensions): only remove dimensions from the top-most <svg>

### DIFF
--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -17,8 +17,10 @@ export const description =
 export const fn = () => {
   return {
     element: {
-      enter: (node) => {
-        if (node.name === 'svg') {
+      enter: (node, parentNode) => {
+        // Only the top-most <svg> may drop width/height; nested <svg> elements
+        // rely on width/height to size and position themselves (#2217).
+        if (node.name === 'svg' && parentNode.type === 'root') {
           if (node.attributes.viewBox != null) {
             delete node.attributes.width;
             delete node.attributes.height;

--- a/test/plugins/removeDimensions.06.svg.txt
+++ b/test/plugins/removeDimensions.06.svg.txt
@@ -1,0 +1,20 @@
+Removes width/height from the top-most <svg> only, not nested <svg> elements
+(nested <svg> rely on width/height for sizing/positioning).
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+    <path fill="pink" d="M0 0h10v10H0Z"/>
+    <svg x="1" y="1" width="8" height="8" viewBox="0 0 33 33">
+        <path fill="red" d="M1 16a1 1 0 0 0 31 1 1 1 0 0 0-31-1"/>
+    </svg>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path fill="pink" d="M0 0h10v10H0Z"/>
+    <svg x="1" y="1" width="8" height="8" viewBox="0 0 33 33">
+        <path fill="red" d="M1 16a1 1 0 0 0 31 1 1 1 0 0 0-31-1"/>
+    </svg>
+</svg>


### PR DESCRIPTION
## Problem

Fixes #2217.

`removeDimensions` strips `width`/`height` from **every** `<svg>` element, including nested ones:

```svg
<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
  <path fill="pink" d="M0 0h10v10H0Z"/>
  <svg x="1" y="1" width="8" height="8" viewBox="0 0 33 33">
    <path fill="red" d="..."/>
  </svg>
</svg>
```

Today the nested `<svg>` loses `width="8" height="8"`, which changes how it is sized and positioned — the rendered output is visibly different. The [plugin docs](https://svgo.dev/docs/plugins/removeDimensions/) say it should only affect *"the top-most `<svg>` element"*, so this is a behavior/doc mismatch.

## Fix

Gate the visitor on `parentNode.type === 'root'` so only the outermost `<svg>` is touched — the same root-detection other plugins already use (`removeOffCanvasPaths`, `reusePaths`, `addAttributesToSVGElement`; `removeViewBox` uses the inverse to handle nested `<svg>`). Nested `<svg>` dimensions are now preserved.

## Test plan

- [x] Added fixture `test/plugins/removeDimensions.06.svg.txt`: outer `<svg>` drops `width`/`height`, nested `<svg>` keeps them.
- [x] New fixture fails on `main` (nested dims stripped) and passes with the fix.
- [x] Existing `removeDimensions.01`–`.05` unchanged; full plugin fixture suite **370 passing**.
- [x] `eslint` + `prettier --check` clean.