### PR TITLE
fix(cleanupIds): don't skip IDs that were already reassigned

### DIFF
--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -214,6 +214,13 @@ export const fn = (_root, params) => {
          */
         const isIdPreserved = (id) =>
           preserveIds.has(id) || hasStringPrefix(id, preserveIdPrefixes);
+        /** @type {Set<string>} */
+        const externalIds = new Set();
+        for (const id of referencesById.keys()) {
+          if (!nodeById.has(id)) {
+            externalIds.add(id);
+          }
+        }
         /** @type {?number[]} */
         let currentId = null;
         for (const [id, refs] of referencesById) {
@@ -228,8 +235,10 @@ export const fn = (_root, params) => {
                 currentIdString = getIdString(currentId);
               } while (
                 isIdPreserved(currentIdString) ||
-                (referencesById.has(currentIdString) &&
-                  nodeById.get(currentIdString) == null)
+                externalIds.has(currentIdString) ||
+                (!remove &&
+                  nodeById.has(currentIdString) &&
+                  !referencesById.has(currentIdString))
               );
               node.attributes.id = currentIdString;
               for (const { element, name } of refs) {

--- a/test/plugins/cleanupIds.27.svg.txt
+++ b/test/plugins/cleanupIds.27.svg.txt
@@ -1,0 +1,27 @@
+Minified IDs must be consecutive and stable in a single pass, even when IDs are
+referenced out of alphabetical order. An ID that has already been reassigned
+must not be mistaken for an external reference.
+
+See: https://github.com/svg/svgo/issues/2237
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="b" d="M0 0"/>
+        <path id="a" d="M1 1"/>
+    </defs>
+    <use href="#b"/>
+    <use href="#a"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="a" d="M0 0"/>
+        <path id="b" d="M1 1"/>
+    </defs>
+    <use href="#a"/>
+    <use href="#b"/>
+</svg>

--- a/test/plugins/cleanupIds.28.svg.txt
+++ b/test/plugins/cleanupIds.28.svg.txt
@@ -1,0 +1,28 @@
+With remove disabled, unreferenced IDs are kept, so a generated ID must not
+collide with one of them or the document ends up with duplicate IDs.
+
+See: https://github.com/svg/svgo/issues/2237
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="x" d="M0 0"/>
+        <path id="a" d="M1 1"/>
+    </defs>
+    <use href="#x"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <path id="b" d="M0 0"/>
+        <path id="a" d="M1 1"/>
+    </defs>
+    <use href="#b"/>
+</svg>
+
+@@@
+
+{"remove":false}


### PR DESCRIPTION
The generator skips a candidate ID when it looks like a dangling external reference (#1815). Renaming an element deletes its old ID from nodeById, so IDs already reassigned during the pass matched that test too and were skipped, yielding non-consecutive IDs that changed again on a second pass.

Collect external references before any renaming, and guard separately against unreferenced IDs, which are kept when remove is disabled and otherwise led to duplicate IDs and references resolving to the wrong element.

Fixes #2237