### PR TITLE
fix(removeScripts): filter executable data URLs

### DIFF
--- a/docs/04-plugins/removeScripts.mdx
+++ b/docs/04-plugins/removeScripts.mdx
@@ -18,7 +18,7 @@ This plugin performs the following operations:
 
 - Removes [`<script>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script) elements.
 - Removes [SVG event attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
-- Collapses [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) elements whose links use `javascript:` or an executable `data:` media type (`text/html`, `application/xhtml+xml`, or `image/svg+xml`), moving children up to the parent element. The legacy `vbscript:` scheme is not removed because modern browsers do not support it.
+- Collapses [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) elements whose links use `javascript:`, legacy `vbscript:`, or an executable `data:` media type (`text/html`, `application/xhtml+xml`, or `image/svg+xml`), moving children up to the parent element.
 
 :::info
 

--- a/docs/04-plugins/removeScripts.mdx
+++ b/docs/04-plugins/removeScripts.mdx
@@ -18,7 +18,7 @@ This plugin performs the following operations:
 
 - Removes [`<script>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script) elements.
 - Removes [SVG event attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
-- Collapses [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) elements, moving children up to the parent element.
+- Collapses [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) elements whose links use `javascript:` or an executable `data:` media type (`text/html`, `application/xhtml+xml`, or `image/svg+xml`), moving children up to the parent element. The legacy `vbscript:` scheme is not removed because modern browsers do not support it.
 
 :::info
 

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -153,6 +153,42 @@ const hasScriptsEventAttrs = [
   ...attrsGroups.graphicalEvent,
 ];
 
+const executableDataMediaTypes = new Set([
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'text/html',
+]);
+
+/**
+ * Check whether a URL can contain executable content in modern browsers.
+ *
+ * `vbscript:` is intentionally excluded because it was only implemented by
+ * legacy Internet Explorer and is not supported by modern browsers.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export const isExecutableUrl = (value) => {
+  const normalizedValue = value.trimStart().toLowerCase();
+
+  // lgtm[js/incomplete-url-scheme-check]
+  if (normalizedValue.startsWith('javascript:')) {
+    return true;
+  }
+
+  if (!normalizedValue.startsWith('data:')) {
+    return false;
+  }
+
+  const mediaTypeEnd = normalizedValue.slice(5).search(/[;,]/);
+  if (mediaTypeEnd === -1) {
+    return false;
+  }
+
+  const mediaType = normalizedValue.slice(5, mediaTypeEnd + 5).trim();
+  return executableDataMediaTypes.has(mediaType);
+};
+
 /**
  * If the current node contains any scripts. This does not check parents or
  * children of the node, only the properties and attributes of the node itself.
@@ -166,14 +202,14 @@ export const hasScripts = (node) => {
   }
 
   if (node.name === 'a') {
-    const hasJsLinks = Object.entries(node.attributes).some(
+    const hasExecutableLinks = Object.entries(node.attributes).some(
       ([attrKey, attrValue]) =>
         (attrKey === 'href' || attrKey.endsWith(':href')) &&
         attrValue != null &&
-        attrValue.trimStart().toLowerCase().startsWith('javascript:'),
+        isExecutableUrl(attrValue),
     );
 
-    if (hasJsLinks) {
+    if (hasExecutableLinks) {
       return true;
     }
   }

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -160,10 +160,7 @@ const executableDataMediaTypes = new Set([
 ]);
 
 /**
- * Check whether a URL can contain executable content in modern browsers.
- *
- * `vbscript:` is intentionally excluded because it was only implemented by
- * legacy Internet Explorer and is not supported by modern browsers.
+ * Check whether a URL can contain executable content in a browser.
  *
  * @param {string} value
  * @returns {boolean}
@@ -171,15 +168,26 @@ const executableDataMediaTypes = new Set([
 export const isExecutableUrl = (value) => {
   const normalizedValue = value.trimStart().toLowerCase();
 
-  // lgtm[js/incomplete-url-scheme-check]
-  if (normalizedValue.startsWith('javascript:')) {
+  // `javascript:` is executable in modern browsers. `vbscript:` was only
+  // implemented by legacy Internet Explorer, but rejecting it is inexpensive,
+  // provides defense in depth for old environments, and keeps this security-
+  // oriented plugin's scheme denylist explicit and complete.
+  if (
+    normalizedValue.startsWith('javascript:') ||
+    normalizedValue.startsWith('vbscript:')
+  ) {
     return true;
   }
 
+  // A `data:` URL is not inherently executable: images and other inert media
+  // are common in SVGs and should remain intact. Only reject media types that
+  // browsers parse as active HTML, XHTML, or SVG documents.
   if (!normalizedValue.startsWith('data:')) {
     return false;
   }
 
+  // Data URLs separate the media type from parameters with `;` and from the
+  // payload with `,`. A URL without either separator has no valid media type.
   const mediaTypeEnd = normalizedValue.slice(5).search(/[;,]/);
   if (mediaTypeEnd === -1) {
     return false;

--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -1,4 +1,5 @@
 import { attrsGroups } from './_collections.js';
+import { isExecutableUrl } from '../lib/svgo/tools.js';
 import { detachNodeFromParent } from '../lib/xast.js';
 
 export const name = 'removeScripts';
@@ -110,10 +111,7 @@ export const fn = () => {
           if (attr === 'href' || attr.endsWith(':href')) {
             if (
               node.attributes[attr] == null ||
-              !node.attributes[attr]
-                .trimStart()
-                .toLowerCase()
-                .startsWith('javascript:')
+              !isExecutableUrl(node.attributes[attr])
             ) {
               continue;
             }

--- a/test/plugins/removeScripts.09.svg.txt
+++ b/test/plugins/removeScripts.09.svg.txt
@@ -1,5 +1,5 @@
-Collapses links to executable data documents while preserving data links with
-inert media types and legacy VBScript links.
+Collapses links to executable data documents and legacy VBScript URLs while
+preserving data links with inert media types.
 
 ===
 
@@ -30,7 +30,5 @@ inert media types and legacy VBScript links.
     <a href="data:image/png;base64,iVBORw0KGgo=">
     <text y="40">PNG</text>
   </a>
-    <a href="vbscript:msgbox(1)">
     <text y="50">VBScript</text>
-  </a>
 </svg>

--- a/test/plugins/removeScripts.09.svg.txt
+++ b/test/plugins/removeScripts.09.svg.txt
@@ -1,0 +1,36 @@
+Collapses links to executable data documents while preserving data links with
+inert media types and legacy VBScript links.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+  <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">
+    <text y="10">HTML</text>
+  </a>
+  <a uwu:href="DATA:application/xhtml+xml;charset=utf-8,%3Cscript%3Ealert(1)%3C/script%3E">
+    <text y="20">XHTML</text>
+  </a>
+  <a href="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIi8+">
+    <text y="30">SVG</text>
+  </a>
+  <a href="data:image/png;base64,iVBORw0KGgo=">
+    <text y="40">PNG</text>
+  </a>
+  <a href="vbscript:msgbox(1)">
+    <text y="50">VBScript</text>
+  </a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+    <text y="10">HTML</text>
+    <text y="20">XHTML</text>
+    <text y="30">SVG</text>
+    <a href="data:image/png;base64,iVBORw0KGgo=">
+    <text y="40">PNG</text>
+  </a>
+    <a href="vbscript:msgbox(1)">
+    <text y="50">VBScript</text>
+  </a>
+</svg>


### PR DESCRIPTION
## Summary

- centralize executable URL detection in `isExecutableUrl`
- reject `javascript:` and legacy `vbscript:` URLs
- collapse links to active `data:` documents (`text/html`, `application/xhtml+xml`, and `image/svg+xml`)
- preserve inert `data:` media types such as `image/png`
- add coverage for default and namespaced `href` attributes, MIME parameters, case normalization, inert data URLs, and VBScript URLs

## Why this is necessary

`removeScripts` currently recognizes `javascript:` links, but other URL schemes can also represent executable content:

- A `data:` URL can carry an HTML, XHTML, or SVG document containing script. Whether that content runs depends on how the URL is loaded and browser navigation policy, but these are active document formats and should not pass a plugin whose purpose is to remove scripts.
- `vbscript:` was only implemented by legacy Internet Explorer and is not supported by modern browsers. We still reject it because the compatibility cost is negligible, it provides defense in depth for old environments, and it makes the security-oriented scheme denylist explicit and complete. Also it silences these security advisories and reporters.

Rejecting every `data:` URL would be unnecessarily destructive because many SVGs legitimately link to inert embedded resources such as PNG images. This change therefore filters only media types that browsers parse as script-capable documents. Comments next to the implementation explain both the legacy VBScript decision and the selective parsing of data URLs.

This addresses the underlying concern reported by code-scanning alerts [#18](https://github.com/svg/svgo/security/code-scanning/18) and [#19](https://github.com/svg/svgo/security/code-scanning/19).

## Validation

- `pnpm test` — 1,554 passed, 9 skipped
- `pnpm typecheck`
- ESLint and Prettier checks for all changed source and documentation files
