### PR TITLE
fix(convertPathData): keep full circle when arc endpoints coincide (#2104)

### DIFF
--- a/plugins/convertPathData.js
+++ b/plugins/convertPathData.js
@@ -510,14 +510,24 @@ function filters(path, params, { isSafeToUseZ, isSafeToRemove, hasMarkerMid }) {
               arc.args[3] = 1;
             }
             arcCurves.push(next);
-            if (2 * Math.PI - angle > 1e-3) {
+            // A single arc can't represent a full turn: if its endpoints
+            // coincide, it renders nothing. This happens for a closed circle
+            // whose measured angle falls just short of 360° (cubic-bezier
+            // approximation error), so the angular check alone misses it.
+            // @ts-expect-error
+            const endDx = next.coords[0] - arc.base[0];
+            // @ts-expect-error
+            const endDy = next.coords[1] - arc.base[1];
+            const wouldVanish =
+              angle > Math.PI &&
+              Math.abs(endDx) < error &&
+              Math.abs(endDy) < error;
+            if (2 * Math.PI - angle > 1e-3 && !wouldVanish) {
               // less than 360°
               // @ts-expect-error
               arc.coords = next.coords;
-              // @ts-expect-error
-              arc.args[5] = arc.coords[0] - arc.base[0];
-              // @ts-expect-error
-              arc.args[6] = arc.coords[1] - arc.base[1];
+              arc.args[5] = endDx;
+              arc.args[6] = endDy;
             } else {
               // full circle, make a half-circle arc and add a second one
               arc.args[5] = 2 * (relCircle.center[0] - nextData[4]);

--- a/test/plugins/convertPathData.41.svg.txt
+++ b/test/plugins/convertPathData.41.svg.txt
@@ -1,0 +1,20 @@
+A closed circle whose curves fit an arc must stay a full circle.
+The measured arc angle can fall just short of 360° due to bezier
+approximation, so a single arc would have coincident endpoints and
+render nothing. It must be emitted as two half-circle arcs instead.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2195.656274 1486.713736 52.67746 185.305106">
+    <path d="m2226.68 1586.64061c0-.550781-.45-.996093-.996-.996093c-.551 0-.997 .445312-.997 .996093c0 .550782 .446 .996094 .997 .996094c.546 0 .996-.445312 .996-.996094z"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2195.656274 1486.713736 52.67746 185.305106">
+    <path d="M2226.68 1586.64a.996.996 0 1 0-1.994 0 .996.996 0 0 0 1.994 0"/>
+</svg>
+
+@@@
+
+{ "floatPrecision": 3 }


### PR DESCRIPTION
Closes #2104.

**Repro:** `svgo --precision=3` on a dot drawn as a closed circle path drops the dot. makeArcs emits `a.996.996 0 1 0 0 0` — an arc whose start and end coincide, which the SVG spec omits entirely, so it renders nothing. Precision 2 and 4 are fine.

**Cause:** When curves are combined into arcs, a closed circle's measured sweep can fall ~0.06° short of 360° (cubic-bezier fit error), so the full-circle check `2*Math.PI - angle > 1e-3` took the single-arc branch. The last curve returns exactly to the start, so the relative endpoint is (0,0) — a degenerate arc.

**Fix:** take the existing two half-circle branch whenever the single arc's endpoints would coincide (within the working precision). Only the degenerate case changes; a 120-variant diff of other circles/arcs is byte-identical.

**Evidence:** headless render of the repro path — before: 0 ink pixels (dot gone); after: the circle is drawn. Added fixture `convertPathData.41`. tests / types / lint / bundles pass.
