### PR TITLE
fix(removeScripts): handle anchor URL bypasses

### DIFF
--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -166,7 +166,12 @@ const executableDataMediaTypes = new Set([
  * @returns {boolean}
  */
 export const isExecutableUrl = (value) => {
-  const normalizedValue = value.trimStart().toLowerCase();
+  // Browsers remove ASCII tabs and newlines from URLs before parsing them.
+  // Normalize them here too so they cannot be embedded in a scheme name.
+  const normalizedValue = value
+    .replace(/[\t\n\r]/g, '')
+    .trimStart()
+    .toLowerCase();
 
   // `javascript:` is executable in modern browsers. `vbscript:` was only
   // implemented by legacy Internet Explorer, but rejecting it is inexpensive,

--- a/plugins/removeScripts.js
+++ b/plugins/removeScripts.js
@@ -19,6 +19,9 @@ const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 /** Namespaces that support SVG <foreignObject> elements. */
 const FOREIGN_OBJECT_NAMESPACES = [SVG_NAMESPACE];
 
+/** Namespaces that support SVG <a> elements. */
+const ANCHOR_NAMESPACES = [SVG_NAMESPACE];
+
 /** Namespaces that support executable <script> elements. */
 const SCRIPT_NAMESPACES = [SVG_NAMESPACE, 'http://www.w3.org/1999/xhtml'];
 
@@ -128,6 +131,12 @@ export const fn = () => {
           prefixes,
           FOREIGN_OBJECT_NAMESPACES,
         );
+        const isAnchor = isNamespaceAwareElem(
+          node.name,
+          'a',
+          prefixes,
+          ANCHOR_NAMESPACES,
+        );
 
         for (const k of Object.keys(node.attributes)) {
           if (!k.startsWith('xmlns:')) {
@@ -138,7 +147,7 @@ export const fn = () => {
           /** @type {string[]} */ (prefixes.get(prefix)).pop();
         }
 
-        if (node.name === 'a') {
+        if (isAnchor) {
           for (const attr of Object.keys(node.attributes)) {
             if (attr === 'href' || attr.endsWith(':href')) {
               if (

--- a/test/plugins/removeScripts.11.svg.txt
+++ b/test/plugins/removeScripts.11.svg.txt
@@ -1,0 +1,38 @@
+Collapses namespace-prefixed SVG anchors and links whose executable URL schemes
+contain ASCII tabs or newlines. Anchors in unrelated namespaces are preserved.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:custom="https://example.com/custom">
+  <svg:a xlink:href="javascript:alert(1)">
+    <text y="10">Prefixed anchor</text>
+  </svg:a>
+  <alias:a xmlns:alias="http://www.w3.org/2000/svg" href="javascript:alert(1)">
+    <text y="20">Locally declared prefix</text>
+  </alias:a>
+  <a href="java&#9;script:alert(1)">
+    <text y="30">Tab</text>
+  </a>
+  <a href="java&#10;script:alert(1)">
+    <text y="40">Line feed</text>
+  </a>
+  <a href="java&#13;script:alert(1)">
+    <text y="50">Carriage return</text>
+  </a>
+  <custom:a href="javascript:alert(1)">
+    <text y="60">Custom anchor</text>
+  </custom:a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:custom="https://example.com/custom">
+    <text y="10">Prefixed anchor</text>
+    <text y="20">Locally declared prefix</text>
+    <text y="30">Tab</text>
+    <text y="40">Line feed</text>
+    <text y="50">Carriage return</text>
+    <custom:a href="javascript:alert(1)">
+        <text y="60">Custom anchor</text>
+    </custom:a>
+</svg>


### PR DESCRIPTION
## Summary

- recognize namespace-prefixed SVG `<a>` elements when filtering executable links
- strip ASCII tabs, line feeds, and carriage returns before checking URL schemes
- add regression coverage for prefixed anchors, locally declared prefixes, control characters, and unrelated namespaces

## Security

Addresses [GHSA-w27v-7q3p-w38r](https://github.com/svg/svgo/security/advisories/GHSA-w27v-7q3p-w38r).

Browsers remove ASCII tabs and newlines from URLs before parsing the scheme. Matching that normalization prevents values such as `java&#9;script:` from bypassing executable URL detection.

## Validation

- `pnpm test` — 1,549 passed, 9 skipped
- `pnpm typecheck`
- ESLint on changed JavaScript files
- Prettier on changed JavaScript files
- `pnpm spellcheck`
- `git diff --check`
