### PR TITLE
Avoid removing dimensions on nested SVG elements

### DIFF
--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -17,8 +17,8 @@ export const description =
 export const fn = () => {
   return {
     element: {
-      enter: (node) => {
-        if (node.name === 'svg') {
+      enter: (node, parentNode) => {
+        if (node.name === 'svg' && parentNode.type === 'root') {
           if (node.attributes.viewBox != null) {
             delete node.attributes.width;
             delete node.attributes.height;

--- a/test/plugins/removeDimensions.06.svg.txt
+++ b/test/plugins/removeDimensions.06.svg.txt
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <svg x="0" y="0" width="50" height="50" viewBox="0 0 100 50">
+        test
+    </svg>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <svg x="0" y="0" width="50" height="50" viewBox="0 0 100 50">
+        test
+    </svg>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/svg/svgo/issues/2217

This aligns the behavior with the description in [the docs](https://svgo.dev/docs/plugins/removeDimensions/):

> Removes the width and height attribute from the top-most <svg> element
> if specified, and replaces it with the viewBox attribute if it's missing.
