### PR TITLE
perf: compile stylesheet selectors once per document

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -1,7 +1,7 @@
 import * as csstree from 'css-tree';
 import * as csswhat from 'css-what';
 import { syntax } from 'csso';
-import { matches } from './xast.js';
+import { compileSelector } from './xast.js';
 import { visit } from './util/visit.js';
 import {
   attrsGroups,
@@ -119,12 +119,38 @@ const parseStyleDeclarations = (css) => {
 };
 
 /**
+ * Selectors are recompiled by css-select on every `matches` call, which is
+ * O(nodes x rules) for a stylesheet. Compile each rule once per stylesheet.
+ *
+ * @type {WeakMap<import('./types.js').Stylesheet, Map<string, (node: any) => boolean>>}
+ */
+const matcherCache = new WeakMap();
+
+/**
+ * @param {import('./types.js').Stylesheet} stylesheet
+ * @param {string} selector
+ * @returns {(node: import('./types.js').XastElement) => boolean}
+ */
+const getMatcher = (stylesheet, selector) => {
+  let cache = matcherCache.get(stylesheet);
+  if (cache == null) {
+    cache = new Map();
+    matcherCache.set(stylesheet, cache);
+  }
+  let matcher = cache.get(selector);
+  if (matcher == null) {
+    matcher = compileSelector(selector, stylesheet.parents);
+    cache.set(selector, matcher);
+  }
+  return matcher;
+};
+
+/**
  * @param {import('./types.js').Stylesheet} stylesheet
  * @param {import('./types.js').XastElement} node
- * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {import('./types.js').ComputedStyles}
  */
-const computeOwnStyle = (stylesheet, node, parents) => {
+const computeOwnStyle = (stylesheet, node) => {
   /** @type {import('./types.js').ComputedStyles} */
   const computedStyle = {};
   const importantStyles = new Map();
@@ -139,7 +165,7 @@ const computeOwnStyle = (stylesheet, node, parents) => {
 
   // collect matching rules
   for (const { selector, declarations, dynamic } of stylesheet.rules) {
-    if (matches(node, selector, parents)) {
+    if (getMatcher(stylesheet, selector)(node)) {
       for (const { name, value, important } of declarations) {
         const computed = computedStyle[name];
         if (computed && computed.type === 'dynamic') {
@@ -252,10 +278,10 @@ export const collectStylesheet = (root) => {
  */
 export const computeStyle = (stylesheet, node) => {
   const { parents } = stylesheet;
-  const computedStyles = computeOwnStyle(stylesheet, node, parents);
+  const computedStyles = computeOwnStyle(stylesheet, node);
   let parent = parents.get(node);
   while (parent != null && parent.type !== 'root') {
-    const inheritedStyles = computeOwnStyle(stylesheet, parent, parents);
+    const inheritedStyles = computeOwnStyle(stylesheet, parent);
     for (const [name, computed] of Object.entries(inheritedStyles)) {
       if (
         computedStyles[name] == null &&

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -413,3 +413,38 @@ it('ignores @-o-keyframes atrule', () => {
     },
   });
 });
+
+it('matches ancestor dependent selectors per document', () => {
+  const nested = parseSvg(`
+      <svg>
+        <style>
+          g .a { fill: red; }
+        </style>
+        <g>
+          <rect id="element" class="a" />
+        </g>
+      </svg>
+    `);
+  const flat = parseSvg(`
+      <svg>
+        <style>
+          g .a { fill: red; }
+        </style>
+        <rect id="element" class="a" />
+      </svg>
+    `);
+  // selectors are compiled and cached per stylesheet, so an identical selector
+  // in another document must still be resolved against that document's tree
+  const flatStylesheet = collectStylesheet(flat);
+  const nestedStylesheet = collectStylesheet(nested);
+  // the document without the ancestor is resolved first on purpose, so a
+  // matcher cached from it cannot satisfy the nested document afterwards
+  expect(
+    computeStyle(flatStylesheet, getElementById(flat, 'element')),
+  ).toStrictEqual({});
+  expect(
+    computeStyle(nestedStylesheet, getElementById(nested, 'element')),
+  ).toStrictEqual({
+    fill: { type: 'static', inherited: false, value: 'red' },
+  });
+});

--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -34,20 +34,34 @@ const hasAttrib = (elem, name) => {
 };
 
 /**
+ * Adapter over an already known node to parent mapping, so the same instance
+ * can be reused across nodes.
+ *
+ * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>} parents
+ * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
+ */
+export function createAdapterFromParents(parents) {
+  return createAdapterWithParentLookup((node) => parents.get(node) || null);
+}
+
+/**
  * @param {import('../types.js').XastParent} relativeNode
  * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>=} parents
  * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
  */
 export function createAdapter(relativeNode, parents) {
-  /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getParent']} */
-  const getParent = (node) => {
-    if (!parents) {
-      parents = mapNodesToParents(relativeNode);
-    }
+  return createAdapterWithParentLookup((node) => {
+    parents ??= mapNodesToParents(relativeNode);
 
     return parents.get(node) || null;
-  };
+  });
+}
 
+/**
+ * @param {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getParent']} getParent
+ * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
+ */
+function createAdapterWithParentLookup(getParent) {
   /**
    * @param {any} elem
    * @returns {any}

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -1,5 +1,8 @@
-import { is, selectAll, selectOne } from 'css-select';
-import { createAdapter } from './svgo/css-select-adapter.js';
+import { compile, is, selectAll, selectOne } from 'css-select';
+import {
+  createAdapter,
+  createAdapterFromParents,
+} from './svgo/css-select-adapter.js';
 
 /**
  * @param {import('./types.js').XastParent} relativeNode
@@ -10,6 +13,17 @@ function createCssSelectOptions(relativeNode, parents) {
   return {
     xmlMode: true,
     adapter: createAdapter(relativeNode, parents),
+  };
+}
+
+/**
+ * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>} parents
+ * @returns {import('css-select').Options<import('./types.js').XastNode & { children?: any }, import('./types.js').XastElement>}
+ */
+function createCssSelectOptionsFromParents(parents) {
+  return {
+    xmlMode: true,
+    adapter: createAdapterFromParents(parents),
   };
 }
 
@@ -31,6 +45,20 @@ export const querySelectorAll = (node, selector, parents) => {
  */
 export const querySelector = (node, selector, parents) => {
   return selectOne(selector, node, createCssSelectOptions(node, parents));
+};
+
+/**
+ * Compiles a CSS selector once so it can be tested against many nodes.
+ *
+ * @param {string} selector CSS selector string.
+ * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>} parents
+ * @returns {(node: import('./types.js').XastElement) => boolean}
+ */
+export const compileSelector = (selector, parents) => {
+  if (selector === '') {
+    return () => false;
+  }
+  return compile(selector, createCssSelectOptionsFromParents(parents));
 };
 
 /**

--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -105,27 +105,31 @@ export const fn = (root, params) => {
       : false;
   const attrs = Array.isArray(params.attrs) ? params.attrs : [params.attrs];
 
+  // patterns are static, so compile them once instead of on every element
+  const patterns = attrs.map((attr) => {
+    let pattern = attr;
+    // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
+    if (!pattern.includes(elemSeparator)) {
+      pattern = ['.*', pattern, '.*'].join(elemSeparator);
+      // if only 1 separator, assume it's element and attribute name, and apply regardless of attribute value
+    } else if (pattern.split(elemSeparator).length < 3) {
+      pattern = [pattern, '.*'].join(elemSeparator);
+    }
+
+    // create regexps for element, attribute name, and attribute value
+    return pattern.split(elemSeparator).map((value) => {
+      // adjust single * to match anything
+      if (value === '*') {
+        value = '.*';
+      }
+      return new RegExp(['^', value, '$'].join(''), 'i');
+    });
+  });
+
   return {
     element: {
       enter: (node) => {
-        for (let pattern of attrs) {
-          // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
-          if (!pattern.includes(elemSeparator)) {
-            pattern = ['.*', pattern, '.*'].join(elemSeparator);
-            // if only 1 separator, assume it's element and attribute name, and apply regardless of attribute value
-          } else if (pattern.split(elemSeparator).length < 3) {
-            pattern = [pattern, '.*'].join(elemSeparator);
-          }
-
-          // create regexps for element, attribute name, and attribute value
-          const list = pattern.split(elemSeparator).map((value) => {
-            // adjust single * to match anything
-            if (value === '*') {
-              value = '.*';
-            }
-            return new RegExp(['^', value, '$'].join(''), 'i');
-          });
-
+        for (const list of patterns) {
           // matches element
           if (list[0].test(node.name)) {
             // loop attributes

--- a/test/plugins/removeAttrs.08.svg.txt
+++ b/test/plugins/removeAttrs.08.svg.txt
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke="blue" opacity="0.5" cx="60" cy="60" r="50"/>
+    <path fill="red" stroke="blue" opacity="1" d="M0 0"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle stroke="blue" cx="60" cy="60" r="50"/>
+    <path opacity="1" d="M0 0"/>
+</svg>
+
+@@@
+
+{"attrs":["fill","path:stroke","*:opacity:0.5"]}

--- a/test/plugins/removeAttrs.09.svg.txt
+++ b/test/plugins/removeAttrs.09.svg.txt
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <path fill="red" stroke="blue" d="M0 0"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path stroke="blue" d="M0 0"/>
+</svg>
+
+@@@
+
+{"attrs":["svg|version","path|fill"],"elemSeparator":"|"}


### PR DESCRIPTION
We saw some minor slowdowns when benchmarking our SVG icons workflow with complex SVGs. There are two hot paths recompile static patterns once per element today, and have been fixed here. Pure performance changes: no API change, no config change, byte-identical output.

**1. Stylesheet selectors.** `computeOwnStyle` tests every rule against every element via `matches()`, and css-select parses and compiles the selector string on every call, building a fresh `RegExp` per attribute selector. A document with R rules and E elements pays R × E compilations, multiplied again by tree depth as `computeStyle` walks ancestors. `stylesheet.parents` is already stable, so the compiled matcher is now cached per stylesheet.

**2. `removeAttrs` patterns.** The element/name/value regexes were built inside the element visitor, recompiling every configured pattern for every element, though the patterns come from static config. Moved to plugin init.

## Benchmarks

Synthetic Illustrator-style documents (one class per shape, one stylesheet), Node 24, best of 5:

| Document | before | after | |
| --- | --- | --- | --- |
| 10 rules × 100 shapes | 35.0 ms | 11.9 ms | 2.9× |
| 50 rules × 300 shapes | 383.4 ms | 59.3 ms | 6.5× |
| 100 rules × 600 shapes | 1670.2 ms | 106.8 ms | 15.6× |
| `removeAttrs`, 4 patterns, 600 elements | 7.2 ms | 3.7 ms | 1.9× |

The ratio widens with document size because the old behaviour was quadratic in rules × elements. On a real set of 330 Illustrator-exported icons, a production pipeline (~30 plugins, `multipass`) goes from 835 ms to 552 ms (1.51×); with stock `preset-default`, 1.11×.

<details>
<summary>Benchmark script (repo root, <code>node bench-pr.mjs</code>)</summary>

```js
import { optimize } from './lib/svgo.js';

const makeSvg = (rules, shapes) => {
	const css = Array.from({ length: rules }, (_, i) => `.st${i}{fill:#${(i * 7919 % 0xffffff).toString(16).padStart(6, '0')};}`).join('');
	const body = Array.from({ length: shapes }, (_, i) => `<path class="st${i % rules}" d="M${i % 32} ${Math.floor(i / 32) % 32}h4v4h-4z"/>`).join('');
	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><style>${css}</style>${body}</svg>`;
};

const time = (label, input, config, iters) => {
	for (let i = 0; i < 3; i++) optimize(input, config);
	let best = Infinity;
	for (let r = 0; r < 5; r++) {
		const t = performance.now();
		for (let i = 0; i < iters; i++) optimize(input, config);
		best = Math.min(best, (performance.now() - t) / iters);
	}
	console.log(`${label.padEnd(40)} ${best.toFixed(1).padStart(8)} ms`);
};

for (const [rules, shapes] of [[10, 100], [50, 300], [100, 600]]) {
	time(`${rules} rules x ${shapes} shapes`, makeSvg(rules, shapes), { multipass: true }, 3);
}
time('removeAttrs, 4 patterns', makeSvg(1, 600).replace(/<style>.*<\/style>/, ''), {
	plugins: [{ name: 'removeAttrs', params: { attrs: ['fill', 'stroke', 'class', 'style'] } }],
}, 20);
```