### PR TITLE
fix(removeUnknownsAndDefaults): don't strip inherited attrs across ID boundaries

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -124,7 +124,7 @@ const parseStyleDeclarations = (css) => {
  * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {import('./types.js').ComputedStyles}
  */
-const computeOwnStyle = (stylesheet, node, parents) => {
+export const computeOwnStyle = (stylesheet, node, parents) => {
   /** @type {import('./types.js').ComputedStyles} */
   const computedStyle = {};
   const importantStyles = new Map();

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -3,13 +3,14 @@ import {
   attrsGroupsDefaults,
   elems,
   elemsGroups,
+  inheritableAttrs,
   presentationNonInheritableGroupAttrs,
 } from './_collections.js';
 import { detachNodeFromParent } from '../lib/xast.js';
 import { visitSkip } from '../lib/util/visit.js';
 import {
   collectStylesheet,
-  computeStyle,
+  computeOwnStyle,
   includesAttrSelector,
 } from '../lib/style.js';
 
@@ -93,6 +94,69 @@ for (const [name, config] of Object.entries(elems)) {
 }
 
 /**
+ * Walk the ancestors of node once, collecting the two views of the cascade this
+ * plugin needs:
+ *
+ * - `parent` is the full computed style of the parent element, equivalent to
+ *   `computeStyle(stylesheet, parentNode)`. Its own presentation attributes are
+ *   all included, whether they inherit or not; everything above it contributes
+ *   only inheritable properties.
+ * - `inherited` is what node actually inherits within its own referenceable
+ *   subtree. The walk stops above the first ancestor with an `id`, `<defs>`, or
+ *   `<symbol>`, because such an ancestor may be instantiated via `<use>`
+ *   somewhere else entirely, where the ancestors above it do not apply. Their
+ *   styles must therefore not be treated as inherited by node. The boundary
+ *   ancestor itself is included, since it is cloned along with node.
+ *
+ * Both are collected in a single pass: each level re-matches the whole
+ * stylesheet, so walking twice doubles the cost of the plugin on deep documents.
+ *
+ * @param {import('../lib/types.js').Stylesheet} stylesheet
+ * @param {import('../lib/types.js').XastElement} node
+ * @returns {{ parent: import('../lib/types.js').ComputedStyles, inherited: import('../lib/types.js').ComputedStyles }}
+ */
+const computeAncestorStyles = (stylesheet, node) => {
+  const { parents } = stylesheet;
+  /** @type {import('../lib/types.js').ComputedStyles} */
+  const parentStyles = {};
+  /** @type {import('../lib/types.js').ComputedStyles} */
+  const inheritedStyles = {};
+  let parent = parents.get(node);
+  let isParent = true;
+  let crossedBoundary = false;
+  while (parent != null && parent.type === 'element') {
+    const ownStyles = computeOwnStyle(stylesheet, parent, parents);
+    for (const [name, computed] of Object.entries(ownStyles)) {
+      const inheritable =
+        inheritableAttrs.has(name) &&
+        !presentationNonInheritableGroupAttrs.has(name);
+      if (isParent) {
+        parentStyles[name] = computed;
+      } else if (parentStyles[name] == null && inheritable) {
+        parentStyles[name] = { ...computed, inherited: true };
+      }
+      if (!crossedBoundary && inheritedStyles[name] == null && inheritable) {
+        inheritedStyles[name] = { ...computed, inherited: true };
+      }
+    }
+    // Anything reachable by <use> or url(#…) needs an id, so the id check alone
+    // is sufficient in practice. <defs> and <symbol> are kept as a safety net:
+    // their content is never rendered in place, so treating them as a boundary
+    // can only ever retain attributes, never drop one that was needed.
+    if (
+      parent.attributes.id != null ||
+      parent.name === 'defs' ||
+      parent.name === 'symbol'
+    ) {
+      crossedBoundary = true;
+    }
+    isParent = false;
+    parent = parents.get(parent);
+  }
+  return { parent: parentStyles, inherited: inheritedStyles };
+};
+
+/**
  * Remove unknown elements content and attributes,
  * remove attributes with default values.
  *
@@ -154,10 +218,13 @@ export const fn = (root, params) => {
 
         const allowedAttributes = allowedAttributesPerElement.get(node.name);
         const attributesDefaults = attributesDefaultsPerElement.get(node.name);
-        const computedParentStyle =
-          parentNode.type === 'element'
-            ? computeStyle(stylesheet, parentNode)
-            : null;
+        const {
+          parent: computedParentStyle,
+          inherited: computedInheritedStyle,
+        } =
+          defaultAttrs || uselessOverrides
+            ? computeAncestorStyles(stylesheet, node)
+            : { parent: null, inherited: null };
 
         // remove element's unknown attrs and attrs with default values
         for (const [name, value] of Object.entries(node.attributes)) {
@@ -206,7 +273,7 @@ export const fn = (root, params) => {
             }
           }
           if (uselessOverrides && node.attributes.id == null) {
-            const style = computedParentStyle?.[name];
+            const style = computedInheritedStyle?.[name];
             if (
               presentationNonInheritableGroupAttrs.has(name) === false &&
               style != null &&

--- a/test/plugins/removeUnknownsAndDefaults.18.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.18.svg.txt
@@ -1,0 +1,43 @@
+Do not remove presentation attributes on elements inside an element with an
+id, <defs>, or <symbol> that match styles inherited from an ancestor outside,
+as they may be instantiated via <use> without that ancestor.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <g id="icon">
+        <rect width="10" height="10" stroke="red" fill="none"/>
+    </g>
+    <defs>
+        <rect width="10" height="10" stroke="blue" fill="none"/>
+    </defs>
+    <symbol id="sym">
+        <rect width="10" height="10" stroke="green" fill="none"/>
+    </symbol>
+    <g id="with-fill" fill="yellow">
+        <rect width="10" height="10" stroke="black" fill="yellow"/>
+    </g>
+    <g>
+        <rect width="10" height="10" stroke="purple" fill="none"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" fill="none">
+    <g id="icon">
+        <rect width="10" height="10" stroke="red" fill="none"/>
+    </g>
+    <defs>
+        <rect width="10" height="10" stroke="blue" fill="none"/>
+    </defs>
+    <symbol id="sym">
+        <rect width="10" height="10" stroke="green" fill="none"/>
+    </symbol>
+    <g id="with-fill" fill="yellow">
+        <rect width="10" height="10" stroke="black"/>
+    </g>
+    <g>
+        <rect width="10" height="10" stroke="purple"/>
+    </g>
+</svg>

--- a/test/plugins/removeUnknownsAndDefaults.19.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.19.svg.txt
@@ -1,0 +1,39 @@
+Do not treat a parent's own non-inheriting presentation attributes as inherited
+by its children. Only properties in the inheritable set may be dropped from a
+child as a useless override; overflow, vector-effect, stop-color, stop-opacity,
+flood-color and friends apply to the element that carries them and must survive
+even when the parent happens to carry the same value.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" overflow="visible" vector-effect="non-scaling-stroke">
+    <svg overflow="visible" x="10">
+        <rect width="10" height="10" vector-effect="non-scaling-stroke"/>
+    </svg>
+    <linearGradient stop-color="red" stop-opacity="0.5">
+        <stop offset="0" stop-color="red" stop-opacity="0.5"/>
+    </linearGradient>
+    <filter flood-color="blue">
+        <feFlood flood-color="blue"/>
+    </filter>
+    <g fill="red" stroke-width="2">
+        <rect width="10" height="10" fill="red" stroke-width="2"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" overflow="visible" vector-effect="non-scaling-stroke">
+    <svg overflow="visible" x="10">
+        <rect width="10" height="10" vector-effect="non-scaling-stroke"/>
+    </svg>
+    <linearGradient stop-color="red" stop-opacity="0.5">
+        <stop offset="0" stop-color="red" stop-opacity="0.5"/>
+    </linearGradient>
+    <filter flood-color="blue">
+        <feFlood flood-color="blue"/>
+    </filter>
+    <g fill="red" stroke-width="2">
+        <rect width="10" height="10"/>
+    </g>
+</svg>


### PR DESCRIPTION
Two independent uselessOverrides bugs, both from comparing an attribute against the parent's full computed style.

1. Inheritance was resolved through the whole ancestor chain, but an element with an `id` (or inside `<defs>`/`<symbol>`) may be instantiated by `<use>` somewhere else entirely, where the ancestors above it do not apply. Stop the walk at that boundary, keeping the boundary element itself since it is cloned along with the subtree.

2. The parent's own presentation attributes were all treated as inheritable. `presentationNonInheritableGroupAttrs` only covers eight of them, so `overflow`, `vector-effect`, `stop-color`, `stop-opacity`, `flood-color`, `clip`, `transform-origin` and friends leaked through and were dropped from children that legitimately carried them — e.g. `overflow` on a nested `<svg>`, which controls its clipping. Filter on `inheritableAttrs` instead.

Both views of the cascade are collected in a single ancestor walk. Each level re-matches the whole stylesheet, so walking twice doubled the cost of the plugin on deep documents.