### PR TITLE
ci: build v2 releases with Node.js 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
+          node-version: 16
       - run: corepack enable
-      - run: npm install --global npm@11.5.1
       - run: yarn install
       - run: yarn prepublishOnly
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - run: npm install --global npm@11.5.1
       - run: npm publish --ignore-scripts --access public


### PR DESCRIPTION
## Summary

Build v2 releases under Node.js 16 before switching to Node.js 24 and npm 11.5.1 for trusted publishing.

Yarn 2.4.3 and its compatibility patches are not compatible with Node.js 24 (`isDate is not a function`). Keeping the legacy build on Node.js 16 while using the modern npm runtime for publication preserves compatibility and signed provenance.
