### PR TITLE
fix: preserve inheritable defaults in referenced subtrees

### DIFF
--- a/plugins/removeUnknownsAndDefaults.js
+++ b/plugins/removeUnknownsAndDefaults.js
@@ -3,6 +3,7 @@ import {
   attrsGroupsDefaults,
   elems,
   elemsGroups,
+  inheritableAttrs,
   presentationNonInheritableGroupAttrs,
 } from './_collections.js';
 import { detachNodeFromParent } from '../lib/xast.js';
@@ -114,6 +115,28 @@ export const fn = (root, params) => {
   } = params;
   const stylesheet = collectStylesheet(root);
 
+  /**
+   * A referenced subtree may be instantiated by a `use` element, whose
+   * inherited styles must not replace defaults declared inside the subtree.
+   *
+   * @param {import('../lib/types.js').XastNode} node
+   * @returns {boolean}
+   */
+  const hasReferenceableAncestor = (node) => {
+    let ancestor = node;
+    while (ancestor.type === 'element') {
+      if (ancestor.attributes.id != null) {
+        return true;
+      }
+      const parent = stylesheet.parents.get(ancestor);
+      if (parent == null) {
+        return false;
+      }
+      ancestor = parent;
+    }
+    return false;
+  };
+
   return {
     instruction: {
       enter: (node) => {
@@ -194,7 +217,11 @@ export const fn = (root, params) => {
             defaultAttrs &&
             node.attributes.id == null &&
             attributesDefaults &&
-            attributesDefaults.get(name) === value
+            attributesDefaults.get(name) === value &&
+            // An inheritable default inside a referenceable subtree may keep
+            // that subtree from inheriting a different value via `use`.
+            (inheritableAttrs.has(name) === false ||
+              hasReferenceableAncestor(parentNode) === false)
           ) {
             // keep defaults if parent has own or inherited style
             if (

--- a/test/plugins/removeUnknownsAndDefaults.18.svg.txt
+++ b/test/plugins/removeUnknownsAndDefaults.18.svg.txt
@@ -1,0 +1,23 @@
+Keep inheritable default attributes inside a referenceable subtree.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="a">
+    <rect width="10" height="10" fill-opacity="1"/>
+  </g>
+  <g fill-opacity=".3">
+    <use href="#a"/>
+  </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g id="a">
+        <rect width="10" height="10" fill-opacity="1"/>
+    </g>
+    <g fill-opacity=".3">
+        <use href="#a"/>
+    </g>
+</svg>


### PR DESCRIPTION
Fixes #2239.

When an element with an `id` is instantiated through `<use>`, an inheritable default inside its subtree can prevent the instance from taking an unintended inherited value from the `<use>` context. Preserve only inheritable defaults in those subtrees; ordinary default attributes remain removable.

Adds a focused regression fixture for `fill-opacity="1"` beneath an `id` target used from a `fill-opacity=".3"` context.

Validation:
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (518 passed, 3 skipped)
- `pnpm test:bundles`
- local regression suite completed optimization and comparison with 4,905 expected matches; the local renderer reported 32 `shouldHaveMismatched` differences and no `shouldHaveMatched` differences in unrelated Oxygen/W3C fixtures.

Disclosure: AI assistance was used to investigate and implement this contribution.