### PR TITLE
chore: optimize fixtures in a bounded worker pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "rimraf": "^6.1.3",
     "rollup": "^4.62.4",
     "tar-stream": "^3.2.0",
+    "tinypool": "^2.1.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       tar-stream:
         specifier: ^3.2.0
         version: 3.2.0
+      tinypool:
+        specifier: ^2.1.0
+        version: 2.1.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1604,6 +1607,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   tinyrainbow@3.1.1:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
@@ -3053,6 +3060,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.1: {}
 

--- a/test/regression/delta.js
+++ b/test/regression/delta.js
@@ -63,7 +63,7 @@ function writeReport(deltaReport) {
   console.log(`${HEADING}
        Files Affected: ${filesAffected.toLocaleString()} / ${totalFiles.toLocaleString()}
         Bytes Saved Δ: ${toDisplayString(bytesDelta, (n) => bytesToHumanReadable(n))}
-         Time Taken Δ: ${toDisplayString(secsDelta, (n) => secsToHumanReadable(n))}
+  Optimization Time Δ: ${toDisplayString(secsDelta, (n) => secsToHumanReadable(n))}
   Peak Memory Alloc Δ: ${toDisplayString(memDelta, (n) => bytesToHumanReadable(n, 'KiB'))}`);
 }
 

--- a/test/regression/lib.js
+++ b/test/regression/lib.js
@@ -54,7 +54,7 @@ export async function printReport(report) {
 
 ▶ Metrics
         Bytes Saved: ${bytesToHumanReadable(report.metrics.bytesSaved)}
-         Time Taken: ${secsToHumanReadable(report.metrics.timeTakenSecs)}
+  Optimization Time: ${secsToHumanReadable(report.metrics.timeTakenSecs)}
   Peak Memory Alloc: ${bytesToHumanReadable(report.metrics.peakMemoryAlloc, 'KiB')}${
     shouldHaveMatched.length !== 0
       ? picocolors.red(

--- a/test/regression/optimize-worker.js
+++ b/test/regression/optimize-worker.js
@@ -1,0 +1,39 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { optimize } from '../../lib/svgo.js';
+
+/** @type {import('../../lib/types.js').Config} */
+const SVGO_OPTS = { floatPrecision: 4 };
+
+/**
+ * @typedef OptimizeTask
+ * @property {string} name
+ * @property {string} originalPath
+ * @property {string} optimizedPath
+ *
+ * @typedef OptimizeResult
+ * @property {string} name
+ * @property {number} bytesSaved
+ * @property {string} checksum
+ */
+
+/**
+ * @param {OptimizeTask} task
+ * @returns {Promise<OptimizeResult>}
+ */
+export default async function optimizeFixture(task) {
+  const original = await fs.readFile(task.originalPath, 'utf8');
+  const optimized = optimize(original, SVGO_OPTS).data;
+
+  await fs.mkdir(path.dirname(task.optimizedPath), { recursive: true });
+  await fs.writeFile(task.optimizedPath, optimized);
+
+  return {
+    name: task.name,
+    bytesSaved:
+      Buffer.byteLength(original, 'utf8') -
+      Buffer.byteLength(optimized, 'utf8'),
+    checksum: crypto.createHash('md5').update(optimized).digest('hex'),
+  };
+}

--- a/test/regression/optimize.js
+++ b/test/regression/optimize.js
@@ -15,9 +15,10 @@ const workerUrl = new URL('./optimize-worker.js', import.meta.url);
 
 /**
  * @param {ReadonlyArray<string>} list
- * @returns {Promise<Partial<import('./regression-io.js').TestReport>>}
+ * @returns {Promise<Pick<import('./regression-io.js').TestReport, 'metrics' | 'checksums'>>}
  */
 const optimizeFixtures = async (list) => {
+  const started = performance.now();
   const totalFiles = list.length;
   let processed = 0;
 
@@ -67,7 +68,7 @@ const optimizeFixtures = async (list) => {
     }
   }
 
-  report.metrics.timeTakenSecs = process.uptime();
+  report.metrics.timeTakenSecs = (performance.now() - started) / 1000;
   report.metrics.peakMemoryAlloc = process.resourceUsage().maxRSS;
   return report;
 };
@@ -79,7 +80,12 @@ const optimizeFixtures = async (list) => {
     });
     const list = (await filesPromise).filter((name) => name.endsWith('.svg'));
     const report = await optimizeFixtures(list);
-    console.log();
+    if (process.stdout.isTTY) {
+      console.log();
+    }
+    console.info(
+      `Optimized SVGs in ${report.metrics.timeTakenSecs.toFixed(2)}s`,
+    );
     await writeReport(report);
   } catch (error) {
     console.error(error);

--- a/test/regression/optimize.js
+++ b/test/regression/optimize.js
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import {
   REGRESSION_FIXTURES_PATH,
@@ -13,7 +12,7 @@ import { optimize } from '../../lib/svgo.js';
 const SVGO_OPTS = { floatPrecision: 4 };
 
 /**
- * @param {string[]} list
+ * @param {ReadonlyArray<string>} list
  * @returns {Promise<Partial<import('./regression-io.js').TestReport>>}
  */
 const optimizeFixtures = async (list) => {
@@ -58,16 +57,14 @@ const optimizeFixtures = async (list) => {
     }
   };
 
-  const worker = async () => {
-    let item;
-    while ((item = list.pop())) {
-      await processFile(item);
-    }
-  };
-
-  await Promise.all(
-    Array.from(new Array(os.cpus().length * 2), () => worker()),
-  );
+  // optimize() is synchronous, so async workers cannot optimize in parallel.
+  // They only read multiple fixtures ahead of the active optimization, retaining
+  // several large inputs at once and increasing peak memory without adding CPU
+  // throughput. Keep one fixture in flight until optimization moves to actual
+  // worker threads with a memory-aware scheduler.
+  for (const name of list) {
+    await processFile(name);
+  }
 
   report.metrics.timeTakenSecs = process.uptime();
   report.metrics.peakMemoryAlloc = process.resourceUsage().maxRSS;

--- a/test/regression/optimize.js
+++ b/test/regression/optimize.js
@@ -1,15 +1,17 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import Tinypool from 'tinypool';
 import {
   REGRESSION_FIXTURES_PATH,
   REGRESSION_OPTIMIZED_PATH,
   writeReport,
 } from './regression-io.js';
-import { md5sum, pathToPosix } from './lib.js';
-import { optimize } from '../../lib/svgo.js';
+import { pathToPosix } from './lib.js';
 
-/** @type {import('../../lib/types.js').Config} */
-const SVGO_OPTS = { floatPrecision: 4 };
+// Keep concurrent large ASTs bounded on memory-constrained CI runners.
+const DEFAULT_OPTIMIZE_WORKERS = Math.min(os.availableParallelism(), 2);
+const workerUrl = new URL('./optimize-worker.js', import.meta.url);
 
 /**
  * @param {ReadonlyArray<string>} list
@@ -29,41 +31,40 @@ const optimizeFixtures = async (list) => {
     checksums: {},
   };
 
-  /**
-   * @param {string} name
-   */
-  const processFile = async (name) => {
-    const original = await fs.readFile(
-      path.join(REGRESSION_FIXTURES_PATH, name),
-      'utf-8',
-    );
-    const optimized = optimize(original, SVGO_OPTS).data;
-    const namePosix = pathToPosix(name);
-    report.checksums[namePosix] = md5sum(optimized);
-
-    const prevFileSize = Buffer.byteLength(original, 'utf8');
-    const resultFileSize = Buffer.byteLength(optimized, 'utf8');
-    report.metrics.bytesSaved += prevFileSize - resultFileSize;
-
-    const file = path.join(REGRESSION_OPTIMIZED_PATH, name);
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, optimized);
-
-    if (process.stdout.isTTY) {
-      process.stdout.clearLine(0);
-      process.stdout.write(
-        `\rOptimized ${(++processed).toLocaleString()} of ${totalFiles.toLocaleString()}…`,
+  const workerCount = Math.min(DEFAULT_OPTIMIZE_WORKERS, list.length);
+  if (workerCount !== 0) {
+    const pool = new Tinypool({
+      filename: workerUrl.href,
+      minThreads: workerCount,
+      maxThreads: workerCount,
+    });
+    /** @type {import('./optimize-worker.js').OptimizeResult[]} */
+    let results;
+    try {
+      results = await Promise.all(
+        list.map(async (name) => {
+          const result = await pool.run({
+            name,
+            originalPath: path.join(REGRESSION_FIXTURES_PATH, name),
+            optimizedPath: path.join(REGRESSION_OPTIMIZED_PATH, name),
+          });
+          if (process.stdout.isTTY) {
+            process.stdout.clearLine(0);
+            process.stdout.write(
+              `\rOptimized ${(++processed).toLocaleString()} of ${totalFiles.toLocaleString()}…`,
+            );
+          }
+          return result;
+        }),
       );
+    } finally {
+      await pool.destroy();
     }
-  };
 
-  // optimize() is synchronous, so async workers cannot optimize in parallel.
-  // They only read multiple fixtures ahead of the active optimization, retaining
-  // several large inputs at once and increasing peak memory without adding CPU
-  // throughput. Keep one fixture in flight until optimization moves to actual
-  // worker threads with a memory-aware scheduler.
-  for (const name of list) {
-    await processFile(name);
+    for (const result of results) {
+      report.checksums[pathToPosix(result.name)] = result.checksum;
+      report.metrics.bytesSaved += result.bytesSaved;
+    }
   }
 
   report.metrics.timeTakenSecs = process.uptime();

--- a/test/regression/regression-io.js
+++ b/test/regression/regression-io.js
@@ -22,7 +22,7 @@ import { getCommitRef } from './lib.js';
  *
  * @typedef Metrics
  * @property {number} bytesSaved Total bytes saved throughout this test run.
- * @property {number} timeTakenSecs Total time taken throughout this test run.
+ * @property {number} timeTakenSecs Time taken to optimize all fixtures.
  * @property {number} peakMemoryAlloc
  *   Peak memory allocation throughout this test run in kibibytes (1,024 bytes).
  *


### PR DESCRIPTION
## Summary

- optimize regression fixtures in worker threads orchestrated by Tinypool
- cap optimization at two concurrent workers on memory-constrained CI runners
- move fixture reads, synchronous optimization, checksumming, and writes into the worker
- avoid retaining fixture contents or optimized SVGs on the main thread
- report optimization, rendering, and comparison durations separately

## Motivation

`optimize()` is synchronous, so the previous `os.cpus().length * 2` async functions did not provide CPU parallelism. They only allowed multiple fixture reads to complete around the active optimization, increasing peak memory without parallelizing the expensive work.

This uses actual worker threads while bounding the number of concurrent large ASTs to two. Tasks contain only file paths, and workers return only checksums and byte counts.

## Benchmark

A local run over 256 fixtures sampled across the regression corpus:

- one Tinypool worker: 11.7 seconds
- two Tinypool workers: 6.6 seconds
- wall-time reduction: about 43%

The benchmark excludes the corpus's seven extreme 20–90 MB fixtures. The two-worker cap is intentionally conservative for those files and the 8 GiB CI environment.

## Verification

- `pnpm test` — 1,554 passed, 9 skipped
- `pnpm typecheck`
- `pnpm exec eslint test/regression/optimize.js test/regression/optimize-worker.js`
- `pnpm exec prettier --check test/regression/optimize.js test/regression/optimize-worker.js package.json pnpm-lock.yaml`
- `git diff --check`
- Tinypool worker smoke test verified optimization output, checksum, and byte metrics

The full regression corpus was not run locally because it is host-dependent and includes several very large fixtures.

