### PR TITLE
feat: upgrade sax to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "css-what": "^7.0.0",
     "csso": "^5.0.5",
     "picocolors": "^1.1.1",
-    "sax": "1.5.0"
+    "sax": "1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/patches/sax@1.6.1.patch
+++ b/patches/sax@1.6.1.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/sax.js b/lib/sax.js
-index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd133213dcc7e0 100644
+index 3ae6728570523de9a800e0ec5cf20aac5a65cc42..d22155e37440de1b91fbc9f699f0ad986cb67032 100644
 --- a/lib/sax.js
 +++ b/lib/sax.js
 @@ -4,8 +4,6 @@
@@ -11,7 +11,7 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
  
    // When we pass the MAX_BUFFER_LENGTH position, start checking for buffer overruns.
    // When we check, schedule the next check for MAX_BUFFER_LENGTH - (max(buffer lengths)),
-@@ -191,123 +189,6 @@
+@@ -192,193 +190,6 @@
      },
    }
  
@@ -29,6 +29,39 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
 -
 -  function createStream(strict, opt) {
 -    return new SAXStream(strict, opt)
+-  }
+-
+-  function determineBufferEncoding(data, isEnd) {
+-    // BOM-based detection is the most reliable signal when present.
+-    if (data.length >= 2) {
+-      if (data[0] === 0xff && data[1] === 0xfe) {
+-        return 'utf-16le'
+-      }
+-
+-      if (data[0] === 0xfe && data[1] === 0xff) {
+-        return 'utf-16be'
+-      }
+-    }
+-
+-    if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
+-      return 'utf8'
+-    }
+-
+-    if (data.length >= 4) {
+-      // XML documents without a BOM still start with "<?xml", which is enough
+-      // to distinguish UTF-16LE/BE from UTF-8 by looking at the zero bytes.
+-      if (data[0] === 0x3c && data[1] === 0x00 && data[2] === 0x3f && data[3] === 0x00) {
+-        return 'utf-16le'
+-      }
+-
+-      if (data[0] === 0x00 && data[1] === 0x3c && data[2] === 0x00 && data[3] === 0x3f) {
+-        return 'utf-16be'
+-      }
+-
+-      return 'utf8'
+-    }
+-
+-    return isEnd ? 'utf8' : null
 -  }
 -
 -  function SAXStream(strict, opt) {
@@ -57,7 +90,7 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
 -    }
 -
 -    this._decoder = null
--
+-    this._decoderBuffer = null
 -    streamWraps.forEach(function (ev) {
 -      Object.defineProperty(me, 'on' + ev, {
 -        get: function () {
@@ -83,16 +116,47 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
 -    },
 -  })
 -
+-  SAXStream.prototype._decodeBuffer = function (data, isEnd) {
+-    if (this._decoderBuffer) {
+-      // Keep incomplete leading bytes until we have enough data to infer the
+-      // stream encoding, then decode the buffered prefix together with the next chunk.
+-      data = Buffer.concat([this._decoderBuffer, data])
+-      this._decoderBuffer = null
+-    }
+-
+-    if (!this._decoder) {
+-      var encoding = determineBufferEncoding(data, isEnd)
+-      if (!encoding) {
+-        // A very short first chunk may not contain enough bytes to detect the
+-        // encoding yet, so defer decoding until the next write/end call.
+-        this._decoderBuffer = data
+-        return ''
+-      }
+-
+-      // Store the detected transport encoding so strict mode can compare it
+-      // with the optional encoding declared in the XML prolog later on.
+-      this._parser.encoding = encoding
+-      this._decoder = new TextDecoder(encoding)
+-    }
+-
+-    return this._decoder.decode(data, { stream: !isEnd })
+-  }
+-
 -  SAXStream.prototype.write = function (data) {
 -    if (
 -      typeof Buffer === 'function' &&
 -      typeof Buffer.isBuffer === 'function' &&
 -      Buffer.isBuffer(data)
 -    ) {
--      if (!this._decoder) {
--        this._decoder = new TextDecoder('utf8')
+-      data = this._decodeBuffer(data, false)
+-    } else if (this._decoderBuffer) {
+-      // Flush any buffered binary prefix before handling a string chunk.
+-      // This only matters if the caller mixes Buffer and string writes (used in test).
+-      var remaining = this._decodeBuffer(Buffer.alloc(0), true)
+-      if (remaining) {
+-        this._parser.write(remaining)
+-        this.emit('data', remaining)
 -      }
--      data = this._decoder.decode(data, { stream: true })
 -    }
 -
 -    this._parser.write(data.toString())
@@ -105,7 +169,13 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
 -      this.write(chunk)
 -    }
 -    // Flush any remaining decoded data from the TextDecoder
--    if (this._decoder) {
+-    if (this._decoderBuffer) {
+-      var finalChunk = this._decodeBuffer(Buffer.alloc(0), true)
+-      if (finalChunk) {
+-        this._parser.write(finalChunk)
+-        this.emit('data', finalChunk)
+-      }
+-    } else if (this._decoder) {
 -      var remaining = this._decoder.decode()
 -      if (remaining) {
 -        this._parser.write(remaining)
@@ -134,4 +204,4 @@ index d35adf1a319b7f064d7a7e43c46630ed5ef587ff..4c5a08844f3be4ddceb12285d3fd1332
 -
    // this really needs to be replaced with character classes.
    // XML allows all manner of ridiculous numbers and digits.
-   var CDATA = '[CDATA['
+   var CDATAre = /^\[CDATA\[$/i

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  sax@1.5.0:
-    hash: 25c0130c4f78e166bc348f7a21469d906b42329c8e4b3e27ba67bf981409fb6f
-    path: patches/sax@1.5.0.patch
+  sax@1.6.1:
+    hash: 202ba53c76ed752bbd220e2bedc5e27439865e12890d94649651dafb07ba5c2d
+    path: patches/sax@1.6.1.patch
 
 importers:
 
@@ -32,8 +32,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       sax:
-        specifier: 1.5.0
-        version: 1.5.0(patch_hash=25c0130c4f78e166bc348f7a21469d906b42329c8e4b3e27ba67bf981409fb6f)
+        specifier: 1.6.1
+        version: 1.6.1(patch_hash=202ba53c76ed752bbd220e2bedc5e27439865e12890d94649651dafb07ba5c2d)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1836,8 +1836,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  sax@1.5.0:
-    resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
 
   semver@5.7.2:
@@ -3669,7 +3669,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  sax@1.5.0(patch_hash=25c0130c4f78e166bc348f7a21469d906b42329c8e4b3e27ba67bf981409fb6f): {}
+  sax@1.6.1(patch_hash=202ba53c76ed752bbd220e2bedc5e27439865e12890d94649651dafb07ba5c2d): {}
 
   semver@5.7.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ minimumReleaseAgeExclude:
   - eslint@10.8.1
 
 patchedDependencies:
-  sax@1.5.0: patches/sax@1.5.0.patch
+  sax@1.6.1: patches/sax@1.6.1.patch

--- a/test/svg2js/_index.test.js
+++ b/test/svg2js/_index.test.js
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { parseSvg } from '../../lib/parser.js';
+import { parseSvg, SvgoParserError } from '../../lib/parser.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -101,19 +101,30 @@ describe('svg2js', () => {
   });
 
   describe('character references', () => {
-    it.each(['&#x1;', '&#xB;', '&#x1F;', '&#xD800;', '&#xFFFF;'])(
+    /** @param {string} source */
+    const getParserError = (source) => {
+      try {
+        parseSvg(source);
+      } catch (error) {
+        return error;
+      }
+    };
+
+    it.each(['&#1;', '&#x1;', '&#xB;', '&#x1F;', '&#xD800;', '&#xFFFF;'])(
       'should reject invalid character reference %s in text',
       (reference) => {
-        expect(() => parseSvg(`<svg>${reference}</svg>`)).toThrow(
-          'Invalid character entity',
-        );
+        const error = getParserError(`<svg>${reference}</svg>`);
+
+        expect(error).toBeInstanceOf(SvgoParserError);
+        expect(error).toHaveProperty('reason', 'Invalid character entity');
       },
     );
 
     it('should reject invalid character references in attributes', () => {
-      expect(() => parseSvg('<svg data-value="&#xD800;"/>')).toThrow(
-        'Invalid character entity',
-      );
+      const error = getParserError('<svg data-value="&#xD800;"/>');
+
+      expect(error).toBeInstanceOf(SvgoParserError);
+      expect(error).toHaveProperty('reason', 'Invalid character entity');
     });
 
     it('should parse valid boundary character references', () => {

--- a/test/svg2js/_index.test.js
+++ b/test/svg2js/_index.test.js
@@ -99,4 +99,35 @@ describe('svg2js', () => {
       });
     });
   });
+
+  describe('character references', () => {
+    it.each(['&#x1;', '&#xB;', '&#x1F;', '&#xD800;', '&#xFFFF;'])(
+      'should reject invalid character reference %s in text',
+      (reference) => {
+        expect(() => parseSvg(`<svg>${reference}</svg>`)).toThrow(
+          'Invalid character entity',
+        );
+      },
+    );
+
+    it('should reject invalid character references in attributes', () => {
+      expect(() => parseSvg('<svg data-value="&#xD800;"/>')).toThrow(
+        'Invalid character entity',
+      );
+    });
+
+    it('should parse valid boundary character references', () => {
+      const root = parseSvg(
+        '<svg data-value="&#x20;&#xD7FF;&#xE000;&#xFFFD;&#x10000;&#x10FFFF;"/>',
+      );
+      const svg = root.children[0];
+
+      expect(svg).toMatchObject({
+        type: 'element',
+        attributes: {
+          'data-value': ' \uD7FF\uE000\uFFFD\u{10000}\u{10FFFF}',
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
This is technically a feature since parser does more strict validation

## Summary

- upgrade the SAX parser from 1.5.0 to 1.6.1
- rebase the browser-oriented stream-removal patch
- cover strict XML character-reference validation and parser error wrapping

## Bundle impact

Built from latest `main` (`7afa566`) and this branch with the same pnpm/Rollup toolchain:

| Bundle | Main | This PR | Difference |
| --- | ---: | ---: | ---: |
| `svgo-node.cjs` raw | 190,380 B | 190,380 B | 0 B |
| `svgo-node.cjs` gzip | 46,060 B | 46,060 B | 0 B |
| `svgo-node.cjs` Brotli | 39,436 B | 39,436 B | 0 B |
| `svgo.browser.js` raw | 802,307 B | 803,581 B | +1,274 B (+0.16%) |
| `svgo.browser.js` gzip | 194,608 B | 195,032 B | +424 B (+0.22%) |
| `svgo.browser.js` Brotli | 129,877 B | 130,321 B | +444 B (+0.34%) |

The Node bundle is byte-identical. Neither resulting bundle contains `SAXStream` or a Node `stream` import.

## Testing

- `pnpm lint`
- `pnpm test:types`
- `pnpm test` (520 passed, 3 skipped)
- `pnpm test:bundles`