### PR TITLE
ci: set up pnpm without Corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with: &setup-node-config
           node-version: 24
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
@@ -53,8 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - run: npm install -g corepack@0.34.5 --force
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
@@ -65,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
@@ -85,8 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - run: npm install -g corepack@0.34.5 --force
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -46,7 +46,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ Clone the repository with Git.
 git clone https://github.com/svg/svgo.git
 ```
 
-As this is a Node.js project and uses pnpm for package management, enable Corepack and install the dependencies.
+As this is a Node.js project and uses pnpm for package management, install pnpm and the dependencies.
 
 ```sh
-corepack enable
+npm install --global pnpm@10.34.5
 pnpm install
 ```
 


### PR DESCRIPTION
## Summary
- replace Corepack setup with `pnpm/action-setup@v4` in every GitHub Actions job
- infer pnpm 10.34.5 from the `packageManager` field
- update contributor setup instructions to install the same pnpm version directly

## Verification
- `pnpm lint`
- confirmed 10 `pnpm/action-setup@v4` steps
- confirmed zero Corepack references in the repository
- `git diff --check`