### PR TITLE
fix: trim surrounding whitespace in <title> same as <desc>

### DIFF
--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -31,3 +31,21 @@ test('a text preserved', () => {
 
   expect(actual).toBe(expected);
 });
+
+test('title surrounding whitespace trimmed same as desc', () => {
+  const descTitleInput = `<svg xmlns="http://www.w3.org/2000/svg">
+<desc>  My Desc  </desc>
+<title>  My Title  </title>
+</svg>`;
+
+  const descTitleExpected =
+    '<svg xmlns="http://www.w3.org/2000/svg">' +
+    '<desc>My Desc</desc>' +
+    '<title>My Title</title>' +
+    '</svg>';
+
+  const parsed = parseSvg(descTitleInput);
+  const actual = stringifySvg(parsed, {});
+
+  expect(actual).toBe(descTitleExpected);
+});

--- a/plugins/_collections.js
+++ b/plugins/_collections.js
@@ -109,7 +109,7 @@ export const elemsGroups = {
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
  * @type {Readonly<Set<string>>}
  */
-export const textElems = new Set([...elemsGroups.textContent, 'pre', 'title']);
+export const textElems = new Set([...elemsGroups.textContent, 'pre']);
 
 /**
  * @type {Readonly<Set<string>>}

--- a/test/plugins/inlineStyles.16.svg.txt
+++ b/test/plugins/inlineStyles.16.svg.txt
@@ -26,7 +26,9 @@
 
 <svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 222 57.28">
     <defs/>
-    <title>button</title>
+    <title>
+        button
+    </title>
     <rect width="222" height="57.28" rx="28.64" ry="28.64" style="fill:#37d0cd;stroke:red"/>
     <path d="M312.75,168.66A2.15,2.15,0,0,1,311.2,165L316,160l-4.8-5a2.15,2.15,0,1,1,3.1-3l6.21,6.49a2.15,2.15,0,0,1,0,3L314.31,168a2.14,2.14,0,0,1-1.56.67Zm0,0" transform="translate(-119 -131.36)" style="fill:#fff"/>
     <circle cx="33.5" cy="27.25" r="2.94" style="fill:#fff"/>


### PR DESCRIPTION
Fixes #2052.

## Problem

`textElems` in `plugins/_collections.js` explicitly included `'title'` alongside `'pre'` and the genuinely-rendered text-content elements (`text`, `tspan`, etc.) — the elements where surrounding whitespace is semantically meaningful and must be preserved verbatim. `<title>` is a non-rendered accessibility/metadata element — like its sibling `<desc>` and `<metadata>` in `elemsGroups.descriptive` — where whitespace has no such significance, but it was the only member of that group also present in `textElems`.

`lib/parser.js`'s `sax.ontext` handler branches on `textElems` membership: members keep raw (untrimmed) text, non-members get `text.trim()`. Since `title` was in `textElems`, `<title>  My Title  </title>` kept its leading/trailing whitespace while the structurally identical `<desc>  My Desc  </desc>` got trimmed to `"My Desc"` — the exact asymmetry reported in #2052.

## Fix

Remove `'title'` from the `textElems` Set literal (one line). Confirmed via repo-wide code search that only `lib/parser.js` and `lib/stringifier.js` reference `textElems` besides the definition itself, so the change is fully self-contained.

`lib/stringifier.js` also branches on the same `textElems` set to decide whether an element's children get pretty-mode indentation/newlines, so this also makes `<title>` format consistently with `<desc>` when `js2svg` pretty output is used — same underlying membership change, not a separate behavior. This surfaced as one existing fixture test failure (`inlineStyles.16`), whose expected output I've updated to match: `<title>button</title>` now gets the same indented multi-line layout `<desc>` already receives in pretty mode.

## Testing

Added a regression test in `lib/parser.test.js` reproducing the exact before/after asymmetry from #2052 (title now trims identically to desc).

Ran the actual suite locally (not just hand-traced):
- `pnpm install --frozen-lockfile`
- `pnpm vitest run` — 521 passed, 3 skipped. Confirmed the new test genuinely catches the bug by temporarily reverting the fix and re-running (it fails as expected), then restored the fix and re-ran (passes).
- `pnpm lint` (eslint + prettier) — clean.
- `pnpm typecheck` (tsc) — clean.

Did not run `test:bundles` / `test:regression` (the full `qa` script's remaining steps) — those build the rollup bundle and pixel-diff a large external SVG corpus, which felt disproportionate to verify for a one-line `Set` membership change already covered by the unit/fixture suite above; happy to run them too if maintainers want that before merge.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
