### PR TITLE
fix(removeScriptElement): backport security hardening to v3

### DIFF
--- a/docs/03-plugins/remove-scripts.mdx
+++ b/docs/03-plugins/remove-scripts.mdx
@@ -17,8 +17,9 @@ This **will** break interactive SVGs that rely on JavaScript.
 This plugin performs the following operations:
 
 - Removes [`<script>`](https://developer.mozilla.org/docs/Web/SVG/Element/script) elements.
+- Sanitizes HTML inside [`<foreignObject>`](https://developer.mozilla.org/docs/Web/SVG/Element/foreignObject) elements by removing event attributes, `srcdoc`, and executable URLs from HTML URL attributes such as `action`, `data`, `formaction`, `href`, and `src`. The elements and other visual content are preserved.
 - Removes [SVG event attributes](https://developer.mozilla.org/docs/Web/SVG/Attribute/Events), such as `onload`, `onclick`, and `oninput`, preserving the element itself.
-- Collapses [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a) elements, moving children up to the parent element.
+- Collapses [`<a>`](https://developer.mozilla.org/docs/Web/SVG/Element/a) elements whose links use `javascript:`, legacy `vbscript:`, or an executable `data:` media type (`text/html`, `application/xhtml+xml`, or `image/svg+xml`), moving children up to the parent element.
 
 ## Usage
 

--- a/lib/svgo/tools.js
+++ b/lib/svgo/tools.js
@@ -145,6 +145,56 @@ const removeLeadingZero = (value) => {
 };
 exports.removeLeadingZero = removeLeadingZero;
 
+const executableDataMediaTypes = new Set([
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'text/html',
+]);
+
+/**
+ * Check whether a URL can contain executable content in a browser.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+const isExecutableUrl = (value) => {
+  // Browsers remove ASCII tabs and newlines from URLs before parsing them.
+  // Normalize them here too so they cannot be embedded in a scheme name.
+  const normalizedValue = value
+    .replace(/[\t\n\r]/g, '')
+    .trimStart()
+    .toLowerCase();
+
+  // `javascript:` is executable in modern browsers. `vbscript:` was only
+  // implemented by legacy Internet Explorer, but rejecting it is inexpensive,
+  // provides defense in depth for old environments, and keeps this security-
+  // oriented plugin's scheme denylist explicit and complete.
+  if (
+    normalizedValue.startsWith('javascript:') ||
+    normalizedValue.startsWith('vbscript:')
+  ) {
+    return true;
+  }
+
+  // A `data:` URL is not inherently executable: images and other inert media
+  // are common in SVGs and should remain intact. Only reject media types that
+  // browsers parse as active HTML, XHTML, or SVG documents.
+  if (!normalizedValue.startsWith('data:')) {
+    return false;
+  }
+
+  // Data URLs separate the media type from parameters with `;` and from the
+  // payload with `,`. A URL without either separator has no valid media type.
+  const mediaTypeEnd = normalizedValue.slice(5).search(/[;,]/);
+  if (mediaTypeEnd === -1) {
+    return false;
+  }
+
+  const mediaType = normalizedValue.slice(5, mediaTypeEnd + 5).trim();
+  return executableDataMediaTypes.has(mediaType);
+};
+exports.isExecutableUrl = isExecutableUrl;
+
 /**
  * If the current node contains any scripts. This does not check parents or
  * children of the node, only the properties and attributes of the node itself.
@@ -158,14 +208,14 @@ const hasScripts = (node) => {
   }
 
   if (node.name === 'a') {
-    const hasJsLinks = Object.entries(node.attributes).some(
+    const hasExecutableLinks = Object.entries(node.attributes).some(
       ([attrKey, attrValue]) =>
         (attrKey === 'href' || attrKey.endsWith(':href')) &&
         attrValue != null &&
-        attrValue.trimStart().toLowerCase().startsWith('javascript:'),
+        isExecutableUrl(attrValue),
     );
 
-    if (hasJsLinks) {
+    if (hasExecutableLinks) {
       return true;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@2.4.3",
   "name": "svgo",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Nodejs-based tool for optimizing SVG vector graphics files",
   "license": "MIT",
   "keywords": [

--- a/plugins/removeScriptElement.js
+++ b/plugins/removeScriptElement.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { detachNodeFromParent } = require('../lib/xast.js');
+const { isExecutableUrl } = require('../lib/svgo/tools.js');
 const { attrsGroups } = require('./_collections.js');
 
 exports.name = 'removeScriptElement';
@@ -15,11 +16,19 @@ const eventAttrs = [
   ...attrsGroups.graphicalEvent,
 ];
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/** Namespaces that support SVG <foreignObject> elements. */
+const FOREIGN_OBJECT_NAMESPACES = [SVG_NAMESPACE];
+
+/** Namespaces that support SVG <a> elements. */
+const ANCHOR_NAMESPACES = [SVG_NAMESPACE];
+
 /** Namespaces that support executable <script> elements. */
-const SCRIPT_NAMESPACES = [
-  'http://www.w3.org/2000/svg',
-  'http://www.w3.org/1999/xhtml',
-];
+const SCRIPT_NAMESPACES = [SVG_NAMESPACE, 'http://www.w3.org/1999/xhtml'];
+
+/** Attributes that can load or navigate to executable documents in HTML. */
+const HTML_URL_ATTRS = new Set(['action', 'data', 'formaction', 'href', 'src']);
 
 /**
  * @param {string} elem
@@ -62,6 +71,7 @@ exports.fn = () => {
    *
    * @type {Map<string, string[]>} */
   const prefixes = new Map();
+  let foreignObjectDepth = 0;
 
   return {
     element: {
@@ -81,19 +91,54 @@ exports.fn = () => {
         }
 
         if (
+          isNamespaceAwareElem(
+            node.name,
+            'foreignObject',
+            prefixes,
+            FOREIGN_OBJECT_NAMESPACES,
+          )
+        ) {
+          foreignObjectDepth += 1;
+        }
+
+        if (
           isNamespaceAwareElem(node.name, 'script', prefixes, SCRIPT_NAMESPACES)
         ) {
           detachNodeFromParent(node, parentNode);
           return;
         }
 
-        for (const attr of eventAttrs) {
-          if (node.attributes[attr] != null) {
+        for (const [attr, value] of Object.entries(node.attributes)) {
+          const localAttr = attr.slice(attr.lastIndexOf(':') + 1).toLowerCase();
+          const isEventAttr =
+            eventAttrs.includes(attr) ||
+            (foreignObjectDepth > 0 && localAttr.startsWith('on'));
+          const isEmbeddedDocumentAttr =
+            foreignObjectDepth > 0 && localAttr === 'srcdoc';
+          const isExecutableHtmlUrl =
+            foreignObjectDepth > 0 &&
+            HTML_URL_ATTRS.has(localAttr) &&
+            isExecutableUrl(value);
+
+          if (isEventAttr || isEmbeddedDocumentAttr || isExecutableHtmlUrl) {
             delete node.attributes[attr];
           }
         }
       },
       exit: (node, parentNode) => {
+        const isForeignObject = isNamespaceAwareElem(
+          node.name,
+          'foreignObject',
+          prefixes,
+          FOREIGN_OBJECT_NAMESPACES,
+        );
+        const isAnchor = isNamespaceAwareElem(
+          node.name,
+          'a',
+          prefixes,
+          ANCHOR_NAMESPACES,
+        );
+
         for (const k of Object.keys(node.attributes)) {
           if (!k.startsWith('xmlns:')) {
             continue;
@@ -103,33 +148,32 @@ exports.fn = () => {
           /** @type {string[]} */ (prefixes.get(prefix)).pop();
         }
 
-        if (node.name !== 'a') {
-          return;
-        }
+        if (isAnchor) {
+          for (const attr of Object.keys(node.attributes)) {
+            if (attr === 'href' || attr.endsWith(':href')) {
+              if (
+                node.attributes[attr] == null ||
+                !isExecutableUrl(node.attributes[attr])
+              ) {
+                continue;
+              }
 
-        for (const attr of Object.keys(node.attributes)) {
-          if (attr === 'href' || attr.endsWith(':href')) {
-            if (
-              node.attributes[attr] == null ||
-              !node.attributes[attr]
-                .trimStart()
-                .toLowerCase()
-                .startsWith('javascript:')
-            ) {
-              continue;
-            }
+              const index = parentNode.children.indexOf(node);
+              parentNode.children.splice(index, 1, ...node.children);
 
-            const index = parentNode.children.indexOf(node);
-            parentNode.children.splice(index, 1, ...node.children);
-
-            // TODO remove legacy parentNode in v4
-            for (const child of node.children) {
-              Object.defineProperty(child, 'parentNode', {
-                writable: true,
-                value: parentNode,
-              });
+              // TODO remove legacy parentNode in v4
+              for (const child of node.children) {
+                Object.defineProperty(child, 'parentNode', {
+                  writable: true,
+                  value: parentNode,
+                });
+              }
             }
           }
+        }
+
+        if (isForeignObject) {
+          foreignObjectDepth -= 1;
         }
       },
     },

--- a/test/plugins/removeScriptElement.09.svg
+++ b/test/plugins/removeScriptElement.09.svg
@@ -1,0 +1,34 @@
+Collapses links to executable data documents and legacy VBScript URLs while
+preserving data links with inert media types.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+  <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">
+    <text y="10">HTML</text>
+  </a>
+  <a uwu:href="DATA:application/xhtml+xml;charset=utf-8,%3Cscript%3Ealert(1)%3C/script%3E">
+    <text y="20">XHTML</text>
+  </a>
+  <a href="data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIi8+">
+    <text y="30">SVG</text>
+  </a>
+  <a href="data:image/png;base64,iVBORw0KGgo=">
+    <text y="40">PNG</text>
+  </a>
+  <a href="vbscript:msgbox(1)">
+    <text y="50">VBScript</text>
+  </a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:uwu="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+    <text y="10">HTML</text>
+    <text y="20">XHTML</text>
+    <text y="30">SVG</text>
+    <a href="data:image/png;base64,iVBORw0KGgo=">
+        <text y="40">PNG</text>
+    </a>
+    <text y="50">VBScript</text>
+</svg>

--- a/test/plugins/removeScriptElement.10.svg
+++ b/test/plugins/removeScriptElement.10.svg
@@ -1,0 +1,42 @@
+Sanitizes executable HTML inside foreignObject elements while preserving their
+visual content. Elements with the same local name in unrelated namespaces do
+not enable the additional HTML attribute handling.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:custom="https://example.com/custom">
+  <foreignObject width="300" height="300">
+    <xhtml:iframe srcdoc="&lt;script&gt;alert(document.domain)&lt;/script&gt;" src="https://example.com/content"/>
+    <xhtml:form action="javascript:alert(document.domain)" class="form"/>
+    <xhtml:object data="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;" title="Object"/>
+    <xhtml:div onbeforetoggle="alert(1)" style="color: red">Visual HTML</xhtml:div>
+    <xhtml:script>alert(1)</xhtml:script>
+  </foreignObject>
+  <svg:foreignObject width="300" height="300">
+    <xhtml:button formaction="vbscript:msgbox(1)">Button</xhtml:button>
+  </svg:foreignObject>
+  <custom:foreignObject srcdoc="Custom data">Non-executable custom content</custom:foreignObject>
+  <text>Safe SVG content</text>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:custom="https://example.com/custom">
+    <foreignObject width="300" height="300">
+        <xhtml:iframe src="https://example.com/content"/>
+        <xhtml:form class="form"/>
+        <xhtml:object title="Object"/>
+        <xhtml:div style="color: red">
+            Visual HTML
+        </xhtml:div>
+    </foreignObject>
+    <svg:foreignObject width="300" height="300">
+        <xhtml:button>
+            Button
+        </xhtml:button>
+    </svg:foreignObject>
+    <custom:foreignObject srcdoc="Custom data">
+        Non-executable custom content
+    </custom:foreignObject>
+    <text>Safe SVG content</text>
+</svg>

--- a/test/plugins/removeScriptElement.11.svg
+++ b/test/plugins/removeScriptElement.11.svg
@@ -1,0 +1,38 @@
+Collapses namespace-prefixed SVG anchors and links whose executable URL schemes
+contain ASCII tabs or newlines. Anchors in unrelated namespaces are preserved.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:custom="https://example.com/custom">
+  <svg:a xlink:href="javascript:alert(1)">
+    <text y="10">Prefixed anchor</text>
+  </svg:a>
+  <alias:a xmlns:alias="http://www.w3.org/2000/svg" href="javascript:alert(1)">
+    <text y="20">Locally declared prefix</text>
+  </alias:a>
+  <a href="java&#9;script:alert(1)">
+    <text y="30">Tab</text>
+  </a>
+  <a href="java&#10;script:alert(1)">
+    <text y="40">Line feed</text>
+  </a>
+  <a href="java&#13;script:alert(1)">
+    <text y="50">Carriage return</text>
+  </a>
+  <custom:a href="javascript:alert(1)">
+    <text y="60">Custom anchor</text>
+  </custom:a>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:custom="https://example.com/custom">
+    <text y="10">Prefixed anchor</text>
+    <text y="20">Locally declared prefix</text>
+    <text y="30">Tab</text>
+    <text y="40">Line feed</text>
+    <text y="50">Carriage return</text>
+    <custom:a href="javascript:alert(1)">
+        <text y="60">Custom anchor</text>
+    </custom:a>
+</svg>


### PR DESCRIPTION
## Summary

Backport the v4 `removeScripts` security hardening to v3's `removeScriptElement` plugin:

- reject executable `data:` URLs and legacy `vbscript:` URLs while preserving inert data URLs
- sanitize executable content inside SVG `foreignObject` elements
- recognize namespace-prefixed SVG anchors
- normalize ASCII tabs and newlines before checking URL schemes
- add v3 regression coverage and update the plugin documentation

This backports the fixes from #2263, #2264, and #2268 and addresses GHSA-4vpr-x523-8j87 and GHSA-w27v-7q3p-w38r for the v3 release line.

## Validation

- `yarn test` — 425 passed, 3 skipped
- `yarn lint`
- `yarn typecheck`
- `git diff --check`
