### PR TITLE
fix(removeUselessDefs): keep animations that target elements by href

### DIFF
--- a/plugins/removeUselessDefs.js
+++ b/plugins/removeUselessDefs.js
@@ -41,11 +41,29 @@ export const fn = () => {
 const collectUsefulNodes = (node, usefulNodes) => {
   for (const child of node.children) {
     if (child.type === 'element') {
-      if (child.attributes.id != null || child.name === 'style') {
+      if (
+        child.attributes.id != null ||
+        child.name === 'style' ||
+        isAnimationWithTarget(child)
+      ) {
         usefulNodes.push(child);
       } else {
         collectUsefulNodes(child, usefulNodes);
       }
     }
   }
+};
+
+/**
+ * Animation elements that reference their target through href apply to that
+ * target even when they are placed in a non-rendering element such as defs.
+ *
+ * @param {import('../lib/types.js').XastElement} node
+ * @returns {boolean}
+ */
+const isAnimationWithTarget = (node) => {
+  return (
+    elemsGroups.animation.has(node.name) &&
+    (node.attributes.href != null || node.attributes['xlink:href'] != null)
+  );
 };

--- a/test/plugins/removeUselessDefs.06.svg.txt
+++ b/test/plugins/removeUselessDefs.06.svg.txt
@@ -1,0 +1,28 @@
+Don't remove animation elements that target another element with href.
+
+===
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <animateTransform xlink:href="#mover" attributeName="transform" type="translate" values="0 0;120 0;0 0" dur="2s" repeatCount="indefinite"/>
+        <g>
+            <animate href="#mover" attributeName="opacity" values="1;0;1" dur="2s" repeatCount="indefinite"/>
+        </g>
+        <animate attributeName="opacity" values="1;0;1" dur="2s"/>
+    </defs>
+    <g id="mover">
+        <circle cx="40" cy="50" r="20" fill="#ff156d"/>
+    </g>
+</svg>
+
+@@@
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <animateTransform xlink:href="#mover" attributeName="transform" type="translate" values="0 0;120 0;0 0" dur="2s" repeatCount="indefinite"/>
+        <animate href="#mover" attributeName="opacity" values="1;0;1" dur="2s" repeatCount="indefinite"/>
+    </defs>
+    <g id="mover">
+        <circle cx="40" cy="50" r="20" fill="#ff156d"/>
+    </g>
+</svg>


### PR DESCRIPTION
removeUselessDefs dropped animation elements inside defs that have no id, but an animation with href or xlink:href animates its target element wherever it is placed, so removing it broke the animation from #2290. The plugin now keeps animation elements that reference a target through href. I added fixture removeUselessDefs.06 (fails before the change, passes after), and pnpm test, pnpm lint and pnpm typecheck pass.

Fixes #2290