### PR TITLE
perf: compile removeAttrs patterns once per run

### DIFF
--- a/plugins/removeAttrs.js
+++ b/plugins/removeAttrs.js
@@ -105,27 +105,31 @@ export const fn = (root, params) => {
       : false;
   const attrs = Array.isArray(params.attrs) ? params.attrs : [params.attrs];
 
+  // patterns are static, so compile them once instead of on every element
+  const patterns = attrs.map((attr) => {
+    let pattern = attr;
+    // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
+    if (!pattern.includes(elemSeparator)) {
+      pattern = ['.*', pattern, '.*'].join(elemSeparator);
+      // if only 1 separator, assume it's element and attribute name, and apply regardless of attribute value
+    } else if (pattern.split(elemSeparator).length < 3) {
+      pattern = [pattern, '.*'].join(elemSeparator);
+    }
+
+    // create regexps for element, attribute name, and attribute value
+    return pattern.split(elemSeparator).map((value) => {
+      // adjust single * to match anything
+      if (value === '*') {
+        value = '.*';
+      }
+      return new RegExp(['^', value, '$'].join(''), 'i');
+    });
+  });
+
   return {
     element: {
       enter: (node) => {
-        for (let pattern of attrs) {
-          // if no element separators (:), assume it's attribute name, and apply to all elements *regardless of value*
-          if (!pattern.includes(elemSeparator)) {
-            pattern = ['.*', pattern, '.*'].join(elemSeparator);
-            // if only 1 separator, assume it's element and attribute name, and apply regardless of attribute value
-          } else if (pattern.split(elemSeparator).length < 3) {
-            pattern = [pattern, '.*'].join(elemSeparator);
-          }
-
-          // create regexps for element, attribute name, and attribute value
-          const list = pattern.split(elemSeparator).map((value) => {
-            // adjust single * to match anything
-            if (value === '*') {
-              value = '.*';
-            }
-            return new RegExp(['^', value, '$'].join(''), 'i');
-          });
-
+        for (const list of patterns) {
           // matches element
           if (list[0].test(node.name)) {
             // loop attributes

--- a/test/plugins/removeAttrs.08.svg.txt
+++ b/test/plugins/removeAttrs.08.svg.txt
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle fill="red" stroke="blue" opacity="0.5" cx="60" cy="60" r="50"/>
+    <path fill="red" stroke="blue" opacity="1" d="M0 0"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle stroke="blue" cx="60" cy="60" r="50"/>
+    <path opacity="1" d="M0 0"/>
+</svg>
+
+@@@
+
+{"attrs":["fill","path:stroke","*:opacity:0.5"]}

--- a/test/plugins/removeAttrs.09.svg.txt
+++ b/test/plugins/removeAttrs.09.svg.txt
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <path fill="red" stroke="blue" d="M0 0"/>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path stroke="blue" d="M0 0"/>
+</svg>
+
+@@@
+
+{"attrs":["svg|version","path|fill"],"elemSeparator":"|"}


### PR DESCRIPTION
We saw some minor slowdowns when benchmarking our SVG icons workflow with complex SVGs. This is one of two hot paths that recompile static patterns per element; split out from #2279 so each can be reviewed and tested in isolation. The other half is https://github.com/svg/svgo/pull/2283.

Pure performance change: no API change, no config change, byte-identical output.

The element, name and value regexes in `removeAttrs` were built inside the element visitor, recompiling every configured pattern for every element in the document, though the patterns come from static config. Moved to plugin init.

Adds two fixtures covering the paths the hoisting touches: multi-pattern element/name/value matching, and the `elemSeparator` form.

## Benchmarks

600-element document where every element carries all four target attributes, so the name and value matching paths actually run. Node 24, best of 15.

| Case | before | after | |
| --- | --- | --- | --- |
| `removeAttrs`, 600 elems × 4 patterns | 9.32–9.72 ms | 5.65–6.08 ms | ~1.6× |

Range is across three alternating before/after rounds on the same machine.

<details>
<summary>Benchmark script (repo root, <code>node bench-pr.mjs</code>)</summary>

```js
import { optimize } from './lib/svgo.js';

const svg =
      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
      Array.from(
              { length: 600 },
              (_, i) =>
                      `<path fill="red" stroke="blue" class="st0" style="opacity:1" d="M${i % 32} ${Math.floor(i / 32) % 32}h4v4h-4z"/>`,
      ).join('') +
      `</svg>`;

const config = {
      plugins: [
              {
                      name: 'removeAttrs',
                      params: { attrs: ['fill', 'stroke', 'class', 'style'] },
              },
      ],
};

for (let i = 0; i < 50; i++) optimize(svg, config);

let best = Infinity;
for (let r = 0; r < 15; r++) {
      const t = performance.now();
      for (let i = 0; i < 40; i++) optimize(svg, config);
      best = Math.min(best, (performance.now() - t) / 40);
}
console.log(`removeAttrs 600 elems x 4 patterns: ${best.toFixed(2)} ms`);
```

</details>