### PR TITLE
fix(removeScripts): sanitize foreignObject content

### DIFF
--- a/docs/04-plugins/removeScripts.mdx
+++ b/docs/04-plugins/removeScripts.mdx
@@ -17,6 +17,7 @@ This **will** break interactive SVGs that rely on JavaScript.
 This plugin performs the following operations:
 
 - Removes [`<script>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script) elements.
+- Sanitizes HTML inside [`<foreignObject>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject) elements by removing event attributes, `srcdoc`, and executable URLs from HTML URL attributes such as `action`, `data`, `formaction`, `href`, and `src`. The elements and other visual content are preserved.
 - Removes [SVG event attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
 - Collapses [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) elements whose links use `javascript:`, legacy `vbscript:`, or an executable `data:` media type (`text/html`, `application/xhtml+xml`, or `image/svg+xml`), moving children up to the parent element.
 

--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -14,11 +14,16 @@ const eventAttrs = [
   ...attrsGroups.graphicalEvent,
 ];
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/** Namespaces that support SVG <foreignObject> elements. */
+const FOREIGN_OBJECT_NAMESPACES = [SVG_NAMESPACE];
+
 /** Namespaces that support executable <script> elements. */
-const SCRIPT_NAMESPACES = [
-  'http://www.w3.org/2000/svg',
-  'http://www.w3.org/1999/xhtml',
-];
+const SCRIPT_NAMESPACES = [SVG_NAMESPACE, 'http://www.w3.org/1999/xhtml'];
+
+/** Attributes that can load or navigate to executable documents in HTML. */
+const HTML_URL_ATTRS = new Set(['action', 'data', 'formaction', 'href', 'src']);
 
 /**
  * @param {string} elem
@@ -62,6 +67,7 @@ export const fn = () => {
    *
    * @type {Map<string, string[]>} */
   const prefixes = new Map();
+  let foreignObjectDepth = 0;
 
   return {
     element: {
@@ -81,19 +87,48 @@ export const fn = () => {
         }
 
         if (
+          isNamespaceAwareElem(
+            node.name,
+            'foreignObject',
+            prefixes,
+            FOREIGN_OBJECT_NAMESPACES,
+          )
+        ) {
+          foreignObjectDepth += 1;
+        }
+
+        if (
           isNamespaceAwareElem(node.name, 'script', prefixes, SCRIPT_NAMESPACES)
         ) {
           detachNodeFromParent(node, parentNode);
           return;
         }
 
-        for (const attr of eventAttrs) {
-          if (node.attributes[attr] != null) {
+        for (const [attr, value] of Object.entries(node.attributes)) {
+          const localAttr = attr.slice(attr.lastIndexOf(':') + 1).toLowerCase();
+          const isEventAttr =
+            eventAttrs.includes(attr) ||
+            (foreignObjectDepth > 0 && localAttr.startsWith('on'));
+          const isEmbeddedDocumentAttr =
+            foreignObjectDepth > 0 && localAttr === 'srcdoc';
+          const isExecutableHtmlUrl =
+            foreignObjectDepth > 0 &&
+            HTML_URL_ATTRS.has(localAttr) &&
+            isExecutableUrl(value);
+
+          if (isEventAttr || isEmbeddedDocumentAttr || isExecutableHtmlUrl) {
             delete node.attributes[attr];
           }
         }
       },
       exit: (node, parentNode) => {
+        const isForeignObject = isNamespaceAwareElem(
+          node.name,
+          'foreignObject',
+          prefixes,
+          FOREIGN_OBJECT_NAMESPACES,
+        );
+
         for (const k of Object.keys(node.attributes)) {
           if (!k.startsWith('xmlns:')) {
             continue;
@@ -103,25 +138,27 @@ export const fn = () => {
           /** @type {string[]} */ (prefixes.get(prefix)).pop();
         }
 
-        if (node.name !== 'a') {
-          return;
+        if (node.name === 'a') {
+          for (const attr of Object.keys(node.attributes)) {
+            if (attr === 'href' || attr.endsWith(':href')) {
+              if (
+                node.attributes[attr] == null ||
+                !isExecutableUrl(node.attributes[attr])
+              ) {
+                continue;
+              }
+
+              const index = parentNode.children.indexOf(node);
+              const usefulChildren = node.children.filter(
+                (child) => child.type !== 'text',
+              );
+              parentNode.children.splice(index, 1, ...usefulChildren);
+            }
+          }
         }
 
-        for (const attr of Object.keys(node.attributes)) {
-          if (attr === 'href' || attr.endsWith(':href')) {
-            if (
-              node.attributes[attr] == null ||
-              !isExecutableUrl(node.attributes[attr])
-            ) {
-              continue;
-            }
-
-            const index = parentNode.children.indexOf(node);
-            const usefulChildren = node.children.filter(
-              (child) => child.type !== 'text',
-            );
-            parentNode.children.splice(index, 1, ...usefulChildren);
-          }
+        if (isForeignObject) {
+          foreignObjectDepth -= 1;
         }
       },
     },

--- a/test/plugins/removeScripts.10.svg.txt
+++ b/test/plugins/removeScripts.10.svg.txt
@@ -1,0 +1,42 @@
+Sanitizes executable HTML inside foreignObject elements while preserving their
+visual content. Elements with the same local name in unrelated namespaces do
+not enable the additional HTML attribute handling.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:custom="https://example.com/custom">
+  <foreignObject width="300" height="300">
+    <xhtml:iframe srcdoc="&lt;script&gt;alert(document.domain)&lt;/script&gt;" src="https://example.com/content"/>
+    <xhtml:form action="javascript:alert(document.domain)" class="form"/>
+    <xhtml:object data="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;" title="Object"/>
+    <xhtml:div onbeforetoggle="alert(1)" style="color: red">Visual HTML</xhtml:div>
+    <xhtml:script>alert(1)</xhtml:script>
+  </foreignObject>
+  <svg:foreignObject width="300" height="300">
+    <xhtml:button formaction="vbscript:msgbox(1)">Button</xhtml:button>
+  </svg:foreignObject>
+  <custom:foreignObject srcdoc="Custom data">Non-executable custom content</custom:foreignObject>
+  <text>Safe SVG content</text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:custom="https://example.com/custom">
+    <foreignObject width="300" height="300">
+        <xhtml:iframe src="https://example.com/content"/>
+        <xhtml:form class="form"/>
+        <xhtml:object title="Object"/>
+        <xhtml:div style="color: red">
+            Visual HTML
+        </xhtml:div>
+    </foreignObject>
+    <svg:foreignObject width="300" height="300">
+        <xhtml:button>
+            Button
+        </xhtml:button>
+    </svg:foreignObject>
+    <custom:foreignObject srcdoc="Custom data">
+        Non-executable custom content
+    </custom:foreignObject>
+    <text>Safe SVG content</text>
+</svg>


### PR DESCRIPTION
## Summary

- preserve visual HTML inside SVG `foreignObject` elements
- remove `srcdoc`, all HTML `on*` event attributes, and executable URLs from active HTML URL attributes
- continue removing SVG and XHTML `script` elements
- add namespace-aware regression coverage and documentation

## Security

Addresses [GHSA-4vpr-x523-8j87](https://github.com/svg/svgo/security/advisories/GHSA-4vpr-x523-8j87).

Rather than removing the entire `foreignObject`, this strips known execution paths while retaining non-executable HTML and visual content.

## Validation

- `pnpm test` — 1,555 passed, 9 skipped
- `pnpm typecheck`
- ESLint
- Prettier
- `git diff --check`