### PR TITLE
fix(convertStyleToAttrs): skip foreignObject content

### DIFF
--- a/plugins/convertStyleToAttrs.js
+++ b/plugins/convertStyleToAttrs.js
@@ -1,3 +1,4 @@
+import { visitSkip } from '../lib/util/visit.js';
 import { attrsGroups } from './_collections.js';
 
 /**
@@ -84,6 +85,11 @@ export const fn = (_root, params) => {
   return {
     element: {
       enter: (node) => {
+        // skip <foreignObject> content
+        if (node.name === 'foreignObject') {
+          return visitSkip;
+        }
+
         if (node.attributes.style != null) {
           // ['opacity: 1', 'color: #000']
           let styles = [];

--- a/test/plugins/convertStyleToAttrs.06.svg.txt
+++ b/test/plugins/convertStyleToAttrs.06.svg.txt
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <foreignObject>
+        <div xmlns="http://www.w3.org/1999/xhtml" style="clip-path:url(#a)"/>
+    </foreignObject>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <foreignObject>
+        <div xmlns="http://www.w3.org/1999/xhtml" style="clip-path:url(#a)"/>
+    </foreignObject>
+</svg>


### PR DESCRIPTION
`convertStyleToAttrs` descends into `<foreignObject>` and rewrites HTML `style` declarations as presentation attributes (e.g. `style="clip-path:url(#a)"` → `clip-path="url(#a)"`). Inside `<foreignObject>` the content is HTML, where those are plain attributes with no rendering effect, so the styling is silently dropped after optimization. This plugin runs in `preset-default`.

`mergeStyles`, `inlineStyles`, `removeUnknownsAndDefaults` and `removeScripts` already skip `<foreignObject>` for the same reason; this adds the matching guard.

Fixes #2222.
