### PR TITLE
perf: cache parsed inline style declarations

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -12,6 +12,15 @@ import {
 const csstreeWalkSkip = csstree.walk.skip;
 
 /**
+ * Parsed inline styles shared by stylesheet snapshots of the same AST. Values
+ * are keyed by the style string rather than the node, so attribute updates
+ * cannot return stale declarations. The cache is released with the AST.
+ *
+ * @type {WeakMap<import('./types.js').XastRoot, Map<string, import('./types.js').StylesheetDeclaration[]>>}
+ */
+const declarationCaches = new WeakMap();
+
+/**
  * @param {import('css-tree').Rule} ruleNode
  * @param {boolean} dynamic
  * @returns {import('./types.js').StylesheetRule[]}
@@ -162,10 +171,19 @@ const computeOwnStyle = (stylesheet, node, parents) => {
   }
 
   // collect inline styles
-  const styleDeclarations =
-    node.attributes.style == null
-      ? []
-      : parseStyleDeclarations(node.attributes.style);
+  /** @type {import('./types.js').StylesheetDeclaration[]} */
+  let styleDeclarations = [];
+  if (node.attributes.style != null) {
+    const cachedDeclarations = stylesheet.declarationCache.get(
+      node.attributes.style,
+    );
+    if (cachedDeclarations == null) {
+      styleDeclarations = parseStyleDeclarations(node.attributes.style);
+      stylesheet.declarationCache.set(node.attributes.style, styleDeclarations);
+    } else {
+      styleDeclarations = cachedDeclarations;
+    }
+  }
   for (const { name, value, important } of styleDeclarations) {
     const computed = computedStyle[name];
     if (computed && computed.type === 'dynamic') {
@@ -242,7 +260,12 @@ export const collectStylesheet = (root) => {
   });
   // sort by selectors specificity
   rules.sort((a, b) => compareSpecificity(a.specificity, b.specificity));
-  return { rules, parents };
+  let declarationCache = declarationCaches.get(root);
+  if (declarationCache == null) {
+    declarationCache = new Map();
+    declarationCaches.set(root, declarationCache);
+  }
+  return { rules, parents, declarationCache };
 };
 
 /**

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -85,6 +85,38 @@ it('collects styles', () => {
   });
 });
 
+it('caches inline declarations by style value', () => {
+  const root = parseSvg(`
+    <svg>
+      <rect id="one" style="fill: red" />
+      <rect id="two" style="fill: red" />
+    </svg>
+  `);
+  const stylesheet = collectStylesheet(root);
+  const one = getElementById(root, 'one');
+  const two = getElementById(root, 'two');
+
+  expect(computeStyle(stylesheet, one).fill).toStrictEqual({
+    type: 'static',
+    inherited: false,
+    value: 'red',
+  });
+  expect(computeStyle(stylesheet, two).fill).toStrictEqual({
+    type: 'static',
+    inherited: false,
+    value: 'red',
+  });
+  expect(stylesheet.declarationCache.size).toBe(1);
+
+  two.attributes.style = 'fill: blue';
+  expect(computeStyle(stylesheet, two).fill).toStrictEqual({
+    type: 'static',
+    inherited: false,
+    value: 'blue',
+  });
+  expect(stylesheet.declarationCache.size).toBe(2);
+});
+
 it('prioritizes different kinds of styles', () => {
   const root = parseSvg(`
       <svg>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -289,6 +289,7 @@ export type StylesheetRule = {
 export type Stylesheet = {
   rules: StylesheetRule[];
   parents: Map<XastElement, XastParent>;
+  declarationCache: Map<string, StylesheetDeclaration[]>;
 };
 
 export type StaticStyle = {


### PR DESCRIPTION
## Summary

Cache parsed inline style declarations by their exact `style` attribute string for the lifetime of an AST.

**Overall, this improves end-to-end SVG optimization time by 20% on the 4,592-icon benchmark (186.94s → 149.55s), increasing throughput by approximately 25% (24.6 → 30.7 SVGs/sec).**

Nine default plugins collect their own stylesheet snapshot. Previously, every style computation reparsed inline declarations with `css-tree`, including repeated ancestor computations. The new cache is shared by all stylesheet snapshots for the same AST.

The cache stores declarations rather than computed styles. Updated style attributes use a different string key, while selectors, presentation attributes, and inheritance continue to be computed normally. The cache is released with its AST through a `WeakMap`.

## Alternatives explored

A deterministic 460-icon sample was used to compare cache strategies:

| Variant | Runtime | Style CPU | Inline parsing | Runtime change |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 36.45s | 9.60s | 6.44s | — |
| Per stylesheet/value | 30.16s | 4.23s | 1.21s | -17.3% |
| Per node | 28.92s | 3.91s | 0.95s | -20.7% |
| Per node + inherited-property filtering | 29.54s | 3.79s | 1.03s | -19.0% |
| **Per AST/value** | 29.49s | **3.24s** | **0.38s** | -19.1% |

The AST/value variant had the lowest style-processing cost and avoids stale data after attribute updates.

## Full benchmark

Benchmark configuration:

- SVGO Test Suite `77ba065b4e4b4902c8795921287f9cf7`
- all 4,592 Charm and Oxygen icon fixtures
- default preset, single pass, `floatPrecision: 4`
- two workers
- Node.js 22.23.2 on Linux x86-64
- CPU timings summed across workers

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall time | 186.94s | 149.55s | **-20.0%** |
| Profiled CPU | 371.74s | 297.27s | **-20.0%** |
| Style computation | 98.87s | 29.63s | **-70.0%** |
| Stylesheet collection | 3.95s | 4.00s | effectively unchanged |
| Total style processing | 102.82s | 33.63s | **-67.3%** |

### Memory

The regression optimization step already records peak RSS as `metrics.peakMemoryAlloc` using `process.resourceUsage().maxRSS`. I repeated the same 4,592-icon, two-worker benchmark without the CPU profiler to compare that metric:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall time | 191.97s | 154.71s | **-19.4%** |
| Peak RSS | 763.41 MiB | 692.12 MiB | **-9.3%** |

### Plugin impact

| Plugin | Before | After | Change | Style CPU before | Style CPU after |
| --- | ---: | ---: | ---: | ---: | ---: |
| `convertPathData` | 73.06s | 61.51s | -15.8% | 13.05s | 2.95s |
| `removeHiddenElems` | 59.97s | 28.62s | **-52.3%** | 42.32s | 12.78s |
| `mergePaths` | 28.33s | 18.77s | **-33.7%** | 11.02s | 2.04s |
| `removeUselessStrokeAndFill` | 26.14s | 13.32s | **-49.0%** | 21.28s | 8.87s |
| `removeUnknownsAndDefaults` | 13.80s | 7.65s | **-44.6%** | 9.93s | 4.28s |
| `removeEmptyContainers` | 6.81s | 4.51s | -33.8% | 3.49s | 1.44s |
| `collapseGroups` | 1.46s | 1.08s | -26.4% | 0.82s | 0.40s |

A deterministic 460-file output comparison against the baseline found no differences.

## Tests

- `pnpm typecheck`
- `pnpm exec vitest run lib/style.test.js test/plugins/_index.test.js --exclude '.worktrees/**'` (386 tests)
- ESLint and Prettier on changed files
