### PR TITLE
docs(plugins): drop defaultPlugin key and add since JSDoc tags

### DIFF
--- a/docs/04-plugins/cleanupAttrs.mdx
+++ b/docs/04-plugins/cleanupAttrs.mdx
@@ -2,7 +2,6 @@
 title: cleanupAttrs
 svgo:
   pluginId: cleanupAttrs
-  defaultPlugin: true
   parameters:
     newlines:
       description: Replace instances of a newline with a single whitespace.

--- a/docs/04-plugins/cleanupEnableBackground.mdx
+++ b/docs/04-plugins/cleanupEnableBackground.mdx
@@ -2,7 +2,6 @@
 title: cleanupEnableBackground
 svgo:
   pluginId: cleanupEnableBackground
-  defaultPlugin: true
 ---
 
 Cleans up [`enable-background`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/enable-background), unless the document uses [`<filter>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/filter) elements.

--- a/docs/04-plugins/cleanupIds.mdx
+++ b/docs/04-plugins/cleanupIds.mdx
@@ -18,7 +18,6 @@ svgo:
     force:
       description: This plugin normally does nothing if a `<script>` or `<style>` element is found. Setting this to true will bypass that behavior, which may result in destructive changes.
       default: false
-  defaultPlugin: true
 ---
 
 Removes unused IDs, and minifies IDs that are referenced by other elements.

--- a/docs/04-plugins/cleanupNumericValues.mdx
+++ b/docs/04-plugins/cleanupNumericValues.mdx
@@ -2,7 +2,6 @@
 title: cleanupNumericValues
 svgo:
   pluginId: cleanupNumericValues
-  defaultPlugin: true
   parameters:
     floatPrecision:
       description: Number of decimal places to round to, using conventional rounding rules.

--- a/docs/04-plugins/collapseGroups.mdx
+++ b/docs/04-plugins/collapseGroups.mdx
@@ -2,7 +2,6 @@
 title: collapseGroups
 svgo:
   pluginId: collapseGroups
-  defaultPlugin: true
 ---
 
 Finds groups that effectively do nothing and flattens them, preserving the contents of the groups.

--- a/docs/04-plugins/convertColors.mdx
+++ b/docs/04-plugins/convertColors.mdx
@@ -2,7 +2,6 @@
 title: convertColors
 svgo:
   pluginId: convertColors
-  defaultPlugin: true
   parameters:
     currentColor:
       description: If to convert all instances of a color to `currentColor`. This means to inherit the active foreground color, for example in HTML5 this would be the [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color) property in CSS.

--- a/docs/04-plugins/convertEllipseToCircle.mdx
+++ b/docs/04-plugins/convertEllipseToCircle.mdx
@@ -2,7 +2,6 @@
 title: convertEllipseToCircle
 svgo:
   pluginId: convertEllipseToCircle
-  defaultPlugin: true
 ---
 
 Convert non-eccentric [`<ellipse>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/ellipse) elements to [`<circle>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle) elements.

--- a/docs/04-plugins/convertPathData.mdx
+++ b/docs/04-plugins/convertPathData.mdx
@@ -2,7 +2,6 @@
 title: convertPathData
 svgo:
   pluginId: convertPathData
-  defaultPlugin: true
   parameters:
     applyTransforms:
       description: If to apply transforms.

--- a/docs/04-plugins/convertShapeToPath.mdx
+++ b/docs/04-plugins/convertShapeToPath.mdx
@@ -2,7 +2,6 @@
 title: convertShapeToPath
 svgo:
   pluginId: convertShapeToPath
-  defaultPlugin: true
   parameters:
     convertArcs:
       description: If to convert `<circle>` and `<ellipse>` elements to paths.

--- a/docs/04-plugins/convertTransform.mdx
+++ b/docs/04-plugins/convertTransform.mdx
@@ -2,7 +2,6 @@
 title: convertTransform
 svgo:
   pluginId: convertTransform
-  defaultPlugin: true
   parameters:
     convertToShorts:
       description: Convert transforms to their shorthand alternatives.

--- a/docs/04-plugins/inlineStyles.mdx
+++ b/docs/04-plugins/inlineStyles.mdx
@@ -2,7 +2,6 @@
 title: inlineStyles
 svgo:
   pluginId: inlineStyles
-  defaultPlugin: true
   parameters:
     onlyMatchedOnce:
       description: If to only inline styles if the selector matches one element.

--- a/docs/04-plugins/mergePaths.mdx
+++ b/docs/04-plugins/mergePaths.mdx
@@ -2,7 +2,6 @@
 title: mergePaths
 svgo:
   pluginId: mergePaths
-  defaultPlugin: true
   parameters:
     force:
       default: false

--- a/docs/04-plugins/mergeStyles.mdx
+++ b/docs/04-plugins/mergeStyles.mdx
@@ -2,7 +2,6 @@
 title: mergeStyles
 svgo:
   pluginId: mergeStyles
-  defaultPlugin: true
 ---
 
 Merge multiple `<style>` elements into one.

--- a/docs/04-plugins/minifyStyles.mdx
+++ b/docs/04-plugins/minifyStyles.mdx
@@ -2,7 +2,6 @@
 title: minifyStyles
 svgo:
   pluginId: minifyStyles
-  defaultPlugin: true
   parameters:
     usage:
       description: If to collect usage data such as tags, classes, and IDs to pass to CSSO. This is an object with four properties, which are each configured with a boolean, `tags`, `ids`, `classes`, and `force`. By default, if a script is found this does not pass usage data to CSSO, but this can be overridden with `force`, which may yield destructive changes.

--- a/docs/04-plugins/moveElemsAttrsToGroup.mdx
+++ b/docs/04-plugins/moveElemsAttrsToGroup.mdx
@@ -2,7 +2,6 @@
 title: moveElemsAttrsToGroup
 svgo:
   pluginId: moveElemsAttrsToGroup
-  defaultPlugin: true
 ---
 
 Move an elements attributes to their enclosing group.

--- a/docs/04-plugins/moveGroupAttrsToElems.mdx
+++ b/docs/04-plugins/moveGroupAttrsToElems.mdx
@@ -2,7 +2,6 @@
 title: moveGroupAttrsToElems
 svgo:
   pluginId: moveGroupAttrsToElems
-  defaultPlugin: true
 ---
 
 Move some group attributes to the contained elements.

--- a/docs/04-plugins/removeComments.mdx
+++ b/docs/04-plugins/removeComments.mdx
@@ -2,7 +2,6 @@
 title: removeComments
 svgo:
   pluginId: removeComments
-  defaultPlugin: true
   parameters:
     preservePatterns:
       description: An array of regular expressions ([RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) or string). If the comment matches any of these, including partial matches, the comment is preserved. Set to `false` to disable this behavior and remove comments indiscriminately.

--- a/docs/04-plugins/removeDeprecatedAttrs.mdx
+++ b/docs/04-plugins/removeDeprecatedAttrs.mdx
@@ -2,7 +2,6 @@
 title: removeDeprecatedAttrs
 svgo:
   pluginId: removeDeprecatedAttrs
-  defaultPlugin: true
   parameters:
     removeAny:
       description: By default, this plugin only removes safe deprecated attributes that do not change the rendered image. Enabling this will remove all deprecated attributes which may impact rendering.

--- a/docs/04-plugins/removeDesc.mdx
+++ b/docs/04-plugins/removeDesc.mdx
@@ -2,7 +2,6 @@
 title: removeDesc
 svgo:
   pluginId: removeDesc
-  defaultPlugin: true
   parameters:
     removeAny:
       description: By default, this plugin only removes descriptions that are either empty or contain editor attribution. Enabling this removes the `<desc>` element indiscriminately.

--- a/docs/04-plugins/removeDoctype.mdx
+++ b/docs/04-plugins/removeDoctype.mdx
@@ -2,7 +2,6 @@
 title: removeDoctype
 svgo:
   pluginId: removeDoctype
-  defaultPlugin: true
 ---
 
 Removes the [Document Type Definition](https://en.wikipedia.org/wiki/Document_type_definition), also known as the DOCTYPE, from the document.

--- a/docs/04-plugins/removeEditorsNSData.mdx
+++ b/docs/04-plugins/removeEditorsNSData.mdx
@@ -2,7 +2,6 @@
 title: removeEditorsNSData
 svgo:
   pluginId: removeEditorsNSData
-  defaultPlugin: true
   parameters:
     additionalNamespaces:
       description: If you want to remove additional XML namespaces, you can provide them in a list.

--- a/docs/04-plugins/removeEmptyAttrs.mdx
+++ b/docs/04-plugins/removeEmptyAttrs.mdx
@@ -2,7 +2,6 @@
 title: removeEmptyAttrs
 svgo:
   pluginId: removeEmptyAttrs
-  defaultPlugin: true
 ---
 
 Remove empty attributes from elements in the document.

--- a/docs/04-plugins/removeEmptyContainers.mdx
+++ b/docs/04-plugins/removeEmptyContainers.mdx
@@ -2,7 +2,6 @@
 title: removeEmptyContainers
 svgo:
   pluginId: removeEmptyContainers
-  defaultPlugin: true
 ---
 
 Remove container elements in the document that have no children or meaningful attributes, excluding the `<svg>` element which is ignored.

--- a/docs/04-plugins/removeEmptyText.mdx
+++ b/docs/04-plugins/removeEmptyText.mdx
@@ -2,7 +2,6 @@
 title: removeEmptyText
 svgo:
   pluginId: removeEmptyText
-  defaultPlugin: true
   parameters:
     text:
       description: If to remove empty [`<text>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text) elements.

--- a/docs/04-plugins/removeHiddenElems.mdx
+++ b/docs/04-plugins/removeHiddenElems.mdx
@@ -2,7 +2,6 @@
 title: removeHiddenElems
 svgo:
   pluginId: removeHiddenElems
-  defaultPlugin: true
   parameters:
     isHidden:
       description: Removes elements where [`visibility`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/visibility) is `hidden`, unless a child element has `visibility` set to `visible`.

--- a/docs/04-plugins/removeMetadata.mdx
+++ b/docs/04-plugins/removeMetadata.mdx
@@ -2,7 +2,6 @@
 title: removeMetadata
 svgo:
   pluginId: removeMetadata
-  defaultPlugin: true
 ---
 
 Removes the [`<metadata>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/metadata) element from the document.

--- a/docs/04-plugins/removeNonInheritableGroupAttrs.mdx
+++ b/docs/04-plugins/removeNonInheritableGroupAttrs.mdx
@@ -2,7 +2,6 @@
 title: removeNonInheritableGroupAttrs
 svgo:
   pluginId: removeNonInheritableGroupAttrs
-  defaultPlugin: true
 ---
 
 Removes non-inheritable [presentation attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Presentation) from groups.

--- a/docs/04-plugins/removeUnknownsAndDefaults.mdx
+++ b/docs/04-plugins/removeUnknownsAndDefaults.mdx
@@ -2,7 +2,6 @@
 title: removeUnknownsAndDefaults
 svgo:
   pluginId: removeUnknownsAndDefaults
-  defaultPlugin: true
   parameters:
     unknownContent:
       description: If to remove elements that are not known or can't be the child of its parent element.

--- a/docs/04-plugins/removeUnusedNS.mdx
+++ b/docs/04-plugins/removeUnusedNS.mdx
@@ -2,7 +2,6 @@
 title: removeUnusedNS
 svgo:
   pluginId: removeUnusedNS
-  defaultPlugin: true
 ---
 
 Removes unused namespace declarations from the document.

--- a/docs/04-plugins/removeUselessDefs.mdx
+++ b/docs/04-plugins/removeUselessDefs.mdx
@@ -2,7 +2,6 @@
 title: removeUselessDefs
 svgo:
   pluginId: removeUselessDefs
-  defaultPlugin: true
 ---
 
 Removes children of [`<defs>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs) element that do not have an ID to reference.

--- a/docs/04-plugins/removeUselessStrokeAndFill.mdx
+++ b/docs/04-plugins/removeUselessStrokeAndFill.mdx
@@ -2,7 +2,6 @@
 title: removeUselessStrokeAndFill
 svgo:
   pluginId: removeUselessStrokeAndFill
-  defaultPlugin: true
   parameters:
     stroke:
       description: If to remove redundant strokes.

--- a/docs/04-plugins/removeXMLProcInst.mdx
+++ b/docs/04-plugins/removeXMLProcInst.mdx
@@ -2,7 +2,6 @@
 title: removeXMLProcInst
 svgo:
   pluginId: removeXMLProcInst
-  defaultPlugin: true
 ---
 
 Removes the [XML declaration](https://developer.mozilla.org/en-US/docs/Web/XML/XML_introduction#xml_declaration) from the document.

--- a/docs/04-plugins/sortAttrs.mdx
+++ b/docs/04-plugins/sortAttrs.mdx
@@ -2,7 +2,6 @@
 title: sortAttrs
 svgo:
   pluginId: sortAttrs
-  defaultPlugin: true
   parameters:
     order:
       description: An array of attribute keys to order by. Attributes not found in the array are sorted alphabetically.

--- a/docs/04-plugins/sortDefsChildren.mdx
+++ b/docs/04-plugins/sortDefsChildren.mdx
@@ -2,7 +2,6 @@
 title: sortDefsChildren
 svgo:
   pluginId: sortDefsChildren
-  defaultPlugin: true
 ---
 
 Sorts all children in the `<defs>` element. This does not reduce the size of the SVG, but _may_ improve how compression algorithms perform on it.

--- a/plugins/addAttributesToSVGElement.js
+++ b/plugins/addAttributesToSVGElement.js
@@ -52,6 +52,7 @@ plugins: [
  * @author April Arcus
  *
  * @type {import('../lib/types.js').Plugin<AddAttributesToSVGElementParams>}
+ * @since 0.7.0
  */
 export const fn = (root, params) => {
   if (!Array.isArray(params.attributes) && !params.attribute) {

--- a/plugins/addClassesToSVGElement.js
+++ b/plugins/addClassesToSVGElement.js
@@ -54,6 +54,7 @@ plugins: [
  * @author April Arcus
  *
  * @type {import('../lib/types.js').Plugin<AddClassesToSVGElementParams>}
+ * @since 0.5.2
  */
 export const fn = (root, params, info) => {
   if (

--- a/plugins/cleanupAttrs.js
+++ b/plugins/cleanupAttrs.js
@@ -18,6 +18,7 @@ const regSpaces = /\s{2,}/g;
  *
  * @author Kir Belevich
  * @type {import('../lib/types.js').Plugin<CleanupAttrsParams>}
+ * @since 0.0.1
  */
 export const fn = (root, params) => {
   const { newlines = true, trim = true, spaces = true } = params;

--- a/plugins/cleanupEnableBackground.js
+++ b/plugins/cleanupEnableBackground.js
@@ -19,6 +19,7 @@ const regEnableBackground =
  * <svg width="100" height="50">
  * @author Kir Belevich
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.4
  */
 export const fn = (root) => {
   let hasFilter = false;

--- a/plugins/cleanupIds.js
+++ b/plugins/cleanupIds.js
@@ -128,6 +128,7 @@ const getIdString = (arr) => {
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<CleanupIdsParams>}
+ * @since 0.1.9
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/cleanupListOfValues.js
+++ b/plugins/cleanupListOfValues.js
@@ -39,6 +39,7 @@ const absoluteLengths = {
  * @author kiyopikko
  *
  * @type {import('../lib/types.js').Plugin<CleanupListOfValuesParams>}
+ * @since 0.5.1
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/cleanupNumericValues.js
+++ b/plugins/cleanupNumericValues.js
@@ -31,6 +31,7 @@ const absoluteLengths = {
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<CleanupNumericValuesParams>}
+ * @since 0.1.3
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/collapseGroups.js
+++ b/plugins/collapseGroups.js
@@ -47,6 +47,7 @@ const hasAnimatedAttr = (node, name) => {
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/convertColors.js
+++ b/plugins/convertColors.js
@@ -76,6 +76,7 @@ const convertRgbToHex = ([r, g, b]) => {
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<ConvertColorsParams>}
+ * @since 0.0.1
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/convertEllipseToCircle.js
+++ b/plugins/convertEllipseToCircle.js
@@ -9,6 +9,7 @@ export const description = 'converts non-eccentric <ellipse>s to <circle>s';
  * @author Taylor Hunt
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 1.3.0
  */
 export const fn = () => {
   return {

--- a/plugins/convertOneStopGradients.js
+++ b/plugins/convertOneStopGradients.js
@@ -15,6 +15,7 @@ export const description =
  *
  * @author Seth Falco <seth@falco.fun>
  * @type {import('../lib/types.js').Plugin}
+ * @since 3.0.3
  * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient
  * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient
  */

--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -67,6 +67,7 @@ let arcTolerance;
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<ConvertPathDataParams>}
+ * @since 0.0.7
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/convertShapeToPath.js
+++ b/plugins/convertShapeToPath.js
@@ -21,6 +21,7 @@ const regNumber = /[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g;
  * @author Lev Solntsev
  *
  * @type {import('../lib/types.js').Plugin<ConvertShapeToPathParams>}
+ * @since 0.4.3
  */
 export const fn = (root, params) => {
   const { convertArcs = false, floatPrecision: precision } = params;

--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -77,6 +77,7 @@ const regStripComments = new RegExp(
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<ConvertStyleToAttrsParams>}
+ * @since 0.0.1
  */
 export const fn = (_root, params) => {
   const { keepImportant = false } = params;

--- a/plugins/convertTransform.js
+++ b/plugins/convertTransform.js
@@ -55,6 +55,7 @@ export const description =
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<ConvertTransformParams>}
+ * @since 0.0.8
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -41,6 +41,7 @@ const preservedPseudos = [
  *
  * @type {import('../lib/types.js').Plugin<InlineStylesParams>}
  * @author strarsis <strarsis@gmail.com>
+ * @since 1.0.0
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/mergePaths.js
+++ b/plugins/mergePaths.js
@@ -33,6 +33,7 @@ function elementHasUrl(computedStyle, attName) {
  * @author Kir Belevich, Lev Solntsev
  *
  * @type {import('../lib/types.js').Plugin<MergePathsParams>}
+ * @since 0.3.0
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/mergeStyles.js
+++ b/plugins/mergeStyles.js
@@ -10,6 +10,7 @@ export const description = 'merge multiple style elements into one';
  * @author strarsis <strarsis@gmail.com>
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 2.3.0
  */
 export const fn = () => {
   /** @type {?import('../lib/types.js').XastElement} */

--- a/plugins/minifyStyles.js
+++ b/plugins/minifyStyles.js
@@ -31,6 +31,7 @@ export const description = 'minifies styles and removes unused styles';
  *
  * @author strarsis <strarsis@gmail.com>
  * @type {import('../lib/types.js').Plugin<MinifyStylesParams>}
+ * @since 0.6.0
  */
 export const fn = (_root, { usage, ...params }) => {
   /** @type {Map<import('../lib/types.js').XastElement, import('../lib/types.js').XastParent>} */

--- a/plugins/moveElemsAttrsToGroup.js
+++ b/plugins/moveElemsAttrsToGroup.js
@@ -26,6 +26,7 @@ export const description =
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = (root) => {
   // find if any style element is present

--- a/plugins/moveGroupAttrsToElems.js
+++ b/plugins/moveGroupAttrsToElems.js
@@ -24,6 +24,7 @@ const pathElemsWithGroupsAndText = [...pathElems, 'g', 'text'];
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = () => {
   return {

--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -125,6 +125,7 @@ const generatePrefix = (body, node, info, prefixGenerator, delim, history) => {
  *
  * @author strarsis <strarsis@gmail.com>
  * @type {import('../lib/types.js').Plugin<PrefixIdsParams>}
+ * @since 1.0.0
  */
 export const fn = (_root, params, info) => {
   const {

--- a/plugins/removeAttributesBySelector.js
+++ b/plugins/removeAttributesBySelector.js
@@ -94,6 +94,7 @@ Without either, the plugin is a noop.`;
  * @author Bradley Mease
  *
  * @type {import('../lib/types.js').Plugin<RemoveAttributesBySelectorParams>}
+ * @since 1.2.0
  */
 export const fn = (root, params) => {
   if (

--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -87,6 +87,7 @@ plugins: [
  * @author Benny Schudel
  *
  * @type {import('../lib/types.js').Plugin<RemoveAttrsParams>}
+ * @since 0.5.3
  */
 export const fn = (root, params) => {
   if (typeof params.attrs == 'undefined') {

--- a/plugins/removeComments.js
+++ b/plugins/removeComments.js
@@ -24,6 +24,7 @@ const DEFAULT_PRESERVE_PATTERNS = [/^!/];
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveCommentsParams>}
+ * @since 0.0.1
  */
 export const fn = (_root, params) => {
   const { preservePatterns = DEFAULT_PRESERVE_PATTERNS } = params;

--- a/plugins/removeDeprecatedAttrs.js
+++ b/plugins/removeDeprecatedAttrs.js
@@ -72,6 +72,7 @@ function processAttributes(
  * Remove deprecated attributes.
  *
  * @type {import('../lib/types.js').Plugin<RemoveDeprecatedAttrsParams>}
+ * @since 3.3.0
  */
 export function fn(root, params) {
   const stylesheet = collectStylesheet(root);

--- a/plugins/removeDesc.js
+++ b/plugins/removeDesc.js
@@ -20,6 +20,7 @@ const standardDescs = /^(Created with|Created using)/;
  * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc
  *
  * @type {import('../lib/types.js').Plugin<RemoveDescParams>}
+ * @since 0.5.0
  */
 export const fn = (root, params) => {
   const { removeAny = false } = params;

--- a/plugins/removeDimensions.js
+++ b/plugins/removeDimensions.js
@@ -13,6 +13,7 @@ export const description =
  * @author Benny Schudel
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.5.3
  */
 export const fn = () => {
   return {

--- a/plugins/removeDoctype.js
+++ b/plugins/removeDoctype.js
@@ -26,6 +26,7 @@ export const description = 'removes doctype declaration';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = () => {
   return {

--- a/plugins/removeEditorsNSData.js
+++ b/plugins/removeEditorsNSData.js
@@ -21,6 +21,7 @@ export const description =
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveEditorsNSDataParams>}
+ * @since 0.0.1
  */
 export const fn = (_root, params) => {
   let namespaces = [...editorNamespaces];

--- a/plugins/removeElementsByAttr.js
+++ b/plugins/removeElementsByAttr.js
@@ -41,6 +41,7 @@ export const description = 'removes arbitrary elements by ID or className';
  * @author Eli Dupuis (@elidupuis)
  *
  * @type {import('../lib/types.js').Plugin<RemoveElementsByAttrParams>}
+ * @since 0.7.0
  */
 export const fn = (root, params) => {
   const ids =

--- a/plugins/removeEmptyAttrs.js
+++ b/plugins/removeEmptyAttrs.js
@@ -9,6 +9,7 @@ export const description = 'removes empty attributes';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = () => {
   return {

--- a/plugins/removeEmptyContainers.js
+++ b/plugins/removeEmptyContainers.js
@@ -20,6 +20,7 @@ export const description = 'removes empty container elements';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/removeEmptyText.js
+++ b/plugins/removeEmptyText.js
@@ -28,6 +28,7 @@ export const description = 'removes empty <text> elements';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveEmptyTextParams>}
+ * @since 0.0.1
  */
 export const fn = (root, params) => {
   const { text = true, tspan = true, tref = true } = params;

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -46,6 +46,7 @@ export const description =
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveHiddenElemsParams>}
+ * @since 0.0.1
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/removeMetadata.js
+++ b/plugins/removeMetadata.js
@@ -11,6 +11,7 @@ export const description = 'removes <metadata>';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = () => {
   return {

--- a/plugins/removeNonInheritableGroupAttrs.js
+++ b/plugins/removeNonInheritableGroupAttrs.js
@@ -14,6 +14,7 @@ export const description =
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.2.3
  */
 export const fn = () => {
   return {

--- a/plugins/removeOffCanvasPaths.js
+++ b/plugins/removeOffCanvasPaths.js
@@ -13,6 +13,7 @@ export const description =
  * @author JoshyPHP
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 1.2.0
  */
 export const fn = () => {
   /**

--- a/plugins/removeRasterImages.js
+++ b/plugins/removeRasterImages.js
@@ -11,6 +11,7 @@ export const description = 'removes raster images';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.2.3
  */
 export const fn = () => {
   return {

--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -51,6 +51,7 @@ function isNamespaceAwareElem(elem, targetElem, prefixes, targetNamespaces) {
  *
  * @author Patrick Klingemann
  * @type {import('../lib/types.js').Plugin}
+ * @since 1.0.0
  */
 export const fn = () => {
   /**

--- a/plugins/removeStyleElement.js
+++ b/plugins/removeStyleElement.js
@@ -11,6 +11,7 @@ export const description = 'removes <style> element';
  * @author Betsy Dupuis
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.6.0
  */
 export const fn = () => {
   return {

--- a/plugins/removeTitle.js
+++ b/plugins/removeTitle.js
@@ -11,6 +11,7 @@ export const description = 'removes <title>';
  * @author Igor Kalashnikov
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.4.4
  */
 export const fn = () => {
   return {

--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -99,6 +99,7 @@ for (const [name, config] of Object.entries(elems)) {
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveUnknownsAndDefaultsParams>}
+ * @since 0.1.0
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/removeUnusedNS.js
+++ b/plugins/removeUnusedNS.js
@@ -8,6 +8,7 @@ export const description = 'removes unused namespaces declaration';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.8
  */
 export const fn = () => {
   /** @type {Set<string>} */

--- a/plugins/removeUselessDefs.js
+++ b/plugins/removeUselessDefs.js
@@ -10,6 +10,7 @@ export const description = 'removes elements in <defs> without id';
  * @author Lev Solntsev
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.5.1
  */
 export const fn = () => {
   return {

--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -20,6 +20,7 @@ export const description = 'removes useless stroke and fill attributes';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin<RemoveUselessStrokeAndFillParams>}
+ * @since 0.1.8
  */
 export const fn = (root, params) => {
   const {

--- a/plugins/removeViewBox.js
+++ b/plugins/removeViewBox.js
@@ -16,6 +16,7 @@ const viewBoxElems = new Set(['pattern', 'svg', 'symbol']);
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.4
  */
 export const fn = () => {
   return {

--- a/plugins/removeXMLNS.js
+++ b/plugins/removeXMLNS.js
@@ -12,6 +12,7 @@ export const description = 'removes xmlns attribute (for inline svg)';
  * @author Ricardo Tomasi
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.7.0
  */
 export const fn = () => {
   return {

--- a/plugins/removeXMLProcInst.js
+++ b/plugins/removeXMLProcInst.js
@@ -12,6 +12,7 @@ export const description = 'removes XML processing instructions';
  * @author Kir Belevich
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 0.0.1
  */
 export const fn = () => {
   return {

--- a/plugins/removeXlink.js
+++ b/plugins/removeXlink.js
@@ -61,6 +61,7 @@ const findPrefixedAttrs = (node, prefixes, attr) => {
  *
  * @type {import('../lib/types.js').Plugin<RemoveXlinkParams>}
  * @see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
+ * @since 3.0.4
  */
 export const fn = (_, params) => {
   const { includeLegacy } = params;

--- a/plugins/reusePaths.js
+++ b/plugins/reusePaths.js
@@ -14,6 +14,7 @@ export const description =
  * @author Jacob Howcroft
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 1.2.0
  */
 export const fn = (root) => {
   const stylesheet = collectStylesheet(root);

--- a/plugins/sortAttrs.js
+++ b/plugins/sortAttrs.js
@@ -13,6 +13,7 @@ export const description = 'Sort element attributes for better compression';
  * @author Nikolay Frantsev
  *
  * @type {import('../lib/types.js').Plugin<SortAttrsParams>}
+ * @since 0.3.2
  */
 export const fn = (_root, params) => {
   const {

--- a/plugins/sortDefsChildren.js
+++ b/plugins/sortDefsChildren.js
@@ -9,6 +9,7 @@ export const description = 'Sorts children of <defs> to improve compression';
  * @author David Leston
  *
  * @type {import('../lib/types.js').Plugin}
+ * @since 1.3.0
  */
 export const fn = () => {
   return {


### PR DESCRIPTION
See commit message(s).

TL;DR: 

- svg/svgo.dev will now use SVGO's JS API to determine default plugins. There's no need for us to duplicate that information to frontmatter.
- svg/svgo will now parse sources, including JSDocs. For now that's just for the `@since` attribute, but I'd like to slowly expand this.

The goal isn't to remove the MDX files, the markup files will continue to have information that I wouldn't expect to keep in JSDocs. I'm just looking to remove the frontmatter—I'd like to migrate that data across to either the JS API, JSDocs, or TypeScript type declarations.

## Related

- Pairs with https://github.com/svg/svgo.dev/pull/88 ← includes screenshots