### PR TITLE
chore: separate regression rendering and comparison

### DIFF
--- a/test/regression/compare-worker.js
+++ b/test/regression/compare-worker.js
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { isMainThread, parentPort } from 'node:worker_threads';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+/**
+ * @typedef CompareOptions
+ * @property {string} name
+ * @property {string} originalPath
+ * @property {string} optimizedPath
+ * @property {string | null} diffPath
+ * @property {typeof fs.rm=} remove
+ */
+
+/**
+ * @param {CompareOptions} options
+ * @returns {Promise<{ name: string, matched: number, width: number }>}
+ */
+export async function compareImages(options) {
+  const {
+    name,
+    originalPath,
+    optimizedPath,
+    diffPath,
+    remove = fs.rm,
+  } = options;
+  let primaryError;
+  let result;
+  try {
+    const [originalBuffer, optimizedBuffer] = await Promise.all([
+      fs.readFile(originalPath),
+      fs.readFile(optimizedPath),
+    ]);
+    const originalPng = PNG.sync.read(originalBuffer);
+    const optimizedPng = PNG.sync.read(optimizedBuffer);
+    if (
+      originalPng.width !== optimizedPng.width ||
+      originalPng.height !== optimizedPng.height
+    ) {
+      throw new Error('Image dimensions do not match');
+    }
+    const diff = diffPath
+      ? new PNG({ width: originalPng.width, height: originalPng.height })
+      : null;
+    const matched = pixelmatch(
+      originalPng.data,
+      optimizedPng.data,
+      diff?.data,
+      originalPng.width,
+      originalPng.height,
+    );
+
+    const threshold = originalPng.width <= 16 ? 3 : 4;
+    if (diffPath && matched > threshold && diff) {
+      await fs.mkdir(path.dirname(diffPath), { recursive: true });
+      await fs.writeFile(diffPath, PNG.sync.write(diff));
+    }
+
+    result = { name, matched, width: originalPng.width };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    primaryError = new Error(`Failed to compare ${name}: ${message}`, {
+      cause: error,
+    });
+  }
+
+  let cleanupError;
+  const cleanupResults = await Promise.allSettled([
+    remove(originalPath, { force: true }),
+    remove(optimizedPath, { force: true }),
+  ]);
+  const failedCleanup = cleanupResults.find(
+    (outcome) => outcome.status === 'rejected',
+  );
+  if (failedCleanup) {
+    cleanupError = failedCleanup.reason;
+  }
+  if (primaryError) {
+    throw primaryError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
+  return result;
+}
+
+if (!isMainThread && parentPort) {
+  parentPort.on('message', async (options) => {
+    const result = await compareImages(options);
+    parentPort.postMessage(result);
+  });
+}

--- a/test/regression/compare-worker.js
+++ b/test/regression/compare-worker.js
@@ -11,11 +11,16 @@ import { PNG } from 'pngjs';
  * @property {string} optimizedPath
  * @property {string | null} diffPath
  * @property {typeof fs.rm=} remove
+ *
+ * @typedef CompareResult
+ * @property {string} name
+ * @property {number} matched
+ * @property {number} width
  */
 
 /**
  * @param {CompareOptions} options
- * @returns {Promise<{ name: string, matched: number, width: number }>}
+ * @returns {Promise<CompareResult>}
  */
 export async function compareImages(options) {
   const {
@@ -60,9 +65,10 @@ export async function compareImages(options) {
     result = { name, matched, width: originalPng.width };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    primaryError = new Error(`Failed to compare ${name}: ${message}`, {
-      cause: error,
-    });
+    primaryError = Object.assign(
+      new Error(`Failed to compare ${name}: ${message}`),
+      { cause: error },
+    );
   }
 
   let cleanupError;
@@ -82,12 +88,13 @@ export async function compareImages(options) {
   if (cleanupError) {
     throw cleanupError;
   }
-  return result;
+  return /** @type {CompareResult} */ (result);
 }
 
 if (!isMainThread && parentPort) {
-  parentPort.on('message', async (options) => {
+  const port = parentPort;
+  port.on('message', async (options) => {
     const result = await compareImages(options);
-    parentPort.postMessage(result);
+    port.postMessage(result);
   });
 }

--- a/test/regression/compare-worker.test.js
+++ b/test/regression/compare-worker.test.js
@@ -5,6 +5,10 @@ import { jest } from '@jest/globals';
 import { PNG } from 'pngjs';
 import { compareImages } from './compare-worker.js';
 
+/**
+ * @param {string} file
+ * @param {number[][]} colors
+ */
 const createPng = async (file, colors) => {
   const png = new PNG({ width: colors.length, height: 1 });
   for (const [index, color] of colors.entries()) {
@@ -14,6 +18,7 @@ const createPng = async (file, colors) => {
 };
 
 describe('compareImages', () => {
+  /** @type {string} */
   let directory;
 
   beforeEach(async () => {

--- a/test/regression/compare-worker.test.js
+++ b/test/regression/compare-worker.test.js
@@ -1,0 +1,176 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { jest } from '@jest/globals';
+import { PNG } from 'pngjs';
+import { compareImages } from './compare-worker.js';
+
+const createPng = async (file, colors) => {
+  const png = new PNG({ width: colors.length, height: 1 });
+  for (const [index, color] of colors.entries()) {
+    png.data.set(color, index * 4);
+  }
+  await fs.writeFile(file, PNG.sync.write(png));
+};
+
+describe('compareImages', () => {
+  let directory;
+
+  beforeEach(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'svgo-compare-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  test('compares files, writes a diff, and deletes screenshots', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    const diffPath = path.join(directory, 'diff', 'result.png');
+    const black = [0, 0, 0, 255];
+    const white = [255, 255, 255, 255];
+    await createPng(originalPath, [black, black, black, black, black]);
+    await createPng(optimizedPath, [white, white, white, white, white]);
+
+    await expect(
+      compareImages({
+        name: 'fixture.svg',
+        originalPath,
+        optimizedPath,
+        diffPath,
+      }),
+    ).resolves.toEqual({ name: 'fixture.svg', matched: 5, width: 5 });
+    await expect(fs.stat(diffPath)).resolves.toBeDefined();
+    await expect(fs.stat(originalPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.stat(optimizedPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  test('does not write a diff for differences within the match allowance', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    const diffPath = path.join(directory, 'diff.png');
+    const black = [0, 0, 0, 255];
+    const white = [255, 255, 255, 255];
+    await createPng(originalPath, [black]);
+    await createPng(optimizedPath, [white]);
+
+    await compareImages({
+      name: 'fixture.svg',
+      originalPath,
+      optimizedPath,
+      diffPath,
+    });
+
+    await expect(fs.stat(diffPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('does not write a diff when no path is provided', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    const black = [0, 0, 0, 255];
+    await createPng(originalPath, [black]);
+    await createPng(optimizedPath, [black]);
+
+    await expect(
+      compareImages({
+        name: 'fixture.svg',
+        originalPath,
+        optimizedPath,
+        diffPath: null,
+      }),
+    ).resolves.toEqual({ name: 'fixture.svg', matched: 0, width: 1 });
+  });
+
+  test('rejects images with different dimensions but equal pixel counts', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    const original = new PNG({ width: 1, height: 4 });
+    const optimized = new PNG({ width: 2, height: 2 });
+    await fs.writeFile(originalPath, PNG.sync.write(original));
+    await fs.writeFile(optimizedPath, PNG.sync.write(optimized));
+
+    await expect(
+      compareImages({
+        name: 'layout.svg',
+        originalPath,
+        optimizedPath,
+        diffPath: null,
+      }),
+    ).rejects.toThrow('Image dimensions do not match');
+  });
+
+  test('identifies the fixture and deletes files after a decode error', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    await fs.writeFile(originalPath, 'not a png');
+    await fs.writeFile(optimizedPath, 'not a png');
+
+    await expect(
+      compareImages({
+        name: 'broken.svg',
+        originalPath,
+        optimizedPath,
+        diffPath: null,
+      }),
+    ).rejects.toThrow('Failed to compare broken.svg');
+    await expect(fs.stat(originalPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.stat(optimizedPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  test('preserves a comparison error when screenshot cleanup also fails', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    await fs.writeFile(originalPath, 'not a png');
+    await fs.writeFile(optimizedPath, 'not a png');
+
+    const remove = jest.fn(async () => {
+      throw new Error('cleanup failed');
+    });
+    await expect(
+      compareImages({
+        name: 'broken.svg',
+        originalPath,
+        optimizedPath,
+        diffPath: null,
+        remove,
+      }),
+    ).rejects.toThrow('Failed to compare broken.svg');
+    expect(remove).toHaveBeenCalled();
+  });
+
+  test('waits for both screenshot removals before reporting cleanup failure', async () => {
+    const originalPath = path.join(directory, 'original.png');
+    const optimizedPath = path.join(directory, 'optimized.png');
+    const black = [0, 0, 0, 255];
+    await createPng(originalPath, [black]);
+    await createPng(optimizedPath, [black]);
+    let secondSettled = false;
+    const remove = jest.fn(async (file) => {
+      if (file === originalPath) {
+        throw new Error('cleanup failed');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      secondSettled = true;
+    });
+
+    await expect(
+      compareImages({
+        name: 'fixture.svg',
+        originalPath,
+        optimizedPath,
+        diffPath: null,
+        remove,
+      }),
+    ).rejects.toThrow('cleanup failed');
+    expect(secondSettled).toBe(true);
+  });
+});

--- a/test/regression/compare.js
+++ b/test/regression/compare.js
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import pixelmatch from 'pixelmatch';
+import { pathToFileURL } from 'node:url';
+import { Worker } from 'node:worker_threads';
 import { chromium } from 'playwright';
-import { PNG } from 'pngjs';
 import { expectMismatch, ignore, skip } from './file-lists.js';
 import { pathToPosix, printReport } from './lib.js';
 import {
@@ -12,12 +12,19 @@ import {
   REGRESSION_DIFFS_PATH,
   REGRESSION_FIXTURES_PATH,
   REGRESSION_OPTIMIZED_PATH,
+  REGRESSION_OPTIMIZED_SCREENSHOTS_PATH,
+  REGRESSION_ORIGINAL_SCREENSHOTS_PATH,
+  REGRESSION_SCREENSHOTS_PATH,
   writeReport,
 } from './regression-io.js';
 
 const NAVIGATION_TIMEOUT_MS = 0;
 const WIDTH = 960;
 const HEIGHT = 720;
+const availableParallelism = os.availableParallelism?.() ?? os.cpus().length;
+const DEFAULT_RENDER_WORKERS = Math.min(availableParallelism, 2);
+const DEFAULT_COMPARE_WORKERS = Math.min(availableParallelism, 2);
+const workerUrl = new URL('./compare-worker.js', import.meta.url);
 
 /** @type {import('playwright').PageScreenshotOptions} */
 const screenshotOptions = {
@@ -26,156 +33,302 @@ const screenshotOptions = {
 };
 
 /**
+ * @template T
+ * @param {() => Promise<T>} operation
+ * @param {() => Promise<unknown>} cleanup
+ * @returns {Promise<T>}
+ */
+export async function withCleanup(operation, cleanup) {
+  let result;
+  let primaryError;
+  try {
+    result = await operation();
+  } catch (error) {
+    primaryError = error;
+  }
+  let cleanupError;
+  try {
+    await cleanup();
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (primaryError) {
+    throw primaryError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
+  return /** @type {T} */ (result);
+}
+
+/**
  * @param {ReadonlyArray<string>} list
+ * @param {{ workerCount?: number }=} options
+ */
+export async function renderScreenshots(list, options = {}) {
+  const queue = [...list];
+  const workerCount = Math.min(
+    options.workerCount ?? DEFAULT_RENDER_WORKERS,
+    queue.length,
+  );
+  await fs.rm(REGRESSION_SCREENSHOTS_PATH, { recursive: true, force: true });
+  await fs.mkdir(REGRESSION_ORIGINAL_SCREENSHOTS_PATH, { recursive: true });
+  await fs.mkdir(REGRESSION_OPTIMIZED_SCREENSHOTS_PATH, { recursive: true });
+
+  const browser = await chromium.launch();
+  await withCleanup(
+    async () => {
+      const context = await browser.newContext({
+        javaScriptEnabled: false,
+        viewport: { width: WIDTH, height: HEIGHT },
+      });
+      context.setDefaultTimeout(NAVIGATION_TIMEOUT_MS);
+
+      const worker = async () => {
+        const page = await context.newPage();
+        await withCleanup(
+          async () => {
+            let name;
+            while ((name = queue.pop())) {
+              const originalPath = path.join(
+                REGRESSION_ORIGINAL_SCREENSHOTS_PATH,
+                `${name}.png`,
+              );
+              const optimizedPath = path.join(
+                REGRESSION_OPTIMIZED_SCREENSHOTS_PATH,
+                `${name}.png`,
+              );
+
+              await page.goto(
+                `file://${path.join(REGRESSION_FIXTURES_PATH, name)}`,
+              );
+              let element = await page.waitForSelector('svg');
+              await element.screenshot({
+                ...screenshotOptions,
+                path: originalPath,
+              });
+
+              await page.goto(
+                `file://${path.join(REGRESSION_OPTIMIZED_PATH, name)}`,
+              );
+              element = await page.waitForSelector('svg');
+              await element.screenshot({
+                ...screenshotOptions,
+                path: optimizedPath,
+              });
+            }
+          },
+          () => page.close(),
+        );
+      };
+
+      const outcomes = await Promise.allSettled(
+        Array.from({ length: workerCount }, worker),
+      );
+      const failed = outcomes.find((outcome) => outcome.status === 'rejected');
+      if (failed) {
+        throw failed.reason;
+      }
+    },
+    () => browser.close(),
+  );
+}
+
+/**
+ * @param {ReadonlyArray<string>} list
+ * @param {{ workerCount?: number, compare?: (name: string) => Promise<{ name: string, matched: number, width: number }>, Worker?: typeof Worker }=} options
+ * @returns {Promise<Array<{ name: string, isMatch: boolean }>>}
+ */
+export async function compareScreenshots(list, options = {}) {
+  const queue = [...list];
+  const results = [];
+  const workerCount = Math.min(
+    options.workerCount ?? DEFAULT_COMPARE_WORKERS,
+    queue.length,
+  );
+
+  const getOptions = (name) => ({
+    name,
+    originalPath: path.join(
+      REGRESSION_ORIGINAL_SCREENSHOTS_PATH,
+      `${name}.png`,
+    ),
+    optimizedPath: path.join(
+      REGRESSION_OPTIMIZED_SCREENSHOTS_PATH,
+      `${name}.png`,
+    ),
+    diffPath:
+      process.env.NO_DIFF == null
+        ? path.join(REGRESSION_DIFFS_PATH, `${name}.diff.png`)
+        : null,
+  });
+
+  if (options.compare) {
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        let name;
+        while ((name = queue.pop())) {
+          const result = await options.compare(name);
+          const threshold = result.width <= 16 ? 3 : 4;
+          results.push({
+            name: result.name,
+            isMatch: result.matched <= threshold,
+          });
+        }
+      }),
+    );
+    return results;
+  }
+
+  const WorkerClass = options.Worker ?? Worker;
+  const workers = [];
+  await withCleanup(
+    async () => {
+      for (let index = 0; index < workerCount; index++) {
+        workers.push(new WorkerClass(workerUrl));
+      }
+      await Promise.all(
+        workers.map(
+          (worker) =>
+            new Promise((resolve, reject) => {
+              let active = false;
+              let settled = false;
+              const fail = (error) => {
+                if (!settled) {
+                  settled = true;
+                  reject(error);
+                }
+              };
+              const next = () => {
+                const name = queue.pop();
+                if (name == null) {
+                  settled = true;
+                  resolve();
+                  return;
+                }
+                active = true;
+                worker.postMessage(getOptions(name));
+              };
+              worker.on('message', (result) => {
+                active = false;
+                const threshold = result.width <= 16 ? 3 : 4;
+                results.push({
+                  name: result.name,
+                  isMatch: result.matched <= threshold,
+                });
+                next();
+              });
+              worker.on('error', fail);
+              worker.on('exit', (code) => {
+                if (!settled && (active || code !== 0)) {
+                  fail(new Error(`Comparison worker exited with code ${code}`));
+                }
+              });
+              next();
+            }),
+        ),
+      );
+    },
+    async () => {
+      const outcomes = await Promise.allSettled(
+        workers.map((worker) => worker.terminate()),
+      );
+      const failed = outcomes.find((outcome) => outcome.status === 'rejected');
+      if (failed) {
+        throw failed.reason;
+      }
+    },
+  );
+  return results;
+}
+
+/**
+ * @param {ReadonlyArray<string>} list
+ * @param {{ screenshotPath?: string, readVersion?: () => Promise<string>, render?: (list: ReadonlyArray<string>) => Promise<unknown>, compare?: (list: ReadonlyArray<string>) => Promise<Array<{ name: string, isMatch: boolean }>>, cleanup?: typeof fs.rm }=} options
  * @returns {Promise<Omit<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>>}
  */
-const runTests = async (list) => {
-  const version = await readVersion();
-  const listCopy = [...list];
-
-  /** @type {Omit<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>} */
+export async function runTests(list, options = {}) {
+  const versionReader = options.readVersion ?? readVersion;
+  const render = options.render ?? renderScreenshots;
+  const compare = options.compare ?? compareScreenshots;
+  const cleanup = options.cleanup ?? fs.rm;
+  const screenshotPath = options.screenshotPath ?? REGRESSION_SCREENSHOTS_PATH;
+  const version = await versionReader();
   const report = {
     version,
     files: {
-      toMatch: listCopy.length - expectMismatch.length - ignore.length,
+      toMatch: list.length - expectMismatch.length - ignore.length,
       toMismatch: expectMismatch.length,
       toIgnore: ignore.length,
       toSkip: skip.length,
     },
-    results: {
-      match: 0,
-      expectMismatch: 0,
-      ignored: 0,
-    },
-    errors: {
-      shouldHaveMatched: [],
-      shouldHaveMismatched: [],
-    },
+    results: { match: 0, expectMismatch: 0, ignored: 0 },
+    errors: { shouldHaveMatched: [], shouldHaveMismatched: [] },
   };
 
-  const totalFiles = listCopy.length;
-  let tested = 0;
-
-  /**
-   * @param {import('playwright').Page} page
-   * @param {string} name
-   */
-  const processFile = async (page, name) => {
-    await page.goto(`file://${path.join(REGRESSION_FIXTURES_PATH, name)}`);
-    let element = await page.waitForSelector('svg');
-    const originalBuffer = await element.screenshot(screenshotOptions);
-
-    await page.goto(`file://${path.join(REGRESSION_OPTIMIZED_PATH, name)}`);
-    element = await page.waitForSelector('svg');
-    const optimizedBufferPromise = element.screenshot(screenshotOptions);
-
-    const originalPng = PNG.sync.read(originalBuffer);
-    const optimizedPng = PNG.sync.read(await optimizedBufferPromise);
-    const writeDiffs = process.env.NO_DIFF == null;
-    const diff = writeDiffs
-      ? new PNG({ width: originalPng.width, height: originalPng.height })
-      : null;
-
-    const matched = pixelmatch(
-      originalPng.data,
-      optimizedPng.data,
-      diff?.data,
-      originalPng.width,
-      originalPng.height,
-    );
-
-    // ignore small aliasing issues
-    const threshold = originalPng.width <= 16 ? 3 : 4;
-    const isMatch = matched <= threshold;
-    const namePosix = pathToPosix(name);
-    const expectedToMismatch = expectMismatch.includes(namePosix);
-
-    if (isMatch) {
-      if (expectedToMismatch) {
-        report.errors.shouldHaveMismatched.push(namePosix);
-      } else if (ignore.includes(namePosix)) {
-        report.results.ignored++;
-      } else {
-        report.results.match++;
-      }
-    } else {
-      if (expectedToMismatch) {
+  let primaryError;
+  try {
+    await render(list);
+    const results = await compare(list);
+    for (const { name, isMatch } of results) {
+      const namePosix = pathToPosix(name);
+      const expectedToMismatch = expectMismatch.includes(namePosix);
+      if (isMatch) {
+        if (expectedToMismatch) {
+          report.errors.shouldHaveMismatched.push(namePosix);
+        } else if (ignore.includes(namePosix)) {
+          report.results.ignored++;
+        } else {
+          report.results.match++;
+        }
+      } else if (expectedToMismatch) {
         report.results.expectMismatch++;
       } else if (!ignore.includes(namePosix)) {
         report.errors.shouldHaveMatched.push(namePosix);
       }
-
-      if (diff) {
-        const file = path.join(REGRESSION_DIFFS_PATH, `${name}.diff.png`);
-        await fs.mkdir(path.dirname(file), { recursive: true });
-        await fs.writeFile(file, PNG.sync.write(diff));
-      }
     }
-
-    if (process.stdout.isTTY) {
-      process.stdout.clearLine(0);
-      process.stdout.write(
-        `\rCompared ${(++tested).toLocaleString()} of ${totalFiles.toLocaleString()}…`,
-      );
-    }
-  };
-
-  const worker = async () => {
-    let item;
-    const page = await context.newPage();
-    while ((item = listCopy.pop())) {
-      await processFile(page, item);
-    }
-    await page.close();
-  };
-
-  const browser = await chromium.launch();
-  const context = await browser.newContext({
-    javaScriptEnabled: false,
-    viewport: { width: WIDTH, height: HEIGHT },
-  });
-  context.setDefaultTimeout(NAVIGATION_TIMEOUT_MS);
-
-  await Promise.all(
-    Array.from(new Array(os.cpus().length * 2), () => worker()),
-  );
-  await browser.close();
-
-  if (process.stdout.isTTY) {
-    console.log();
+  } catch (error) {
+    primaryError = error;
   }
-
-  return report;
-};
-
-(async () => {
+  let cleanupError;
   try {
-    const filesPromise = fs.readdir(REGRESSION_FIXTURES_PATH, {
-      recursive: true,
-    });
-    const list = (await filesPromise).filter((name) => name.endsWith('.svg'));
+    await cleanup(screenshotPath, { recursive: true, force: true });
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (primaryError) {
+    throw primaryError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
+  return report;
+}
 
+async function main() {
+  try {
+    const list = (
+      await fs.readdir(REGRESSION_FIXTURES_PATH, { recursive: true })
+    ).filter((name) => name.endsWith('.svg'));
     const report = await runTests(list);
-    const metrics = await readReport();
-    const combinedReport = {
-      ...report,
-      ...metrics,
-    };
-
-    printReport(
-      /** @type {import('./regression-io.js').TestReport}*/ (combinedReport),
-    );
+    const combinedReport = { ...report, ...(await readReport()) };
+    printReport(combinedReport);
     await writeReport(combinedReport);
-
-    const failed =
+    if (
       report.results.match !== report.files.toMatch ||
-      report.results.expectMismatch !== report.files.toMismatch;
-
-    if (failed) {
-      process.exit(1);
+      report.results.expectMismatch !== report.files.toMismatch
+    ) {
+      process.exitCode = 1;
     }
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    process.exitCode = 1;
   }
-})();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  await main();
+}

--- a/test/regression/compare.js
+++ b/test/regression/compare.js
@@ -22,7 +22,7 @@ const NAVIGATION_TIMEOUT_MS = 0;
 const WIDTH = 960;
 const HEIGHT = 720;
 const availableParallelism = os.availableParallelism?.() ?? os.cpus().length;
-const DEFAULT_RENDER_WORKERS = Math.min(availableParallelism, 2);
+export const DEFAULT_RENDER_WORKERS = os.cpus().length * 2;
 const DEFAULT_COMPARE_WORKERS = Math.min(availableParallelism, 2);
 const workerUrl = new URL('./compare-worker.js', import.meta.url);
 

--- a/test/regression/compare.js
+++ b/test/regression/compare.js
@@ -26,6 +26,12 @@ const DEFAULT_RENDER_WORKERS = Math.min(availableParallelism, 2);
 const DEFAULT_COMPARE_WORKERS = Math.min(availableParallelism, 2);
 const workerUrl = new URL('./compare-worker.js', import.meta.url);
 
+/**
+ * @typedef {import('./compare-worker.js').CompareResult} CompareResult
+ * @typedef {{ name: string, isMatch: boolean }} MatchResult
+ * @typedef {{ new (filename: URL): { postMessage: (value: unknown) => void, on: (event: string, listener: (...args: any[]) => void) => unknown, terminate: () => Promise<number> | number } }} WorkerConstructor
+ */
+
 /** @type {import('playwright').PageScreenshotOptions} */
 const screenshotOptions = {
   omitBackground: true,
@@ -136,17 +142,19 @@ export async function renderScreenshots(list, options = {}) {
 
 /**
  * @param {ReadonlyArray<string>} list
- * @param {{ workerCount?: number, compare?: (name: string) => Promise<{ name: string, matched: number, width: number }>, Worker?: typeof Worker }=} options
- * @returns {Promise<Array<{ name: string, isMatch: boolean }>>}
+ * @param {{ workerCount?: number, compare?: (name: string) => Promise<CompareResult>, Worker?: WorkerConstructor }=} options
+ * @returns {Promise<MatchResult[]>}
  */
 export async function compareScreenshots(list, options = {}) {
   const queue = [...list];
+  /** @type {MatchResult[]} */
   const results = [];
   const workerCount = Math.min(
     options.workerCount ?? DEFAULT_COMPARE_WORKERS,
     queue.length,
   );
 
+  /** @param {string} name */
   const getOptions = (name) => ({
     name,
     originalPath: path.join(
@@ -164,11 +172,12 @@ export async function compareScreenshots(list, options = {}) {
   });
 
   if (options.compare) {
+    const compare = options.compare;
     await Promise.all(
       Array.from({ length: workerCount }, async () => {
         let name;
         while ((name = queue.pop())) {
-          const result = await options.compare(name);
+          const result = await compare(name);
           const threshold = result.width <= 16 ? 3 : 4;
           results.push({
             name: result.name,
@@ -180,7 +189,9 @@ export async function compareScreenshots(list, options = {}) {
     return results;
   }
 
-  const WorkerClass = options.Worker ?? Worker;
+  const WorkerClass =
+    options.Worker ?? /** @type {WorkerConstructor} */ (Worker);
+  /** @type {InstanceType<WorkerConstructor>[]} */
   const workers = [];
   await withCleanup(
     async () => {
@@ -193,6 +204,7 @@ export async function compareScreenshots(list, options = {}) {
             new Promise((resolve, reject) => {
               let active = false;
               let settled = false;
+              /** @param {unknown} error */
               const fail = (error) => {
                 if (!settled) {
                   settled = true;
@@ -203,13 +215,13 @@ export async function compareScreenshots(list, options = {}) {
                 const name = queue.pop();
                 if (name == null) {
                   settled = true;
-                  resolve();
+                  resolve(undefined);
                   return;
                 }
                 active = true;
                 worker.postMessage(getOptions(name));
               };
-              worker.on('message', (result) => {
+              worker.on('message', (/** @type {CompareResult} */ result) => {
                 active = false;
                 const threshold = result.width <= 16 ? 3 : 4;
                 results.push({
@@ -219,7 +231,7 @@ export async function compareScreenshots(list, options = {}) {
                 next();
               });
               worker.on('error', fail);
-              worker.on('exit', (code) => {
+              worker.on('exit', (/** @type {number} */ code) => {
                 if (!settled && (active || code !== 0)) {
                   fail(new Error(`Comparison worker exited with code ${code}`));
                 }
@@ -244,7 +256,7 @@ export async function compareScreenshots(list, options = {}) {
 
 /**
  * @param {ReadonlyArray<string>} list
- * @param {{ screenshotPath?: string, readVersion?: () => Promise<string>, render?: (list: ReadonlyArray<string>) => Promise<unknown>, compare?: (list: ReadonlyArray<string>) => Promise<Array<{ name: string, isMatch: boolean }>>, cleanup?: typeof fs.rm }=} options
+ * @param {{ screenshotPath?: string, readVersion?: () => Promise<string>, render?: (list: ReadonlyArray<string>) => Promise<unknown>, compare?: (list: ReadonlyArray<string>) => Promise<Array<{ name: string, isMatch: boolean }>>, cleanup?: typeof fs.rm, now?: () => number, log?: (message: string) => unknown }=} options
  * @returns {Promise<Omit<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>>}
  */
 export async function runTests(list, options = {}) {
@@ -252,8 +264,11 @@ export async function runTests(list, options = {}) {
   const render = options.render ?? renderScreenshots;
   const compare = options.compare ?? compareScreenshots;
   const cleanup = options.cleanup ?? fs.rm;
+  const now = options.now ?? performance.now.bind(performance);
+  const log = options.log ?? console.info;
   const screenshotPath = options.screenshotPath ?? REGRESSION_SCREENSHOTS_PATH;
   const version = await versionReader();
+  /** @type {Omit<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>} */
   const report = {
     version,
     files: {
@@ -268,8 +283,16 @@ export async function runTests(list, options = {}) {
 
   let primaryError;
   try {
+    const renderStarted = now();
     await render(list);
+    const compareStarted = now();
+    log(
+      `Rendered screenshots in ${((compareStarted - renderStarted) / 1000).toFixed(2)}s`,
+    );
     const results = await compare(list);
+    log(
+      `Compared screenshots in ${((now() - compareStarted) / 1000).toFixed(2)}s`,
+    );
     for (const { name, isMatch } of results) {
       const namePosix = pathToPosix(name);
       const expectedToMismatch = expectMismatch.includes(namePosix);
@@ -312,7 +335,9 @@ async function main() {
     ).filter((name) => name.endsWith('.svg'));
     const report = await runTests(list);
     const combinedReport = { ...report, ...(await readReport()) };
-    printReport(combinedReport);
+    printReport(
+      /** @type {import('./regression-io.js').TestReport} */ (combinedReport),
+    );
     await writeReport(combinedReport);
     if (
       report.results.match !== report.files.toMatch ||

--- a/test/regression/compare.test.js
+++ b/test/regression/compare.test.js
@@ -6,8 +6,12 @@ import { jest } from '@jest/globals';
 
 jest.unstable_mockModule('playwright', () => ({ chromium: {} }));
 
-const { compareScreenshots, runTests, withCleanup } =
+const { compareScreenshots, DEFAULT_RENDER_WORKERS, runTests, withCleanup } =
   await import('./compare.js');
+
+test('uses the original render concurrency for comparison', () => {
+  expect(DEFAULT_RENDER_WORKERS).toBe(os.cpus().length * 2);
+});
 
 describe('withCleanup', () => {
   test('preserves the primary error when cleanup also fails', async () => {

--- a/test/regression/compare.test.js
+++ b/test/regression/compare.test.js
@@ -34,7 +34,10 @@ describe('compareScreenshots', () => {
     await expect(
       compareScreenshots(['small.svg', 'large.svg'], {
         workerCount: 1,
-        compare: async () => results.shift(),
+        compare: async () =>
+          /** @type {NonNullable<ReturnType<typeof results.shift>>} */ (
+            results.shift()
+          ),
       }),
     ).resolves.toEqual([
       { name: 'small.svg', isMatch: true },
@@ -51,7 +54,10 @@ describe('compareScreenshots', () => {
     await expect(
       compareScreenshots(['small.svg', 'large.svg'], {
         workerCount: 1,
-        compare: async () => results.shift(),
+        compare: async () =>
+          /** @type {NonNullable<ReturnType<typeof results.shift>>} */ (
+            results.shift()
+          ),
       }),
     ).resolves.toEqual([
       { name: 'small.svg', isMatch: false },
@@ -61,11 +67,19 @@ describe('compareScreenshots', () => {
 
   test('rejects when a worker exits before returning its fixture', async () => {
     class ExitingWorker extends EventEmitter {
+      /** @param {URL} _filename */
+      constructor(_filename) {
+        super();
+        void _filename;
+      }
+
       postMessage() {
         queueMicrotask(() => this.emit('exit', 1));
       }
 
-      async terminate() {}
+      async terminate() {
+        return 0;
+      }
     }
 
     await expect(
@@ -80,15 +94,20 @@ describe('compareScreenshots', () => {
     const terminate = jest.fn();
     let constructions = 0;
     class FailingWorker extends EventEmitter {
-      constructor() {
+      /** @param {URL} _filename */
+      constructor(_filename) {
         super();
+        void _filename;
         if (++constructions === 2) {
           throw new Error('worker unavailable');
         }
       }
 
+      postMessage() {}
+
       terminate() {
         terminate();
+        return 0;
       }
     }
 
@@ -103,6 +122,7 @@ describe('compareScreenshots', () => {
 });
 
 describe('runTests', () => {
+  /** @type {string} */
   let screenshotPath;
 
   beforeEach(async () => {
@@ -114,6 +134,7 @@ describe('runTests', () => {
   });
 
   test('finishes rendering before comparison and removes screenshots', async () => {
+    /** @type {string[]} */
     const events = [];
     await fs.writeFile(path.join(screenshotPath, 'partial.png'), 'png');
 
@@ -132,6 +153,31 @@ describe('runTests', () => {
     await expect(fs.stat(screenshotPath)).rejects.toMatchObject({
       code: 'ENOENT',
     });
+  });
+
+  test('reports rendering and comparison durations', async () => {
+    /** @type {string[]} */
+    const messages = [];
+    let now = 0;
+
+    await runTests(['fixture.svg'], {
+      screenshotPath,
+      readVersion: async () => 'version',
+      render: async () => {
+        now = 1500;
+      },
+      compare: async () => {
+        now = 4000;
+        return [{ name: 'fixture.svg', isMatch: true }];
+      },
+      now: () => now,
+      log: (message) => messages.push(message),
+    });
+
+    expect(messages).toEqual([
+      'Rendered screenshots in 1.50s',
+      'Compared screenshots in 2.50s',
+    ]);
   });
 
   test('removes partial screenshots after rendering fails', async () => {

--- a/test/regression/compare.test.js
+++ b/test/regression/compare.test.js
@@ -1,0 +1,172 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('playwright', () => ({ chromium: {} }));
+
+const { compareScreenshots, runTests, withCleanup } =
+  await import('./compare.js');
+
+describe('withCleanup', () => {
+  test('preserves the primary error when cleanup also fails', async () => {
+    await expect(
+      withCleanup(
+        async () => {
+          throw new Error('primary failed');
+        },
+        async () => {
+          throw new Error('cleanup failed');
+        },
+      ),
+    ).rejects.toThrow('primary failed');
+  });
+});
+
+describe('compareScreenshots', () => {
+  test('applies the existing width-dependent mismatch allowance', async () => {
+    const results = [
+      { name: 'small.svg', matched: 3, width: 16 },
+      { name: 'large.svg', matched: 4, width: 17 },
+    ];
+
+    await expect(
+      compareScreenshots(['small.svg', 'large.svg'], {
+        workerCount: 1,
+        compare: async () => results.shift(),
+      }),
+    ).resolves.toEqual([
+      { name: 'small.svg', isMatch: true },
+      { name: 'large.svg', isMatch: true },
+    ]);
+  });
+
+  test('rejects differences immediately above both match allowances', async () => {
+    const results = [
+      { name: 'small.svg', matched: 4, width: 16 },
+      { name: 'large.svg', matched: 5, width: 17 },
+    ];
+
+    await expect(
+      compareScreenshots(['small.svg', 'large.svg'], {
+        workerCount: 1,
+        compare: async () => results.shift(),
+      }),
+    ).resolves.toEqual([
+      { name: 'small.svg', isMatch: false },
+      { name: 'large.svg', isMatch: false },
+    ]);
+  });
+
+  test('rejects when a worker exits before returning its fixture', async () => {
+    class ExitingWorker extends EventEmitter {
+      postMessage() {
+        queueMicrotask(() => this.emit('exit', 1));
+      }
+
+      async terminate() {}
+    }
+
+    await expect(
+      compareScreenshots(['fixture.svg'], {
+        workerCount: 1,
+        Worker: ExitingWorker,
+      }),
+    ).rejects.toThrow('Comparison worker exited with code 1');
+  });
+
+  test('terminates workers created before pool construction fails', async () => {
+    const terminate = jest.fn();
+    let constructions = 0;
+    class FailingWorker extends EventEmitter {
+      constructor() {
+        super();
+        if (++constructions === 2) {
+          throw new Error('worker unavailable');
+        }
+      }
+
+      terminate() {
+        terminate();
+      }
+    }
+
+    await expect(
+      compareScreenshots(['one.svg', 'two.svg'], {
+        workerCount: 2,
+        Worker: FailingWorker,
+      }),
+    ).rejects.toThrow('worker unavailable');
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runTests', () => {
+  let screenshotPath;
+
+  beforeEach(async () => {
+    screenshotPath = await fs.mkdtemp(path.join(os.tmpdir(), 'svgo-run-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(screenshotPath, { recursive: true, force: true });
+  });
+
+  test('finishes rendering before comparison and removes screenshots', async () => {
+    const events = [];
+    await fs.writeFile(path.join(screenshotPath, 'partial.png'), 'png');
+
+    const report = await runTests(['fixture.svg'], {
+      screenshotPath,
+      readVersion: async () => 'version',
+      render: async () => events.push('render'),
+      compare: async () => {
+        events.push('compare');
+        return [{ name: 'fixture.svg', isMatch: true }];
+      },
+    });
+
+    expect(events).toEqual(['render', 'compare']);
+    expect(report.results.match).toBe(1);
+    await expect(fs.stat(screenshotPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  test('removes partial screenshots after rendering fails', async () => {
+    await fs.writeFile(path.join(screenshotPath, 'partial.png'), 'png');
+
+    await expect(
+      runTests(['fixture.svg'], {
+        screenshotPath,
+        readVersion: async () => 'version',
+        render: async () => {
+          throw new Error('render failed');
+        },
+        compare: async () => [],
+      }),
+    ).rejects.toThrow('render failed');
+    await expect(fs.stat(screenshotPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  test('preserves a comparison error when root cleanup also fails', async () => {
+    const cleanup = jest.fn(async () => {
+      throw new Error('cleanup failed');
+    });
+    await expect(
+      runTests(['fixture.svg'], {
+        screenshotPath,
+        readVersion: async () => 'version',
+        render: async () => {},
+        compare: async () => {
+          throw new Error('comparison failed');
+        },
+        cleanup,
+      }),
+    ).rejects.toThrow('comparison failed');
+    expect(cleanup).toHaveBeenCalled();
+  });
+});

--- a/test/regression/regression-io.js
+++ b/test/regression/regression-io.js
@@ -56,6 +56,18 @@ export const REGRESSION_DIFFS_PATH = path.join(
   TEMP_DIR_PATH,
   'regression-diff',
 );
+export const REGRESSION_SCREENSHOTS_PATH = path.join(
+  TEMP_DIR_PATH,
+  'regression-screenshots',
+);
+export const REGRESSION_ORIGINAL_SCREENSHOTS_PATH = path.join(
+  REGRESSION_SCREENSHOTS_PATH,
+  'original',
+);
+export const REGRESSION_OPTIMIZED_SCREENSHOTS_PATH = path.join(
+  REGRESSION_SCREENSHOTS_PATH,
+  'optimized',
+);
 export const REGRESSION_VERSION_PATH = path.join(
   REGRESSION_FIXTURES_PATH,
   'VERSION',


### PR DESCRIPTION
## Summary

- render original and optimized SVG screenshots to temporary files with at most two reusable Chromium pages
- close Chromium before decoding PNGs and comparing them in a bounded worker-thread pool
- preserve Pixelmatch thresholds, diff behavior, report classifications, and cleanup temporary screenshots on success or failure

## Motivation

The regression comparison currently overlaps Chromium renderer memory with PNGJS decode buffers and runs synchronous Pixelmatch work on the main thread. This separates those phases and introduces a path-based comparison boundary that can support a future odiff experiment.

## Verification

- focused regression tests: 15 passed
- ESLint passed for changed regression files
- Prettier passed for changed regression files
- `git diff --check` passed
- representative Playwright -> filesystem -> worker-thread smoke test passed

## CI experiment

The full corpus could not complete on the 8 GiB VPS because the existing optimization stage was OOM-killed before comparison while processing its five largest fixtures. CI should validate:

- 4,905 expected matches and 139 expected mismatches remain unchanged
- comparison wall time versus current main
- total process-tree peak memory
- temporary screenshot disk usage

The repository-wide unit suite is currently red on main in this checkout due to existing `css-select` plugin failures unrelated to these regression files.