### PR TITLE
perf: compile stylesheet selectors once per document

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -1,7 +1,7 @@
 import * as csstree from 'css-tree';
 import * as csswhat from 'css-what';
 import { syntax } from 'csso';
-import { matches } from './xast.js';
+import { compileSelector } from './xast.js';
 import { visit } from './util/visit.js';
 import {
   attrsGroups,
@@ -128,12 +128,38 @@ const parseStyleDeclarations = (css) => {
 };
 
 /**
+ * Selectors are recompiled by css-select on every `matches` call, which is
+ * O(nodes x rules) for a stylesheet. Compile each rule once per stylesheet.
+ *
+ * @type {WeakMap<import('./types.js').Stylesheet, Map<string, (node: any) => boolean>>}
+ */
+const matcherCache = new WeakMap();
+
+/**
+ * @param {import('./types.js').Stylesheet} stylesheet
+ * @param {string} selector
+ * @returns {(node: import('./types.js').XastElement) => boolean}
+ */
+const getMatcher = (stylesheet, selector) => {
+  let cache = matcherCache.get(stylesheet);
+  if (cache == null) {
+    cache = new Map();
+    matcherCache.set(stylesheet, cache);
+  }
+  let matcher = cache.get(selector);
+  if (matcher == null) {
+    matcher = compileSelector(selector, stylesheet.parents);
+    cache.set(selector, matcher);
+  }
+  return matcher;
+};
+
+/**
  * @param {import('./types.js').Stylesheet} stylesheet
  * @param {import('./types.js').XastElement} node
- * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>=} parents
  * @returns {import('./types.js').ComputedStyles}
  */
-const computeOwnStyle = (stylesheet, node, parents) => {
+const computeOwnStyle = (stylesheet, node) => {
   /** @type {import('./types.js').ComputedStyles} */
   const computedStyle = {};
   const importantStyles = new Map();
@@ -148,7 +174,7 @@ const computeOwnStyle = (stylesheet, node, parents) => {
 
   // collect matching rules
   for (const { selector, declarations, dynamic } of stylesheet.rules) {
-    if (matches(node, selector, parents)) {
+    if (getMatcher(stylesheet, selector)(node)) {
       for (const { name, value, important } of declarations) {
         const computed = computedStyle[name];
         if (computed && computed.type === 'dynamic') {
@@ -275,10 +301,10 @@ export const collectStylesheet = (root) => {
  */
 export const computeStyle = (stylesheet, node) => {
   const { parents } = stylesheet;
-  const computedStyles = computeOwnStyle(stylesheet, node, parents);
+  const computedStyles = computeOwnStyle(stylesheet, node);
   let parent = parents.get(node);
   while (parent != null && parent.type !== 'root') {
-    const inheritedStyles = computeOwnStyle(stylesheet, parent, parents);
+    const inheritedStyles = computeOwnStyle(stylesheet, parent);
     for (const [name, computed] of Object.entries(inheritedStyles)) {
       if (
         computedStyles[name] == null &&

--- a/lib/style.test.js
+++ b/lib/style.test.js
@@ -445,3 +445,38 @@ it('ignores @-o-keyframes atrule', () => {
     },
   });
 });
+
+it('matches ancestor dependent selectors per document', () => {
+  const nested = parseSvg(`
+      <svg>
+        <style>
+          g .a { fill: red; }
+        </style>
+        <g>
+          <rect id="element" class="a" />
+        </g>
+      </svg>
+    `);
+  const flat = parseSvg(`
+      <svg>
+        <style>
+          g .a { fill: red; }
+        </style>
+        <rect id="element" class="a" />
+      </svg>
+    `);
+  // selectors are compiled and cached per stylesheet, so an identical selector
+  // in another document must still be resolved against that document's tree
+  const flatStylesheet = collectStylesheet(flat);
+  const nestedStylesheet = collectStylesheet(nested);
+  // the document without the ancestor is resolved first on purpose, so a
+  // matcher cached from it cannot satisfy the nested document afterwards
+  expect(
+    computeStyle(flatStylesheet, getElementById(flat, 'element')),
+  ).toStrictEqual({});
+  expect(
+    computeStyle(nestedStylesheet, getElementById(nested, 'element')),
+  ).toStrictEqual({
+    fill: { type: 'static', inherited: false, value: 'red' },
+  });
+});

--- a/lib/svgo/css-select-adapter.js
+++ b/lib/svgo/css-select-adapter.js
@@ -34,20 +34,34 @@ const hasAttrib = (elem, name) => {
 };
 
 /**
+ * Adapter over an already known node to parent mapping, so the same instance
+ * can be reused across nodes.
+ *
+ * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>} parents
+ * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
+ */
+export function createAdapterFromParents(parents) {
+  return createAdapterWithParentLookup((node) => parents.get(node) || null);
+}
+
+/**
  * @param {import('../types.js').XastParent} relativeNode
  * @param {Map<import('../types.js').XastNode, import('../types.js').XastParent>=} parents
  * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
  */
 export function createAdapter(relativeNode, parents) {
-  /** @type {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getParent']} */
-  const getParent = (node) => {
-    if (!parents) {
-      parents = mapNodesToParents(relativeNode);
-    }
+  return createAdapterWithParentLookup((node) => {
+    parents ??= mapNodesToParents(relativeNode);
 
     return parents.get(node) || null;
-  };
+  });
+}
 
+/**
+ * @param {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']['getParent']} getParent
+ * @returns {Required<import('css-select').Options<import('../types.js').XastNode & { children?: any }, import('../types.js').XastElement>>['adapter']}
+ */
+function createAdapterWithParentLookup(getParent) {
   /**
    * @param {any} elem
    * @returns {any}

--- a/lib/xast.js
+++ b/lib/xast.js
@@ -1,5 +1,8 @@
-import { is, selectAll, selectOne } from 'css-select';
-import { createAdapter } from './svgo/css-select-adapter.js';
+import { compile, is, selectAll, selectOne } from 'css-select';
+import {
+  createAdapter,
+  createAdapterFromParents,
+} from './svgo/css-select-adapter.js';
 
 /**
  * @param {import('./types.js').XastParent} relativeNode
@@ -10,6 +13,17 @@ function createCssSelectOptions(relativeNode, parents) {
   return {
     xmlMode: true,
     adapter: createAdapter(relativeNode, parents),
+  };
+}
+
+/**
+ * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>} parents
+ * @returns {import('css-select').Options<import('./types.js').XastNode & { children?: any }, import('./types.js').XastElement>}
+ */
+function createCssSelectOptionsFromParents(parents) {
+  return {
+    xmlMode: true,
+    adapter: createAdapterFromParents(parents),
   };
 }
 
@@ -31,6 +45,20 @@ export const querySelectorAll = (node, selector, parents) => {
  */
 export const querySelector = (node, selector, parents) => {
   return selectOne(selector, node, createCssSelectOptions(node, parents));
+};
+
+/**
+ * Compiles a CSS selector once so it can be tested against many nodes.
+ *
+ * @param {string} selector CSS selector string.
+ * @param {Map<import('./types.js').XastNode, import('./types.js').XastParent>} parents
+ * @returns {(node: import('./types.js').XastElement) => boolean}
+ */
+export const compileSelector = (selector, parents) => {
+  if (selector === '') {
+    return () => false;
+  }
+  return compile(selector, createCssSelectOptionsFromParents(parents));
 };
 
 /**


### PR DESCRIPTION
We saw some minor slowdowns when benchmarking our SVG icons workflow with complex SVGs. This is one of two hot paths that recompile static patterns per element; split out from #2279 so each can be reviewed and tested in isolation. The other half is https://github.com/svg/svgo/pull/2284.

Pure performance change: no API change, no config change, byte-identical output.

`computeOwnStyle` tests every rule against every element via `matches()`, and css-select parses and compiles the selector string on every call, building a fresh `RegExp` per attribute selector. A document with R rules and E elements pays R × E compilations, multiplied again by tree depth as `computeStyle` walks ancestors. `stylesheet.parents` is already stable, so the compiled matcher is now cached per stylesheet.

## Benchmarks

Synthetic Illustrator-style documents (one class per shape, one stylesheet), Node 24, best of 5:

| Case | upstream/main | with branch | |
| --- | --- | --- | --- |
| 10 rules × 100 shapes | 33.7–34.6 ms | 10.0 ms | ~3.4× |
| 50 rules × 300 shapes | 359.9–379.7 ms | 30.4–52.2 ms | ~7–12× |
| 100 rules × 600 shapes | 1306–1368 ms | 91.1–100.2 ms | ~14× |

The ratio widens with document size because the old behaviour was quadratic in rules × elements.

<details>
<summary>Benchmark script (repo root, <code>node bench-pr.mjs</code>)</summary>

```js
import { optimize } from './lib/svgo.js';

const makeSvg = (rules, shapes) => {
      const css = Array.from({ length: rules }, (_, i) => `.st${i}{fill:#${(i * 7919 % 0xffffff).toString(16).padStart(6, '0')};}`).join('');
      const body = Array.from({ length: shapes }, (_, i) => `<path class="st${i % rules}" d="M${i % 32} ${Math.floor(i / 32) % 32}h4v4h-4z"/>`).join('');
      return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><style>${css}</style>${body}</svg>`;
};

const time = (label, input, config, iters) => {
      for (let i = 0; i < 3; i++) optimize(input, config);
      let best = Infinity;
      for (let r = 0; r < 5; r++) {
              const t = performance.now();
              for (let i = 0; i < iters; i++) optimize(input, config);
              best = Math.min(best, (performance.now() - t) / iters);
      }
      console.log(`${label.padEnd(40)} ${best.toFixed(1).padStart(8)} ms`);
};

for (const [rules, shapes] of [[10, 100], [50, 300], [100, 600]]) {
      time(`${rules} rules x ${shapes} shapes`, makeSvg(rules, shapes), { multipass: true }, 3);
}
```

</details>