### PR TITLE
chore: prepare v4.1.0 release

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -4,4 +4,4 @@
  * @type {string}
  * @since 4.0.0
  */
-export const VERSION = '4.0.2';
+export const VERSION = '4.1.0';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "pnpm@10.34.5",
   "name": "svgo",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "SVGO is a Node.js library and command-line application for optimizing vector images.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Prepare SVGO v4.1.0 by synchronizing the package and runtime versions.

The release includes stricter XML character-reference validation from sax 1.6.1 and security hardening for `removeScripts`.

Validation:
- typecheck passed
- bundle tests passed
- scoped ESLint and Prettier checks passed
- main test suite passed (1,549 tests; the root command additionally discovered unrelated local `.worktrees`)