### PR TITLE
Match CSS attribute selector values before retaining attributes

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -335,7 +335,43 @@ export const includesAttrSelector = (
         return false;
       }
 
-      return value == null ? true : segment.value === value;
+      if (value == null || segment.action === 'exists') {
+        return true;
+      }
+
+      const selectorValue =
+        segment.ignoreCase === true
+          ? segment.value.toLowerCase()
+          : segment.value;
+      const attributeValue =
+        segment.ignoreCase === true ? value.toLowerCase() : value;
+
+      switch (segment.action) {
+        case 'equals':
+          return attributeValue === selectorValue;
+        case 'hyphen':
+          return (
+            attributeValue === selectorValue ||
+            attributeValue.startsWith(selectorValue + '-')
+          );
+        case 'element':
+          return attributeValue.split(/\s+/).includes(selectorValue);
+        case 'start':
+          return (
+            selectorValue.length !== 0 &&
+            attributeValue.startsWith(selectorValue)
+          );
+        case 'end':
+          return (
+            selectorValue.length !== 0 && attributeValue.endsWith(selectorValue)
+          );
+        case 'any':
+          return (
+            selectorValue.length !== 0 && attributeValue.includes(selectorValue)
+          );
+        case 'not':
+          return attributeValue !== selectorValue;
+      }
     });
 
     if (hasAttrSelector) {

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -1,5 +1,9 @@
+import {
+  collectStylesheet,
+  computeStyle,
+  includesAttrSelector,
+} from './style.js';
 import { expect, it } from 'vitest';
-import { collectStylesheet, computeStyle } from './style.js';
 import { visit } from './util/visit.js';
 import { parseSvg } from './parser.js';
 
@@ -25,6 +29,20 @@ const getElementById = (node, id) => {
   }
   return matched;
 };
+
+it('matches attribute selector actions against values', () => {
+  expect(includesAttrSelector('[fill]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[fill="red"]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[fill="blue"]', 'fill', 'red')).toBe(false);
+  expect(includesAttrSelector('[fill^="re"]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[fill$="ed"]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[fill*="e"]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[class~="bar"]', 'class', 'foo bar')).toBe(true);
+  expect(includesAttrSelector('[lang|="en"]', 'lang', 'en-US')).toBe(true);
+  expect(includesAttrSelector('[fill!="blue"]', 'fill', 'red')).toBe(true);
+  expect(includesAttrSelector('[fill!="red"]', 'fill', 'red')).toBe(false);
+  expect(includesAttrSelector('[fill="red" i]', 'fill', 'RED')).toBe(true);
+});
 
 it('collects styles', () => {
   const root = parseSvg(`

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -262,7 +262,11 @@ export const fn = (root, params) => {
                 if (
                   attrsGroups.presentation.has(property) &&
                   !selectors.some((selector) =>
-                    includesAttrSelector(selector.item, property),
+                    includesAttrSelector(
+                      selector.item,
+                      property,
+                      selectedEl.attributes[property],
+                    ),
                   )
                 ) {
                   delete selectedEl.attributes[property];

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -200,7 +200,7 @@ export const fn = (root, params) => {
             if (
               computedParentStyle?.[name] == null &&
               !stylesheet.rules.some((rule) =>
-                includesAttrSelector(rule.selector, name),
+                includesAttrSelector(rule.selector, name, value),
               )
             ) {
               delete node.attributes[name];

--- a/test/plugins/inlineStyles.29.svg.txt
+++ b/test/plugins/inlineStyles.29.svg.txt
@@ -1,0 +1,27 @@
+Remove a presentation attribute when a selector references it with a value that does not match.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+  <style>
+    .a {
+      stroke: red;
+    }
+
+    [stroke^="purple"] + path {
+      stroke: purple;
+    }
+  </style>
+  <path class="a" d="M10 10h20" stroke="red"/>
+  <path d="M10 20h20"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+    <style>
+        [stroke^=&quot;purple&quot;]+path{stroke:purple}
+    </style>
+    <path d="M10 10h20" style="stroke:red"/>
+    <path d="M10 20h20"/>
+</svg>

--- a/test/plugins/removeUnknownsAndDefaults.18.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.18.svg.txt
@@ -1,0 +1,23 @@
+Remove a default attribute when an attribute selector does not match its value.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 202 40">
+  <style>
+      [preserveAspectRatio^="y"] { fill: yellow; stroke: black; }
+  </style>
+  <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+    <path d="M50,10 A40,40,1,1,1,50,90 A40,40,1,1,1,50,10 M30,40 Q36,35,42,40 M58,40 Q64,35,70,40 M30,60 Q50,75,70,60 Q50,75,30,60"/>
+  </svg>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 202 40">
+    <style>
+        [preserveAspectRatio^=&quot;y&quot;] { fill: yellow; stroke: black; }
+    </style>
+    <svg viewBox="0 0 100 100">
+        <path d="M50,10 A40,40,1,1,1,50,90 A40,40,1,1,1,50,10 M30,40 Q36,35,42,40 M58,40 Q64,35,70,40 M30,60 Q50,75,70,60 Q50,75,30,60"/>
+    </svg>
+</svg>


### PR DESCRIPTION
Fixes #2145

`includesAttrSelector` now evaluates CSS attribute selector operators against the current attribute value. The callers in `inlineStyles` and `removeUnknownsAndDefaults` now provide that value, so selectors that cannot match no longer keep a redundant attribute.

Added unit coverage for supported operators and regressions for both affected plugins.

Validation:
- full Jest suite: 494 passed, 3 skipped
- ESLint and Prettier
- type checks, `tsd`, and bundle build
- bundled-browser test

AI assistance: this patch was AI-assisted and the listed validations were run locally.