### PR TITLE
ci: publish v3 with npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,25 +10,14 @@ permissions:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
+      - run: corepack enable
+      - run: npm install --global npm@11.5.1
       - run: yarn install
-      - run: |
-          VERSION=$(jq -r .version <package.json)
-          if [[ "$VERSION" = *"-rc."* ]]; then
-            yarn npm publish --access public --tag rc
-          else
-            LATEST_VERSION="$(gh release view --json tagName -q '.tagName' --repo ${{ github.repository }})"
-            if [[ "${{ github.ref_name }}" = "$LATEST_VERSION" ]]; then
-              yarn npm publish --access public
-            else
-              MAJOR="$(awk -F '.' '{ print $1 }' <<< "$VERSION")"
-              yarn npm publish --access public --tag "v$MAJOR"
-            fi
-          fi
+      - run: yarn prepublishOnly
+      - run: npm publish --ignore-scripts --access public --tag v3


### PR DESCRIPTION
## Summary

- switch the v3 publish workflow from Yarn's publisher to npm 11.5.1 so npm trusted publishing can use GitHub OIDC
- build the package with Yarn before invoking npm with lifecycle scripts disabled
- always publish this release line under the `v3` dist-tag
- use Node.js 24 for publishing

This fixes the authentication failure observed while publishing v3.3.5 (`YN0033: No authentication configured for request`).
