### PR TITLE
ci: configure v3 publish tag in package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,4 +20,4 @@ jobs:
       - run: npm install --global npm@11.5.1
       - run: yarn install
       - run: yarn prepublishOnly
-      - run: npm publish --ignore-scripts --access public --tag v3
+      - run: npm publish --ignore-scripts --access public

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
   "engines": {
     "node": ">=14.0.0"
   },
+  "publishConfig": {
+    "tag": "v3"
+  },
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=4 --coverage",
     "lint": "eslint --ignore-path .gitignore . && prettier --check . --ignore-path .gitignore",


### PR DESCRIPTION
## Summary

Configure `v3` through `publishConfig.tag` and let `npm publish` consume it.

npm 11 rejects `--tag v3` at the CLI because `v3` is a valid semver range, even though this package already uses `v3` as an established registry dist-tag. `publishConfig` passes the tag to the registry publisher without the CLI's semver-range validation, preserving the existing dist-tag.
