### PR TITLE
fix(removeUnknownsAndDefaults): keep href on the a element

### DIFF
--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -428,6 +428,7 @@ export const elems = {
     attrs: new Set([
       'class',
       'externalResourcesRequired',
+      'href',
       'style',
       'target',
       'transform',

--- a/test/plugins/removeUnknownsAndDefaults.18.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.18.svg.txt
@@ -1,0 +1,25 @@
+Preserve both href and xlink:href attributes on the <a> element.
+
+See: https://github.com/svg/svgo/issues/2230
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 160 40">
+    <a href="https://developer.mozilla.org/">
+        <text x="10" y="25">MDN Web Docs</text>
+    </a>
+    <a xlink:href="https://svgo.dev/">
+        <text x="10" y="35">SVGO</text>
+    </a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 160 40">
+    <a href="https://developer.mozilla.org/">
+        <text x="10" y="25">MDN Web Docs</text>
+    </a>
+    <a xlink:href="https://svgo.dev/">
+        <text x="10" y="35">SVGO</text>
+    </a>
+</svg>


### PR DESCRIPTION
## Summary

Fixes #2230.

`removeUnknownsAndDefaults` deleted the `href` attribute from `<a>` elements, so
links in an optimized SVG stopped working:

```js
optimize(`<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg">
  <a href="https://developer.mozilla.org/"><text x="10" y="25">MDN Web Docs</text></a>
</svg>`, { plugins: ['removeUnknownsAndDefaults'] });
// -> <a><text x="10" y="25">MDN Web Docs</text></a>
```

In `_collections.js`, `elems.a` pulls in the `xlink` attribute group — which is
why `xlink:href` survives — but its own `attrs` set never listed the SVG 2
`href`, so the plugin treated it as unknown. Twelve other entries in the same
file already list `'href'` next to `'xlink:href'` (`image`, `use`,
`linearGradient`, `feImage`, `filter`, `mpath`, `script`, …), so `a` looks like
an oversight.

## Changes

- Add `'href'` to `elems.a.attrs` in `plugins/_collections.js` (one line,
  alphabetically placed to match the surrounding entries)
- Add `test/plugins/removeUnknownsAndDefaults.18.svg.txt` covering both `<a
  href>` and `<a xlink:href>`; the `xlink:href` case is the control and passed
  before this change too

## Testing

- `yarn jest test/plugins/_index.test.js -t 'removeUnknownsAndDefaults'`
- `yarn test`
- `yarn lint`
- `yarn test:types`

The new fixture fails on `main` (`- <a href="https://developer.mozilla.org/">` /
`+ <a>`) and passes with the change. I did not run `yarn test:regression` or
`yarn test:bundles` locally.

## Note on #2062

#2061/#2062 is the same class of bug for animation elements. That PR takes a
different route (a new `animationTargetElement` group) and does not touch
`elems.a`, so this is not a duplicate — but it also adds a
`removeUnknownsAndDefaults.18.svg.txt`. `.18` is the next free index on `main`;
happy to renumber if #2062 lands first.