### PR TITLE
Fix addClassesToSVGElement docs to match its actual merge behavior

### DIFF
--- a/docs/04-plugins/addClassesToSVGElement.mdx
+++ b/docs/04-plugins/addClassesToSVGElement.mdx
@@ -10,11 +10,11 @@ svgo:
       description: Adds the specified class name to the outer most `<svg>` element. If `classNames` is specified, this is ignored.
 ---
 
-Overrides the `class` attribute in the outer most `<svg>` element, omitting duplicates or null classes if found in your configuration.
+Adds the configured class names to the outer most `<svg>` element, omitting duplicates or null classes if found in your configuration.
 
 :::caution
 
-If there is no `class` attribute to begin with, it will be added. However, if the there were already classes assigned, these are removed and replaced with the classes configured in this plugin.
+If there is no `class` attribute to begin with, it will be added. If the element already has classes, the ones from your configuration are added alongside the existing ones rather than replacing them.
 
 :::
 


### PR DESCRIPTION
Fixes #2209.

The issue reports that classes already on the outer `<svg>` element don't get cleared when `addClassesToSVGElement` runs, and points at the docs, which say the plugin "removes and replaces" existing classes. I checked the actual plugin code and its own test suite (fixture 03, "Should avoid adding existing classes") and the merge/append behavior is what's really implemented and has been covered by a test since this plugin was added, not something that broke recently. So this isn't a code regression, it's the docs describing a replace-style behavior that was never there.

Rewrote the intro line and the caution callout in the docs to describe what the plugin actually does: existing classes stay, the configured ones get added alongside them, duplicates are avoided through the Set.

No code changes, so no new tests needed. Ran the full suite locally (520 passing, 3 skipped) to confirm nothing else touches this.