### PR TITLE
ci: reduce Playwright browser setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,16 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm playwright install --with-deps chromium
       - run: pnpm test
+  test-browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with: *setup-node-config
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm playwright install --with-deps --only-shell chromium
       - run: pnpm test:bundles
   test-runtime:
     name: test runtime - ${{ matrix.os }} - Node.js v${{ matrix.node-version }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm playwright install --with-deps chromium
+      - run: pnpm playwright install --with-deps --only-shell chromium
       - run: pnpm test:regression
       # We use upload/artifacts instead of outputs because our regression test
       # report can exceed 1 MB which is a limit GitHub imposes.

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm playwright install --with-deps chromium
+      - run: pnpm playwright install --with-deps --only-shell chromium
       - run: pnpm test:regression
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- run browser bundle testing once in a dedicated Ubuntu/Node.js 24 job instead of every test matrix entry
- install only Chromium's headless shell in browser workflows
- keep the regular test suite across all existing OS and Node.js combinations

## Verification
- `pnpm lint`
- `pnpm test:bundles`
- `pnpm playwright install --with-deps --only-shell --dry-run chromium`
- `git diff --check`