### PR TITLE
chore: secure actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: &setup-node-config
           node-version: 24
           cache: pnpm
@@ -23,18 +25,22 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
       - run: pnpm spellcheck
@@ -52,9 +58,11 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -63,9 +71,11 @@ jobs:
   test-browser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
       - run: pnpm playwright install --with-deps --only-shell chromium
@@ -83,13 +93,15 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with: *setup-node-config
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:bundles
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: node ./test/svgo.cjs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,14 +19,14 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: 'javascript'
           queries: +security-and-quality
-      - uses: github/codeql-action/autobuild@v4
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: '/language:javascript'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,15 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - run: pnpm install --frozen-lockfile
       - run: |
           VERSION=$(jq -r .version <package.json)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           if [[ "$VERSION" = *"-rc."* ]]; then
             pnpm publish --access public --tag rc --no-git-checks
           else
-            LATEST_VERSION="$(gh release view --json tagName -q '.tagName' --repo ${{ github.repository }})"
+            LATEST_VERSION="$(gh release view --json tagName -q '.tagName' --repo "$GH_REPOSITORY")"
             if [[ "v$VERSION" = "$LATEST_VERSION" ]]; then
               pnpm publish --access public --no-git-checks
             else
@@ -36,3 +36,5 @@ jobs:
               pnpm publish --access public --tag "v$MAJOR" --no-git-checks
             fi
           fi
+        env:
+          GH_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -72,6 +72,11 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: gh run download -R ${{ env.REPO }} -n svgo-test-report-${{ github.sha }} -D .cache/reports/head/
-      - run: gh run download -R ${{ env.REPO }} -n svgo-test-report -D .cache/reports/main/
+      - run: gh run download -R "$REPO" -n "svgo-test-report-$SHA" -D .cache/reports/head/
+        env:
+          REPO: ${{ env.REPO }}
+          SHA: ${{ github.sha }}
+      - run: gh run download -R "$REPO" -n svgo-test-report -D .cache/reports/main/
+        env:
+          REPO: ${{ env.REPO }}
       - run: ./test/regression/delta.js .cache/reports/main/svgo-test-report.json .cache/reports/head/svgo-test-report.json

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -22,16 +22,18 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm playwright install --with-deps --only-shell chromium
       - run: node ./test/regression/extract.js
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .cache/svgo-regression/screenshots
           key: regression-screenshots-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.cache/svgo-regression/test-suite/regression-fixtures/VERSION') }}-${{ github.sha }}
@@ -40,14 +42,14 @@ jobs:
       - run: node ./test/regression/compare.js --no-diff
       # We use upload/artifacts instead of outputs because our regression test
       # report can exceed 1 MB which is a limit GitHub imposes.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: (success() || failure()) && github.event_name == 'pull_request'
         with:
           name: svgo-test-report-${{ github.sha }}
           path: .cache/svgo-regression/runs/${{ github.sha }}/svgo-test-report.json
           if-no-files-found: error
           retention-days: 1
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: (success() || failure()) && github.event_name != 'pull_request'
         with:
           name: svgo-test-report
@@ -61,9 +63,11 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
As some months ago there have been a few incidents with attackers taking hijacking GitHub actions, I have applied some of the recommendations recommended by the the [zizmor](https://docs.zizmor.sh/) tool: 

 - Pin actions versions to commit hash
 - Do not persist checkout credentials
 - Disable package manager cache in the publish workflow
- add dependabot cooldown delay
- handle variables more safely

I think the last step is in some cases redundant, as the attacker is unlikely to get control of `github.*` input variables, but I have defined everything as env parameters for consistency, since there should be no disadvantage for doing so.