### PR TITLE
chore: prepare v2.8.4 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,25 +10,14 @@ permissions:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
           registry-url: https://registry.npmjs.org
+      - run: corepack enable
+      - run: npm install --global npm@11.5.1
       - run: yarn install
-      - run: |
-          VERSION=$(jq -r .version <package.json)
-          if [[ "$VERSION" = *"-rc."* ]]; then
-            yarn npm publish --access public --tag rc
-          else
-            LATEST_VERSION="$(gh release view --json tagName -q '.tagName' --repo ${{ github.repository }})"
-            if [[ "${{ github.ref_name }}" = "$LATEST_VERSION" ]]; then
-              yarn npm publish --access public
-            else
-              MAJOR="$(awk -F '.' '{ print $1 }' <<< "$VERSION")"
-              yarn npm publish --access public --tag "v$MAJOR"
-            fi
-          fi
+      - run: yarn prepublishOnly
+      - run: npm publish --ignore-scripts --access public

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@2.4.3",
   "name": "svgo",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Nodejs-based tool for optimizing SVG vector graphics files",
   "license": "MIT",
   "keywords": [
@@ -50,6 +50,9 @@
   ],
   "engines": {
     "node": ">=10.13.0"
+  },
+  "publishConfig": {
+    "tag": "v2"
   },
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=4 --coverage",


### PR DESCRIPTION
## Summary

- bump the v2 release line to 2.8.4
- publish with npm 11.5.1 and GitHub OIDC trusted publishing so the package receives signed provenance
- configure the established `v2` dist-tag through `publishConfig.tag`
- build with Yarn before publishing with npm

The `publishConfig` route preserves the existing `v2` tag while avoiding npm CLI's rejection of `--tag v2` as a semver range.
