### PR TITLE
perf: parallelize regression optimization

### DIFF
--- a/test/regression/optimize-worker.js
+++ b/test/regression/optimize-worker.js
@@ -10,8 +10,9 @@ const SVGO_OPTS = { floatPrecision: 4 };
 if (parentPort == null) {
   throw new Error('Optimization worker must run in a worker thread');
 }
+const port = parentPort;
 
-parentPort.on('message', async ({ name }) => {
+port.on('message', async ({ name }) => {
   try {
     const original = await fs.readFile(
       path.join(workerData.fixturesPath, name),
@@ -23,7 +24,7 @@ parentPort.on('message', async ({ name }) => {
     await fs.mkdir(path.dirname(file), { recursive: true });
     await fs.writeFile(file, optimized);
 
-    parentPort.postMessage({
+    port.postMessage({
       name: pathToPosix(name),
       checksum: md5sum(optimized),
       originalBytes: Buffer.byteLength(original, 'utf8'),
@@ -31,6 +32,8 @@ parentPort.on('message', async ({ name }) => {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to optimize ${name}: ${message}`, { cause: error });
+    throw Object.assign(new Error(`Failed to optimize ${name}: ${message}`), {
+      cause: error,
+    });
   }
 });

--- a/test/regression/optimize-worker.js
+++ b/test/regression/optimize-worker.js
@@ -1,0 +1,36 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parentPort, workerData } from 'node:worker_threads';
+import { optimize } from '../../lib/svgo.js';
+import { md5sum, pathToPosix } from './lib.js';
+
+/** @type {import('../../lib/types.js').Config} */
+const SVGO_OPTS = { floatPrecision: 4 };
+
+if (parentPort == null) {
+  throw new Error('Optimization worker must run in a worker thread');
+}
+
+parentPort.on('message', async ({ name }) => {
+  try {
+    const original = await fs.readFile(
+      path.join(workerData.fixturesPath, name),
+      'utf8',
+    );
+    const optimized = optimize(original, SVGO_OPTS).data;
+    const file = path.join(workerData.optimizedPath, name);
+
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, optimized);
+
+    parentPort.postMessage({
+      name: pathToPosix(name),
+      checksum: md5sum(optimized),
+      originalBytes: Buffer.byteLength(original, 'utf8'),
+      optimizedBytes: Buffer.byteLength(optimized, 'utf8'),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to optimize ${name}: ${message}`, { cause: error });
+  }
+});

--- a/test/regression/optimize.js
+++ b/test/regression/optimize.js
@@ -1,24 +1,48 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { Worker } from 'node:worker_threads';
 import {
   REGRESSION_FIXTURES_PATH,
   REGRESSION_OPTIMIZED_PATH,
   writeReport,
 } from './regression-io.js';
-import { md5sum, pathToPosix } from './lib.js';
-import { optimize } from '../../lib/svgo.js';
 
-/** @type {import('../../lib/types.js').Config} */
-const SVGO_OPTS = { floatPrecision: 4 };
+const HEAVY_FILE_SIZE = 10 * 2 ** 20;
+const MEMORY_PER_HEAVY_WORKER = 6 * 2 ** 30;
 
 /**
- * @param {string[]} list
+ * @param {number} fileCount
+ * @param {number} maxWorkers
+ * @returns {number}
+ */
+export const getWorkerCount = (fileCount, maxWorkers) => {
+  if (fileCount === 0) {
+    return 0;
+  }
+
+  return Math.min(fileCount, Math.max(1, maxWorkers));
+};
+
+/**
+ * @param {number} fileCount
+ * @param {number} maxWorkers
+ * @param {number} totalMemory
+ * @returns {number}
+ */
+export const getHeavyWorkerCount = (fileCount, maxWorkers, totalMemory) => {
+  const memoryLimit = Math.floor(totalMemory / MEMORY_PER_HEAVY_WORKER);
+  return getWorkerCount(fileCount, Math.min(maxWorkers, memoryLimit));
+};
+
+/**
+ * @param {ReadonlyArray<string>} list
+ * @param {{ fixturesPath: string, optimizedPath: string, maxWorkers: number, totalMemory?: number }} options
  * @returns {Promise<Partial<import('./regression-io.js').TestReport>>}
  */
-const optimizeFixtures = async (list) => {
+export const optimizeFixtures = async (list, options) => {
   const totalFiles = list.length;
-  let processed = 0;
 
   /** @type {Pick<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>} */
   const report = {
@@ -30,43 +54,144 @@ const optimizeFixtures = async (list) => {
     checksums: {},
   };
 
+  const jobs = await Promise.all(
+    list.map(async (name) => {
+      try {
+        return {
+          name,
+          size: (await fs.stat(path.join(options.fixturesPath, name))).size,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to optimize ${name}: ${message}`, {
+          cause: error,
+        });
+      }
+    }),
+  );
+  jobs.sort((a, b) => a.size - b.size);
+
+  const heavyJobs = jobs.filter((job) => job.size >= HEAVY_FILE_SIZE);
+  const regularJobs = jobs.filter((job) => job.size < HEAVY_FILE_SIZE);
+  let completed = 0;
+
   /**
-   * @param {string} name
+   * @param {{ name: string, size: number }[]} queue
+   * @param {number} workerCount
    */
-  const processFile = async (name) => {
-    const original = await fs.readFile(
-      path.join(REGRESSION_FIXTURES_PATH, name),
-      'utf-8',
-    );
-    const optimized = optimize(original, SVGO_OPTS).data;
-    const namePosix = pathToPosix(name);
-    report.checksums[namePosix] = md5sum(optimized);
-
-    const prevFileSize = Buffer.byteLength(original, 'utf8');
-    const resultFileSize = Buffer.byteLength(optimized, 'utf8');
-    report.metrics.bytesSaved += prevFileSize - resultFileSize;
-
-    const file = path.join(REGRESSION_OPTIMIZED_PATH, name);
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, optimized);
-
-    if (process.stdout.isTTY) {
-      process.stdout.clearLine(0);
-      process.stdout.write(
-        `\rOptimized ${(++processed).toLocaleString()} of ${totalFiles.toLocaleString()}…`,
-      );
+  const runWorkerPool = async (queue, workerCount) => {
+    if (workerCount === 0) {
+      return;
     }
+
+    const jobCount = queue.length;
+    await new Promise((resolve, reject) => {
+      /** @type {Worker[]} */
+      const workers = [];
+      /** @type {Map<Worker, string>} */
+      const activeFixtures = new Map();
+      let poolCompleted = 0;
+      let settled = false;
+
+      const terminateWorkers = () =>
+        Promise.all(workers.map((worker) => worker.terminate()));
+
+      /** @param {unknown} error */
+      const fail = async (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        await terminateWorkers();
+        reject(error);
+      };
+
+      const finish = async () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        await terminateWorkers();
+        resolve(undefined);
+      };
+
+      /** @param {Worker} worker */
+      const dispatch = (worker) => {
+        const job = queue.pop();
+        if (job) {
+          activeFixtures.set(worker, job.name);
+          worker.postMessage({ name: job.name });
+        }
+      };
+
+      for (let index = 0; index < workerCount; index++) {
+        const worker = new Worker(
+          new URL('./optimize-worker.js', import.meta.url),
+          {
+            resourceLimits: { maxOldGenerationSizeMb: 4096 },
+            workerData: {
+              fixturesPath: options.fixturesPath,
+              optimizedPath: options.optimizedPath,
+            },
+          },
+        );
+        workers.push(worker);
+
+        worker.on('message', (result) => {
+          activeFixtures.delete(worker);
+          report.checksums[result.name] = result.checksum;
+          report.metrics.bytesSaved +=
+            result.originalBytes - result.optimizedBytes;
+          completed++;
+          poolCompleted++;
+
+          if (process.stdout.isTTY) {
+            process.stdout.clearLine(0);
+            process.stdout.write(
+              `\rOptimized ${completed.toLocaleString()} of ${totalFiles.toLocaleString()}…`,
+            );
+          }
+
+          if (poolCompleted === jobCount) {
+            void finish();
+          } else {
+            dispatch(worker);
+          }
+        });
+        worker.on('error', (error) => {
+          const name = activeFixtures.get(worker);
+          const workerError = name
+            ? new Error(`Failed to optimize ${name}: ${error.message}`, {
+                cause: error,
+              })
+            : error;
+          void fail(workerError);
+        });
+        worker.on('exit', (code) => {
+          if (!settled) {
+            const name = activeFixtures.get(worker);
+            const message = name
+              ? `Failed to optimize ${name}: worker exited with code ${code}`
+              : `Optimization worker exited with code ${code}`;
+            void fail(new Error(message));
+          }
+        });
+        dispatch(worker);
+      }
+    });
   };
 
-  const worker = async () => {
-    let item;
-    while ((item = list.pop())) {
-      await processFile(item);
-    }
-  };
-
-  await Promise.all(
-    Array.from(new Array(os.cpus().length * 2), () => worker()),
+  await runWorkerPool(
+    heavyJobs,
+    getHeavyWorkerCount(
+      heavyJobs.length,
+      options.maxWorkers,
+      options.totalMemory ?? os.totalmem(),
+    ),
+  );
+  await runWorkerPool(
+    regularJobs,
+    getWorkerCount(regularJobs.length, options.maxWorkers),
   );
 
   report.metrics.timeTakenSecs = process.uptime();
@@ -74,17 +199,26 @@ const optimizeFixtures = async (list) => {
   return report;
 };
 
-(async () => {
-  try {
-    const filesPromise = fs.readdir(REGRESSION_FIXTURES_PATH, {
-      recursive: true,
-    });
-    const list = (await filesPromise).filter((name) => name.endsWith('.svg'));
-    const report = await optimizeFixtures(list);
-    console.log();
-    await writeReport(report);
-  } catch (error) {
-    console.error(error);
-    process.exit(1);
-  }
-})();
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  (async () => {
+    try {
+      const filesPromise = fs.readdir(REGRESSION_FIXTURES_PATH, {
+        recursive: true,
+      });
+      const list = (await filesPromise).filter((name) => name.endsWith('.svg'));
+      const report = await optimizeFixtures(list, {
+        fixturesPath: REGRESSION_FIXTURES_PATH,
+        optimizedPath: REGRESSION_OPTIMIZED_PATH,
+        maxWorkers: os.cpus().length,
+      });
+      console.log();
+      await writeReport(report);
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
+  })();
+}

--- a/test/regression/optimize.js
+++ b/test/regression/optimize.js
@@ -39,7 +39,7 @@ export const getHeavyWorkerCount = (fileCount, maxWorkers, totalMemory) => {
 /**
  * @param {ReadonlyArray<string>} list
  * @param {{ fixturesPath: string, optimizedPath: string, maxWorkers: number, totalMemory?: number }} options
- * @returns {Promise<Partial<import('./regression-io.js').TestReport>>}
+ * @returns {Promise<Pick<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>>}
  */
 export const optimizeFixtures = async (list, options) => {
   const totalFiles = list.length;
@@ -63,9 +63,10 @@ export const optimizeFixtures = async (list, options) => {
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to optimize ${name}: ${message}`, {
-          cause: error,
-        });
+        throw Object.assign(
+          new Error(`Failed to optimize ${name}: ${message}`),
+          { cause: error },
+        );
       }
     }),
   );
@@ -160,10 +161,13 @@ export const optimizeFixtures = async (list, options) => {
         });
         worker.on('error', (error) => {
           const name = activeFixtures.get(worker);
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
           const workerError = name
-            ? new Error(`Failed to optimize ${name}: ${error.message}`, {
-                cause: error,
-              })
+            ? Object.assign(
+                new Error(`Failed to optimize ${name}: ${errorMessage}`),
+                { cause: error },
+              )
             : error;
           void fail(workerError);
         });

--- a/test/regression/optimize.test.js
+++ b/test/regression/optimize.test.js
@@ -1,0 +1,160 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { once } from 'node:events';
+import { Worker } from 'node:worker_threads';
+import {
+  getHeavyWorkerCount,
+  getWorkerCount,
+  optimizeFixtures,
+} from './optimize.js';
+
+const workerUrl = new URL('./optimize-worker.js', import.meta.url);
+
+describe('regression optimization worker', () => {
+  /** @type {string} */
+  let tempPath;
+  /** @type {Worker | undefined} */
+  let worker;
+
+  beforeEach(async () => {
+    tempPath = await fs.mkdtemp(path.join(os.tmpdir(), 'svgo-optimize-'));
+  });
+
+  afterEach(async () => {
+    await worker?.terminate();
+    await fs.rm(tempPath, { recursive: true, force: true });
+  });
+
+  it('writes optimized output and returns its metrics', async () => {
+    const fixturesPath = path.join(tempPath, 'fixtures');
+    const optimizedPath = path.join(tempPath, 'optimized');
+    const name = path.join('nested', 'example.svg');
+    const original =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" fill="#ff0000"/></svg>';
+    const expected =
+      '<svg xmlns="http://www.w3.org/2000/svg"><path fill="red" d="M0 0h10v10H0z"/></svg>';
+
+    await fs.mkdir(path.dirname(path.join(fixturesPath, name)), {
+      recursive: true,
+    });
+    await fs.writeFile(path.join(fixturesPath, name), original);
+
+    worker = new Worker(workerUrl, {
+      workerData: { fixturesPath, optimizedPath },
+    });
+    worker.postMessage({ name });
+    const [message] = await once(worker, 'message');
+
+    await expect(
+      fs.readFile(path.join(optimizedPath, name), 'utf8'),
+    ).resolves.toBe(expected);
+    expect(message).toEqual({
+      name: 'nested/example.svg',
+      checksum: '3b6937a41018bccdcb2bacde85f68fae',
+      originalBytes: 91,
+      optimizedBytes: 82,
+    });
+  });
+});
+
+describe('regression optimization pool', () => {
+  /** @type {string} */
+  let tempPath;
+
+  beforeEach(async () => {
+    tempPath = await fs.mkdtemp(path.join(os.tmpdir(), 'svgo-optimize-pool-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempPath, { recursive: true, force: true });
+  });
+
+  it('bounds workers by the configured maximum and available work', () => {
+    expect(getWorkerCount(0, 4)).toBe(0);
+    expect(getWorkerCount(2, 4)).toBe(2);
+    expect(getWorkerCount(8, 4)).toBe(4);
+    expect(getWorkerCount(8, 0)).toBe(1);
+  });
+
+  it('reserves enough memory for each heavyweight worker', () => {
+    expect(getHeavyWorkerCount(0, 4, 8 * 2 ** 30)).toBe(0);
+    expect(getHeavyWorkerCount(7, 4, 8 * 2 ** 30)).toBe(1);
+    expect(getHeavyWorkerCount(7, 4, 16 * 2 ** 30)).toBe(2);
+    expect(getHeavyWorkerCount(1, 4, 16 * 2 ** 30)).toBe(1);
+  });
+
+  it('optimizes files and aggregates their report', async () => {
+    const fixturesPath = path.join(tempPath, 'fixtures');
+    const optimizedPath = path.join(tempPath, 'optimized');
+    const fixtures = {
+      'circle.svg':
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="5"/></svg>',
+      [path.join('nested', 'path.svg')]:
+        '<svg xmlns="http://www.w3.org/2000/svg"><g><path d="M 0 0 L 10 10"/></g></svg>',
+    };
+
+    for (const [name, data] of Object.entries(fixtures)) {
+      const file = path.join(fixturesPath, name);
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, data);
+    }
+
+    const report = await optimizeFixtures(Object.keys(fixtures), {
+      fixturesPath,
+      optimizedPath,
+      maxWorkers: 2,
+    });
+
+    await expect(
+      fs.readFile(path.join(optimizedPath, 'circle.svg'), 'utf8'),
+    ).resolves.toBe(fixtures['circle.svg']);
+    await expect(
+      fs.readFile(path.join(optimizedPath, 'nested', 'path.svg'), 'utf8'),
+    ).resolves.toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><path d="m0 0 10 10"/></svg>',
+    );
+    expect(report.checksums).toEqual({
+      'circle.svg': '598f8a67e7a060ed41282c770fc3a070',
+      'nested/path.svg': '7dd14598dcf410e106a9c3dff27cdb3c',
+    });
+    expect(report.metrics.bytesSaved).toBe(10);
+    expect(report.metrics.timeTakenSecs).toBeGreaterThanOrEqual(0);
+    expect(report.metrics.peakMemoryAlloc).toBeGreaterThan(0);
+  });
+
+  it('identifies the fixture when optimization fails', async () => {
+    await expect(
+      optimizeFixtures(['missing.svg'], {
+        fixturesPath: path.join(tempPath, 'fixtures'),
+        optimizedPath: path.join(tempPath, 'optimized'),
+        maxWorkers: 2,
+      }),
+    ).rejects.toThrow('Failed to optimize missing.svg:');
+  });
+
+  it('propagates worker errors with the fixture name', async () => {
+    const fixturesPath = path.join(tempPath, 'fixtures');
+    await fs.mkdir(fixturesPath);
+    await fs.writeFile(path.join(fixturesPath, 'invalid.svg'), '<svg>');
+
+    await expect(
+      optimizeFixtures(['invalid.svg'], {
+        fixturesPath,
+        optimizedPath: path.join(tempPath, 'optimized'),
+        maxWorkers: 1,
+      }),
+    ).rejects.toThrow('Failed to optimize invalid.svg:');
+  });
+
+  it('completes without creating workers when there are no files', async () => {
+    const report = await optimizeFixtures([], {
+      fixturesPath: path.join(tempPath, 'fixtures'),
+      optimizedPath: path.join(tempPath, 'optimized'),
+      maxWorkers: 4,
+    });
+
+    expect(report.checksums).toEqual({});
+    expect(report.metrics.bytesSaved).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- move SVG optimization into a bounded worker-thread pool
- process memory-heavy fixtures separately with host-memory-aware concurrency
- preserve regression outputs, checksums, metrics, and fixture-specific errors
- add integration coverage for worker output, reports, failures, and concurrency bounds

## Benchmark

On a 4-core, 8 GiB host with 5,125 SVGs (1.30 GiB input):

- before: failed with OOM after 8m48s at 116% CPU
- after: completed in 9m26s at 171% CPU with 3.61 GiB peak RSS
- single-worker control: completed in 13m47s

The GitHub runner target has enough memory to schedule two heavyweight workers instead of the single heavyweight worker used in the local benchmark.

## Testing

- `pnpm test` (17 suites, 498 passed, 3 skipped)
- `pnpm lint`
- full optimization run produced 5,125 outputs and 5,125 checksums

The subsequent Playwright comparison still crashed under local host memory pressure after about 4m22s, matching the pre-existing comparison-phase behavior and remaining outside this optimization change.