### PR TITLE
Upgrade css-select and css-what

### DIFF
--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -5,13 +5,6 @@ const isTag = (node) => {
   return node.type === 'element';
 };
 
-/** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['existsOne']} */
-const existsOne = (test, elems) => {
-  return elems.some((elem) => {
-    return isTag(elem) && (test(elem) || existsOne(test, getChildren(elem)));
-  });
-};
-
 /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getAttributeValue']} */
 const getAttributeValue = (elem, name) => {
   return elem.attributes[name];
@@ -38,36 +31,6 @@ const getText = (node) => {
 /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['hasAttrib']} */
 const hasAttrib = (elem, name) => {
   return elem.attributes[name] !== undefined;
-};
-
-/** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['findAll']} */
-const findAll = (test, elems) => {
-  const result = [];
-  for (const elem of elems) {
-    if (isTag(elem)) {
-      if (test(elem)) {
-        result.push(elem);
-      }
-      result.push(...findAll(test, getChildren(elem)));
-    }
-  }
-  return result;
-};
-
-/** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['findOne']} */
-const findOne = (test, elems) => {
-  for (const elem of elems) {
-    if (isTag(elem)) {
-      if (test(elem)) {
-        return elem;
-      }
-      const result = findOne(test, getChildren(elem));
-      if (result) {
-        return result;
-      }
-    }
-  }
-  return null;
 };
 
 /**
@@ -128,7 +91,6 @@ export function createAdapter(relativeNode, parents) {
 
   return {
     isTag,
-    existsOne,
     getAttributeValue,
     getChildren,
     getName,
@@ -137,7 +99,5 @@ export function createAdapter(relativeNode, parents) {
     getText,
     hasAttrib,
     removeSubsets,
-    findAll,
-    findOne,
   };
 }

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -40,6 +40,9 @@ export const querySelector = (node, selector, parents) => {
  * @returns {boolean}
  */
 export const matches = (node, selector, parents) => {
+  if (selector === '') {
+    return false;
+  }
   return is(node, selector, createCssSelectOptions(node, parents));
 };
 

--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
   },
   "dependencies": {
     "commander": "^11.1.0",
-    "css-select": "^5.1.0",
+    "css-select": "^6.0.0",
     "css-tree": "^3.0.1",
-    "css-what": "^6.1.0",
+    "css-what": "^7.0.0",
     "csso": "^5.0.5",
     "picocolors": "^1.1.1",
     "sax": "1.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,14 +17,14 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       css-select:
-        specifier: ^5.1.0
-        version: 5.2.2
+        specifier: ^6.0.0
+        version: 6.0.0
       css-tree:
         specifier: ^3.0.1
         version: 3.2.1
       css-what:
-        specifier: ^6.1.0
-        version: 6.2.2
+        specifier: ^7.0.0
+        version: 7.0.0
       csso:
         specifier: ^5.0.5
         version: 5.0.5
@@ -1544,8 +1544,8 @@ packages:
     engines: {node: '>=22.18.0'}
     hasBin: true
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -1555,8 +1555,8 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
 
   csso@5.0.5:
@@ -4220,10 +4220,10 @@ snapshots:
       semver: 7.8.5
       tinyglobby: 0.2.17
 
-  css-select@5.2.2:
+  css-select@6.0.0:
     dependencies:
       boolbase: 1.0.0
-      css-what: 6.2.2
+      css-what: 7.0.0
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
@@ -4238,7 +4238,7 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
-  css-what@6.2.2: {}
+  css-what@7.0.0: {}
 
   csso@5.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade css-select to v6 and css-what to v7 while preserving Node.js 16 support
- update the custom css-select adapter for the smaller v6 adapter contract
- preserve the previous non-matching behavior for empty selectors produced from purely dynamic pseudo-class rules

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm test:types`
- `pnpm test:bundles`
- Node.js 16.20.2 CommonJS bundle optimization, including a pure `:link` stylesheet selector
- regression corpus optimization completed with reduced worker concurrency; rendered comparison could not complete locally because Chromium crashed on non-deterministic fixtures