### PR TITLE
perf(removeHiddenElems): cache computed styles

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -136,11 +136,15 @@ const readNumber = (string, cursor) => {
 
 /**
  * @param {string} string
+ * @param {number=} maxItems Stop parsing after this many path data items.
  * @returns {import('./types.js').PathDataItem[]}
  */
-export const parsePathData = (string) => {
+export const parsePathData = (string, maxItems = Number.POSITIVE_INFINITY) => {
   /** @type {import('./types.js').PathDataItem[]} */
   const pathData = [];
+  if (maxItems <= 0) {
+    return pathData;
+  }
   /** @type {?import('./types.js').PathDataCommand} */
   let command = null;
   let args = /** @type {number[]} */ ([]);
@@ -180,6 +184,9 @@ export const parsePathData = (string) => {
       // flush command without arguments
       if (argsCount === 0) {
         pathData.push({ command, args });
+        if (pathData.length >= maxItems) {
+          return pathData;
+        }
       }
       continue;
     }
@@ -227,6 +234,9 @@ export const parsePathData = (string) => {
         args[1] = Math.abs(args[1]);
       }
       pathData.push({ command, args });
+      if (pathData.length >= maxItems) {
+        return pathData;
+      }
       // subsequent moveto coordinates are treated as implicit lineto commands
       if (command === 'M') {
         command = 'L';

--- a/lib/path.test.js
+++ b/lib/path.test.js
@@ -85,6 +85,13 @@ describe('parse path data', () => {
       { command: 'a', args: [50, 60, 0, 1, 0, 70, 80] },
     ]);
   });
+  it('should stop after the requested number of items', () => {
+    expect(parsePathData('M0 0', 0)).toStrictEqual([]);
+    expect(parsePathData('M0 0 10 10L20 20', 2)).toStrictEqual([
+      { command: 'M', args: [0, 0] },
+      { command: 'L', args: [10, 10] },
+    ]);
+  });
 });
 
 describe('stringify path data', () => {

--- a/lib/style.js
+++ b/lib/style.js
@@ -248,14 +248,24 @@ export const collectStylesheet = (root) => {
 /**
  * @param {import('./types.js').Stylesheet} stylesheet
  * @param {import('./types.js').XastElement} node
+ * @param {WeakMap<import('./types.js').XastElement, import('./types.js').ComputedStyles>=} cache
+ *   Cache to reuse while the stylesheet and element attributes are unchanged.
  * @returns {import('./types.js').ComputedStyles}
  */
-export const computeStyle = (stylesheet, node) => {
+export const computeStyle = (stylesheet, node, cache) => {
+  const cachedStyles = cache?.get(node);
+  if (cachedStyles != null) {
+    return cachedStyles;
+  }
+
   const { parents } = stylesheet;
   const computedStyles = computeOwnStyle(stylesheet, node, parents);
   let parent = parents.get(node);
   while (parent != null && parent.type !== 'root') {
-    const inheritedStyles = computeOwnStyle(stylesheet, parent, parents);
+    const inheritedStyles =
+      cache == null
+        ? computeOwnStyle(stylesheet, parent, parents)
+        : computeStyle(stylesheet, parent, cache);
     for (const [name, computed] of Object.entries(inheritedStyles)) {
       if (
         computedStyles[name] == null &&
@@ -265,8 +275,13 @@ export const computeStyle = (stylesheet, node) => {
         computedStyles[name] = { ...computed, inherited: true };
       }
     }
+    // Cached styles already include styles inherited from all higher ancestors.
+    if (cache != null) {
+      break;
+    }
     parent = parents.get(parent);
   }
+  cache?.set(node, computedStyles);
   return computedStyles;
 };
 

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -85,6 +85,25 @@ it('collects styles', () => {
   });
 });
 
+it('caches computed and inherited styles', () => {
+  const root = parseSvg(`
+    <svg fill="red">
+      <g id="parent">
+        <rect id="child" />
+      </g>
+    </svg>
+  `);
+  const stylesheet = collectStylesheet(root);
+  const child = getElementById(root, 'child');
+  const cache = new WeakMap();
+  const computed = computeStyle(stylesheet, child, cache);
+
+  expect(computed).toStrictEqual(computeStyle(stylesheet, child));
+  expect(computeStyle(stylesheet, child, cache)).toBe(computed);
+  expect(cache.has(child)).toBe(true);
+  expect(cache.has(getElementById(root, 'parent'))).toBe(true);
+});
+
 it('prioritizes different kinds of styles', () => {
   const root = parseSvg(`
       <svg>

--- a/plugins/removeHiddenElems.js
+++ b/plugins/removeHiddenElems.js
@@ -68,6 +68,25 @@ export const fn = (root, params) => {
   } = params;
   const stylesheet = collectStylesheet(root);
 
+  /** @type {WeakMap<import('../lib/types.js').XastElement, import('../lib/types.js').ComputedStyles>} */
+  const computedStyles = new WeakMap();
+
+  /**
+   * Computing styles walks the node's ancestors and matches every stylesheet
+   * rule. This plugin visits most rendered elements twice, but does not mutate
+   * their attributes, so reuse the result between passes.
+   *
+   * @param {import('../lib/types.js').XastElement} node
+   * @returns {import('../lib/types.js').ComputedStyles}
+   */
+  const getComputedStyle = (node) => {
+    let computedStyle = computedStyles.get(node);
+    if (computedStyle == null) {
+      computedStyle = computeStyle(stylesheet, node, computedStyles);
+    }
+    return computedStyle;
+  };
+
   /**
    * Skip non-rendered nodes initially, and only detach if they have no ID, or
    * their ID is not referenced by another node.
@@ -139,7 +158,7 @@ export const fn = (root, params) => {
           nonRenderedNodes.set(node, parentNode);
           return visitSkip;
         }
-        const computedStyle = computeStyle(stylesheet, node);
+        const computedStyle = getComputedStyle(node);
         // opacity="0"
         //
         // https://www.w3.org/TR/SVG11/masking.html#ObjectAndGroupOpacityProperties
@@ -362,7 +381,7 @@ export const fn = (root, params) => {
 
         // Removes hidden elements
         // https://www.w3schools.com/cssref/pr_class_visibility.asp
-        const computedStyle = computeStyle(stylesheet, node);
+        const computedStyle = getComputedStyle(node);
         if (
           isHidden &&
           computedStyle.visibility &&
@@ -402,7 +421,7 @@ export const fn = (root, params) => {
             removeElement(node, parentNode);
             return;
           }
-          const pathData = parsePathData(node.attributes.d);
+          const pathData = parsePathData(node.attributes.d, 2);
           if (pathData.length === 0) {
             removeElement(node, parentNode);
             return;


### PR DESCRIPTION
## Summary

- cache computed styles while `removeHiddenElems` makes its two traversal passes
- optionally cache inherited styles in `computeStyle`, avoiding repeated ancestor traversal and selector matching
- stop parsing path data after two items because `removeHiddenElems` only needs to distinguish empty, single-point, and renderable paths

## Benchmark

Benchmarked against the regression fixture suite at `77ba065b4e4b4902c8795921287f9cf7`, using all Charm and Oxygen icon fixtures:

- 4,592 SVG files (263 Charm and 4,329 Oxygen)
- default preset, single pass, `floatPrecision: 4`
- two worker threads
- Node.js 22.23.2 on Linux x86-64
- phase timings are elapsed time summed across workers

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall time | 209.71s | 172.71s | -17.6% |
| `removeHiddenElems` | 58.35s | 27.21s | **-53.4%** |
| `removeHiddenElems` share | 14.6% | 8.3% | -6.3 pp |
| `removeHiddenElems` rank | 2nd | 4th | -2 places |

The full after profile was:

| Phase | Before | After | After share |
| --- | ---: | ---: | ---: |
| `convertPathData` | 70.36s | 72.94s | 22.1% |
| `removeHiddenElems` | 58.35s | 27.21s | 8.3% |
| `minifyStyles` | 50.95s | 51.21s | 15.5% |
| `mergePaths` | 27.86s | 28.21s | 8.6% |
| `removeUselessStrokeAndFill` | 23.98s | 26.23s | 8.0% |
| `convertTransform` | 18.56s | 18.47s | 5.6% |
| `cleanupEnableBackground` | 14.30s | 14.19s | 4.3% |
| `removeUnknownsAndDefaults` | 13.16s | 13.72s | 4.2% |
| `cleanupIds` | 10.69s | 10.48s | 3.2% |
| serializer | 3.33s | 3.43s | 1.0% |

Because parallel phase timings include GC and worker contention, unrelated phases vary between runs. The `removeHiddenElems` result was also checked separately on a deterministic every-tenth-file Oxygen sample (433 files): **6.52s before vs 2.96s after (-54.6%)**.

Optimized output was compared against the baseline for a deterministic 460-file Charm/Oxygen sample with no differences.

## Tests

- `pnpm typecheck`
- `pnpm exec vitest run lib/path.test.js lib/style.test.js test/plugins/_index.test.js --exclude '.worktrees/**'` (407 tests)
- ESLint and Prettier on changed files
