### PR TITLE
fix: prefixIds handles SMIL begin/end offsets and space-optional semicolons

### DIFF
--- a/plugins/prefixIds.js
+++ b/plugins/prefixIds.js
@@ -258,10 +258,20 @@ export const fn = (_root, params, info) => {
             node.attributes[name] != null &&
             node.attributes[name].length !== 0
           ) {
-            const parts = node.attributes[name].split(/\s*;\s+/).map((val) => {
-              if (val.endsWith('.end') || val.endsWith('.start')) {
-                const [id, postfix] = val.split('.');
-                return `${prefixId(prefixGenerator, id)}.${postfix}`;
+            // Semicolon-separated SMIL timing values don't require
+            // whitespace after the semicolon (e.g. "0;b.end-0.5s" is valid),
+            // so whitespace on either side must be optional here, not
+            // required after.
+            const parts = node.attributes[name].split(/\s*;\s*/).map((val) => {
+              // A syncbase-value is "id.begin" or "id.end", optionally
+              // followed by a "+"/"-" clock-value offset (e.g. "b.end-0.5s",
+              // "a.begin+0.1s") -- a plain suffix check misses any value
+              // with an offset, since it doesn't end with just ".begin" or
+              // ".end" anymore.
+              const match = /^([^.]+)\.(begin|end)([+-].+)?$/.exec(val);
+              if (match) {
+                const [, id, postfix, offset = ''] = match;
+                return `${prefixId(prefixGenerator, id)}.${postfix}${offset}`;
               }
               return val;
             });

--- a/test/plugins/prefixIds.14.svg.txt
+++ b/test/plugins/prefixIds.14.svg.txt
@@ -1,0 +1,30 @@
+Prefix IDs should prefix begin/end syncbase references that carry a clock-value
+offset (e.g. "b.end-0.5s"), not just a bare "id.begin"/"id.end" -- and should
+split semicolon-separated values without requiring whitespace after the
+semicolon.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle>
+        <animate id="a" attributeName="r" begin="0;b.end-0.5s" dur="1s" values="0;10;0"/>
+    </circle>
+    <circle>
+        <animate id="b" attributeName="r" begin="a.begin+0.1s" dur="1s" values="0;10;0"/>
+    </circle>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle>
+        <animate id="icon-a" attributeName="r" begin="0; icon-b.end-0.5s" dur="1s" values="0;10;0"/>
+    </circle>
+    <circle>
+        <animate id="icon-b" attributeName="r" begin="icon-a.begin+0.1s" dur="1s" values="0;10;0"/>
+    </circle>
+</svg>
+
+@@@
+
+{"prefix": "icon", "delim": "-"}


### PR DESCRIPTION
Fixes #2207.

## Problem

Two related bugs in the "prefix begin/end attribute value" block of `plugins/prefixIds.js`:

1. The suffix check `val.endsWith('.end') || val.endsWith('.start')` only matched a bare syncbase-value like `b.end`, not one with a clock-value offset like `b.end-0.5s` or `a.begin+0.1s` — both valid SMIL timing syntax. Any offset suffix made the whole check fail, silently leaving the id reference unprefixed and breaking the animation chain it pointed to. (Side note: this repo's only existing fixture for this code path, `prefixIds.10.svg.txt`, only exercises the `.end` half of the check — `.start` isn't valid SMIL syncbase syntax at all per [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/begin), which documents only `id.begin`/`id.end`, so that branch was untested, un-triggerable dead code from the start.)

2. Separately — and this one only surfaced by actually running the issue's own reproduction end to end, not by reading the diff for fix 1 — the sibling split, `attr.split(/\s*;\s+/)` for the semicolon-separated list of timing values, requires at least one whitespace character *after* the semicolon to split at all. Valid SMIL timing lists don't require that whitespace (`0;b.end-0.5s` is valid, and is literally the reporter's own reproduction case). Without a space, the whole multi-value string never gets split, so it would still fail to prefix correctly even with fix 1 alone.

## Fix

1. Replaced the suffix check with a regex, `/^([^.]+)\.(begin|end)([+-].+)?$/`, that captures the id, the `begin`/`end` keyword, and an optional offset separately — the offset is preserved verbatim, only the id gets prefixed.
2. Changed the split delimiter's trailing `\s+` to `\s*`, making whitespace optional on both sides of the semicolon.

## Testing

Added `test/plugins/prefixIds.14.svg.txt`, reproducing the exact scenario from #2207 (including the unspaced semicolon).

Ran the actual suite locally (not just hand-traced): `pnpm vitest run` — 521 passed, 3 skipped (includes multipass idempotence checking built into the fixture-test harness). Confirmed the new fixture genuinely fails against the pre-fix code by temporarily stashing the fix and re-running (it fails as expected, with the exact broken output described in the issue), then restored the fix and reconfirmed passing. `pnpm lint` (eslint + prettier) and `pnpm typecheck` (tsc) both clean.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
