### PR TITLE
fix(removeUnknownsAndDefaults): keep attributes referenced by attribute selectors

### DIFF
--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -182,10 +182,17 @@ export const fn = (root, params) => {
             }
           }
 
+          // an attribute referenced by an attribute selector must be kept,
+          // otherwise the stylesheet stops matching the element
+          const usedInAttrSelector = stylesheet.rules.some((rule) =>
+            includesAttrSelector(rule.selector, name),
+          );
+
           if (
             unknownAttrs &&
             allowedAttributes &&
-            allowedAttributes.has(name) === false
+            allowedAttributes.has(name) === false &&
+            !usedInAttrSelector
           ) {
             delete node.attributes[name];
           }
@@ -196,12 +203,7 @@ export const fn = (root, params) => {
             attributesDefaults.get(name) === value
           ) {
             // keep defaults if parent has own or inherited style
-            if (
-              computedParentStyle?.[name] == null &&
-              !stylesheet.rules.some((rule) =>
-                includesAttrSelector(rule.selector, name),
-              )
-            ) {
+            if (computedParentStyle?.[name] == null && !usedInAttrSelector) {
               delete node.attributes[name];
             }
           }
@@ -211,7 +213,8 @@ export const fn = (root, params) => {
               presentationNonInheritableGroupAttrs.has(name) === false &&
               style != null &&
               style.type === 'static' &&
-              style.value === value
+              style.value === value &&
+              !usedInAttrSelector
             ) {
               delete node.attributes[name];
             }

--- a/test/plugins/removeUnknownsAndDefaults.18.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.18.svg.txt
@@ -1,0 +1,27 @@
+Don't remove unknown attributes or attributes that override an inherited value
+when they're referenced by an attribute selector in CSS, otherwise the
+stylesheet stops matching the element.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <style>
+        rect[fill] { stroke: red; }
+        [state] { stroke-width: 2; }
+    </style>
+    <g fill="blue">
+        <rect fill="blue" state="active" width="10" height="10"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <style>
+        rect[fill] { stroke: red; }
+        [state] { stroke-width: 2; }
+    </style>
+    <g fill="blue">
+        <rect fill="blue" state="active" width="10" height="10"/>
+    </g>
+</svg>


### PR DESCRIPTION
#2144 made this plugin keep an attribute when its value equals the default and it's referenced by an attribute selector such as `[preserveAspectRatio]`. That guard only landed in the "default value" branch.

The same loop deletes attributes in two other branches: unknown attributes, and attributes that redundantly override an inherited value. Neither one looks at the stylesheet, so both still remove attributes that a selector relies on.

For example, running only this plugin on:

```svg
<svg xmlns="http://www.w3.org/2000/svg">
  <style>rect[fill] { stroke: red; }</style>
  <g fill="blue">
    <rect fill="blue" width="10" height="10"/>
  </g>
</svg>
```

`rect`'s `fill="blue"` repeats the parent value, so the `uselessOverrides` branch drops it, `rect[fill]` stops matching, and the rect loses its stroke. A custom attribute used as a styling hook (`[state]`) runs into the same thing through the unknown-attribute branch.

This applies the existing `includesAttrSelector` check to all three branches instead of just one. Added a test fixture covering the two cases that weren't handled.
